### PR TITLE
[Type] Introduce the Type API

### DIFF
--- a/src/Psl/Gen/from_entries.php
+++ b/src/Psl/Gen/from_entries.php
@@ -10,7 +10,7 @@ use Generator;
  * Returns a generator where each mapping is defined by the given key/value
  * tuples.
  *
- * @psalm-template Tk of array-key
+ * @psalm-template Tk
  * @psalm-template Tv
  *
  * @psalm-param iterable<array{0: Tk, 1: Tv}> $entries

--- a/src/Psl/Gen/pull_with_key.php
+++ b/src/Psl/Gen/pull_with_key.php
@@ -23,9 +23,9 @@ use Generator;
  *          70 => 'H', 131 => 'I', 264 => 'J', 521 => 'K', 1034 => 'L'
  *      )
  *
- * @psalm-template Tk1 of array-key
+ * @psalm-template Tk1
  * @psalm-template Tv1
- * @psalm-template Tk2 of array-key
+ * @psalm-template Tk2
  * @psalm-template Tv2
  *
  * @psalm-param iterable<Tk1, Tv1>          $iterable

--- a/src/Psl/Gen/reindex.php
+++ b/src/Psl/Gen/reindex.php
@@ -26,8 +26,8 @@ use Generator;
  *         24 => ['id' => 24, 'name' => 'bar']
  *     )
  *
- * @psalm-template Tk1 of array-key
- * @psalm-template Tk2 of array-key
+ * @psalm-template Tk1
+ * @psalm-template Tk2
  * @psalm-template Tv
  *
  * @psalm-param iterable<Tk1, Tv>    $iterable Iterable to reindex

--- a/src/Psl/Gen/repeat.php
+++ b/src/Psl/Gen/repeat.php
@@ -35,8 +35,11 @@ function repeat($value, ?int $num = null): Generator
 {
     Psl\invariant(null === $num || $num >= 0, 'Number of repetitions must be non-negative');
 
-    /** @var int $num */
-    $num ??= Math\INFINITY;
+    if (null === $num) {
+        /** @var int $num */
+        $num = Math\INFINITY;
+    }
+
     for ($i = 0; $i < $num; ++$i) {
         yield $value;
     }

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -287,6 +287,22 @@ final class Loader
         'Psl\invariant',
         'Psl\invariant_violation',
         'Psl\sequence',
+        'Psl\Type\arr',
+        'Psl\Type\array_key',
+        'Psl\Type\bool',
+        'Psl\Type\float',
+        'Psl\Type\int',
+        'Psl\Type\intersection',
+        'Psl\Type\iterable',
+        'Psl\Type\mixed',
+        'Psl\Type\null',
+        'Psl\Type\nullable',
+        'Psl\Type\num',
+        'Psl\Type\object',
+        'Psl\Type\resource',
+        'Psl\Type\string',
+        'Psl\Type\scalar',
+        'Psl\Type\union',
     ];
 
     public const INTERFACES = [
@@ -302,10 +318,29 @@ final class Loader
         'Psl\Collection\IMutableVector',
         'Psl\Collection\IMap',
         'Psl\Collection\IMutableMap',
+        'Psl\Type\Internal\ArrayKeyType',
+        'Psl\Type\Internal\ArrayType',
+        'Psl\Type\Internal\BoolType',
+        'Psl\Type\Internal\FloatType',
+        'Psl\Type\Internal\IntersectionType',
+        'Psl\Type\Internal\IntType',
+        'Psl\Type\Internal\IterableType',
+        'Psl\Type\Internal\MixedType',
+        'Psl\Type\Internal\NullType',
+        'Psl\Type\Internal\NumType',
+        'Psl\Type\Internal\ObjectType',
+        'Psl\Type\Internal\ResourceType',
+        'Psl\Type\Internal\StringType',
+        'Psl\Type\Internal\UnionType',
+        'Psl\Type\Exception\TypeTrace',
+        'Psl\Type\Exception\TypeAssertException',
+        'Psl\Type\Exception\TypeCoercionException',
+        'Psl\Type\Exception\TypeException',
+        'Psl\Type\Type',
     ];
 
     public const TRAITS = [
-
+        'Psl\Type\Internal\TypeTraceTrait',
     ];
 
     public const CLASSES = [

--- a/src/Psl/Iter/from_entries.php
+++ b/src/Psl/Iter/from_entries.php
@@ -10,7 +10,7 @@ use Psl\Gen;
  * Returns an iterator where each mapping is defined by the given key/value
  * tuples.
  *
- * @psalm-template Tk of array-key
+ * @psalm-template Tk
  * @psalm-template Tv
  *
  * @psalm-param    iterable<array{0: Tk, 1: Tv}> $entries

--- a/src/Psl/Iter/pull_with_key.php
+++ b/src/Psl/Iter/pull_with_key.php
@@ -23,9 +23,9 @@ use Psl\Gen;
  *          70 => 'H', 131 => 'I', 264 => 'J', 521 => 'K', 1034 => 'L'
  *      )
  *
- * @psalm-template  Tk1 of array-key
+ * @psalm-template  Tk1
  * @psalm-template  Tv1
- * @psalm-template  Tk2 of array-key
+ * @psalm-template  Tk2
  * @psalm-template  Tv2
  *
  * @psalm-param     iterable<Tk1, Tv1>          $iterable

--- a/src/Psl/Iter/reindex.php
+++ b/src/Psl/Iter/reindex.php
@@ -26,8 +26,8 @@ use Psl\Gen;
  *         24 => ['id' => 24, 'name' => 'bar']
  *     )
  *
- * @psalm-template  Tk1 of array-key
- * @psalm-template  Tk2 of array-key
+ * @psalm-template  Tk1
+ * @psalm-template  Tk2
  * @psalm-template  Tv
  *
  * @psalm-param     iterable<Tk1, Tv>       $iterable Iterable to reindex

--- a/src/Psl/Str/join.php
+++ b/src/Psl/Str/join.php
@@ -17,7 +17,7 @@ use Psl\Iter;
  *      Str\join(['Hello', 'World'], ', ')
  *      => Str('Hello, World')
  *
- * @param string[] $pieces the array of strings to implode
+ * @param iterable<string> $pieces the array of strings to implode
  *
  * @return string a string containing a string representation of all the array
  *                elements in the same order, with the glue string between each element

--- a/src/Psl/Type/Exception/TypeAssertException.php
+++ b/src/Psl/Type/Exception/TypeAssertException.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Exception;
+
+use Psl\Str;
+
+final class TypeAssertException extends TypeException
+{
+    private string $expected;
+
+    public function __construct(string $actual, string $expected, TypeTrace $typeTrace)
+    {
+        parent::__construct(Str\format('Expected "%s", got "%s".', $expected, $actual), $actual, $typeTrace);
+
+        $this->expected = $expected;
+    }
+
+    public function getExpectedType(): string
+    {
+        return $this->expected;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public static function withValue(
+        $value,
+        string $expected_type,
+        TypeTrace $trace
+    ): self {
+        return new self(static::getDebugType($value), $expected_type, $trace);
+    }
+}

--- a/src/Psl/Type/Exception/TypeCoercionException.php
+++ b/src/Psl/Type/Exception/TypeCoercionException.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Exception;
+
+use Psl\Str;
+
+final class TypeCoercionException extends TypeException
+{
+    private string $target;
+
+    public function __construct(string $actual, string $target, TypeTrace $typeTrace)
+    {
+        parent::__construct(
+            Str\format('Could not coerce "%s" to type "%s".', $actual, $target),
+            $actual,
+            $typeTrace,
+        );
+
+        $this->target = $target;
+    }
+
+    public function getTargetType(): string
+    {
+        return $this->target;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public static function withValue(
+        $value,
+        string $target,
+        TypeTrace $typeTrace
+    ): self {
+        return new self(static::getDebugType($value), $target, $typeTrace);
+    }
+}

--- a/src/Psl/Type/Exception/TypeException.php
+++ b/src/Psl/Type/Exception/TypeException.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Exception;
+
+use Psl\Exception\RuntimeException;
+use Psl\Str;
+
+abstract class TypeException extends RuntimeException
+{
+    private TypeTrace $typeTrace;
+    private string $actual;
+
+    public function __construct(
+        string $message,
+        string $actual,
+        TypeTrace $typeTrace
+    ) {
+        parent::__construct($message);
+
+        $this->actual = $actual;
+        $this->typeTrace = $typeTrace;
+    }
+
+    public function getActualType(): string
+    {
+        return $this->actual;
+    }
+
+    public function getTypeTrace(): TypeTrace
+    {
+        return $this->typeTrace;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    protected static function getDebugType($value): string
+    {
+        if (is_object($value)) {
+            $actual_type = get_class($value);
+        } elseif (is_resource($value)) {
+            $actual_type = Str\format('resource<%s>', get_resource_type($value));
+        } elseif (is_int($value)) {
+            $actual_type = 'int';
+        } elseif (is_float($value)) {
+            $actual_type = 'float';
+        } else {
+            $actual_type = gettype($value);
+        }
+
+        return $actual_type;
+    }
+}

--- a/src/Psl/Type/Exception/TypeTrace.php
+++ b/src/Psl/Type/Exception/TypeTrace.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Exception;
+
+final class TypeTrace
+{
+    /**
+     * @var string[]
+     */
+    private array $frames = [];
+
+    public function withFrame(string $frame): self
+    {
+        $self = clone $this;
+        $self->frames[] = $frame;
+
+        return $self;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFrames(): array
+    {
+        return $this->frames;
+    }
+}

--- a/src/Psl/Type/Internal/ArrayKeyType.php
+++ b/src/Psl/Type/Internal/ArrayKeyType.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+/**
+ * @extends UnionType<string, int>
+ *
+ * @internal
+ */
+final class ArrayKeyType extends UnionType
+{
+    public function __construct()
+    {
+        parent::__construct(new StringType(), new IntType());
+    }
+
+    public function toString(): string
+    {
+        return 'array-key';
+    }
+}

--- a/src/Psl/Type/Internal/ArrayType.php
+++ b/src/Psl/Type/Internal/ArrayType.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Arr;
+use Psl\Iter;
+use Psl\Str;
+use Psl\Type\Exception\TypeAssertException;
+use Psl\Type\Exception\TypeCoercionException;
+use Psl\Type\Type;
+
+/**
+ * @template Tk of array-key
+ * @template Tv
+ *
+ * @extends Type<array<Tk, Tv>>
+ *
+ * @internal
+ */
+final class ArrayType extends Type
+{
+    /**
+     * @psalm-var Type<Tk>
+     */
+    private Type $key_type_spec;
+
+    /**
+     * @psalm-var Type<Tv>
+     */
+    private Type $value_type_spec;
+
+    /**
+     * @psalm-param Type<Tk> $key_type_spec
+     * @psalm-param Type<Tv> $value_type_spec
+     */
+    public function __construct(
+        Type $key_type_spec,
+        Type $value_type_spec
+    ) {
+        $this->key_type_spec = $key_type_spec;
+        $this->value_type_spec = $value_type_spec;
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return array<Tk, Tv>
+     *
+     * @throws TypeCoercionException
+     */
+    public function coerce($value): array
+    {
+        if (Iter\is_iterable($value)) {
+            $key_trace = $this->getTrace()->withFrame(Str\format('iterable<%s, _>', $this->key_type_spec->toString()));
+            $value_trace = $this->getTrace()->withFrame(Str\format('iterable<_, %s>', $this->value_type_spec->toString()));
+
+            /** @psalm-var Type<Tk> $key_type_spec */
+            $key_type_spec = $this->key_type_spec->withTrace($key_trace);
+            /** @psalm-var Type<Tv> $value_type_spec */
+            $value_type_spec = $this->value_type_spec->withTrace($value_trace);
+
+            /**
+             * @psalm-var list<array{0: Tk, 1: Tv}> $entries
+             */
+            $entries = [];
+            /**
+             * @psalm-var mixed $k
+             * @psalm-var mixed $v
+             */
+            foreach ($value as $k => $v) {
+                /** @psalm-var Tk $k */
+                $k = $key_type_spec->coerce($k);
+                /** @psalm-var Tv $v */
+                $v = $value_type_spec->coerce($v);
+                $entries[] = [$k, $v];
+            }
+
+            /** @psalm-var Iter\Iterator<Tk, Tv> $iterator */
+            $iterator = Iter\from_entries($entries);
+
+            return Iter\to_array_with_keys($iterator);
+        }
+
+
+        throw TypeCoercionException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return array<Tk, Tv>
+     *
+     * @throws TypeAssertException
+     */
+    public function assert($value): array
+    {
+        if (Arr\is_array($value)) {
+            $key_trace = $this->getTrace()->withFrame(Str\format('iterable<%s, _>', $this->key_type_spec->toString()));
+            $value_trace = $this->getTrace()->withFrame(Str\format('iterable<_, %s>', $this->value_type_spec->toString()));
+
+            /** @psalm-var Type<Tk> $key_type_spec */
+            $key_type_spec = $this->key_type_spec->withTrace($key_trace);
+            /** @psalm-var Type<Tv> $value_type_spec */
+            $value_type_spec = $this->value_type_spec->withTrace($value_trace);
+
+            /**
+             * @psalm-var list<array{0: Tk, 1: Tv}> $entries
+             */
+            $entries = [];
+            /**
+             * @psalm-var mixed $k
+             * @psalm-var mixed $v
+             */
+            foreach ($value as $k => $v) {
+                /** @psalm-var Tk $k */
+                $k = $key_type_spec->assert($k);
+                /** @psalm-var Tv $v */
+                $v = $value_type_spec->assert($v);
+                $entries[] = [$k, $v];
+            }
+
+            /** @psalm-var Iter\Iterator<Tk, Tv> $iterator */
+            $iterator = Iter\from_entries($entries);
+
+            return Iter\to_array_with_keys($iterator);
+        }
+
+        throw TypeAssertException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    public function toString(): string
+    {
+        return Str\format('array<%s, %s>', $this->key_type_spec->toString(), $this->value_type_spec->toString());
+    }
+}

--- a/src/Psl/Type/Internal/BoolType.php
+++ b/src/Psl/Type/Internal/BoolType.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Type\Exception\TypeAssertException;
+use Psl\Type\Exception\TypeCoercionException;
+use Psl\Type\Type;
+
+/**
+ * @extends Type<bool>
+ *
+ * @internal
+ */
+final class BoolType extends Type
+{
+    /**
+     * @psalm-return bool
+     *
+     * @throws TypeCoercionException
+     */
+    public function coerce($value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (0 === $value) {
+            return false;
+        }
+
+        if (1 === $value) {
+            return true;
+        }
+
+        throw TypeCoercionException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    /**
+     * @psalm-return bool
+     *
+     * @throws TypeAssertException
+     */
+    public function assert($value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        throw TypeAssertException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    public function toString(): string
+    {
+        return 'bool';
+    }
+}

--- a/src/Psl/Type/Internal/FloatType.php
+++ b/src/Psl/Type/Internal/FloatType.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use function ctype_digit;
+use Psl\Str;
+use Psl\Type\Exception\TypeAssertException;
+use Psl\Type\Exception\TypeCoercionException;
+use Psl\Type\Type;
+
+/**
+ * @extends Type<float>
+ *
+ * @internal
+ */
+final class FloatType extends Type
+{
+    private const TYPE = 'float';
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return float
+     *
+     * @throws TypeCoercionException
+     */
+    public function coerce($value): float
+    {
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (Str\is_string($value) || (is_object($value) && method_exists($value, '__toString'))) {
+            $str = (string) $value;
+            if ('' === $str) {
+                throw TypeCoercionException::withValue($value, $this->toString(), $this->getTrace());
+            }
+
+            if (ctype_digit($str)) {
+                return (float)$str;
+            }
+
+            if (1 === preg_match("/^-?(?:\\d*\\.)?\\d+(?:[eE]\\d+)?$/", $str)) {
+                return (float)$str;
+            }
+        }
+
+        throw TypeCoercionException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return float
+     *
+     * @throws TypeAssertException
+     */
+    public function assert($value): float
+    {
+        if (is_float($value)) {
+            return $value;
+        }
+
+        throw TypeAssertException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    public function toString(): string
+    {
+        return 'float';
+    }
+}

--- a/src/Psl/Type/Internal/IntType.php
+++ b/src/Psl/Type/Internal/IntType.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Str;
+use Psl\Type\Exception\TypeAssertException;
+use Psl\Type\Exception\TypeCoercionException;
+use Psl\Type\Type;
+
+/**
+ * @extends Type<int>
+ *
+ * @internal
+ */
+final class IntType extends Type
+{
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return int
+     *
+     * @throws TypeCoercionException
+     */
+    public function coerce($value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (Str\is_string($value) || (is_object($value) && method_exists($value, '__toString'))) {
+            $str = (string)$value;
+            $int = Str\to_int($str);
+            if (null !== $int) {
+                return $int;
+            }
+
+            $trimmed = Str\trim_left($str, '0');
+            $int = Str\to_int($trimmed);
+            if (null !== $int) {
+                return $int;
+            }
+
+            // Exceptional case "000" -(trim)-> "", but we want to return 0
+            if ('' === $trimmed && '' !== $str) {
+                return 0;
+            }
+        }
+
+        throw TypeCoercionException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return int
+     *
+     * @throws TypeAssertException
+     */
+    public function assert($value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        throw TypeAssertException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    public function toString(): string
+    {
+        return 'int';
+    }
+}

--- a/src/Psl/Type/Internal/IntersectionType.php
+++ b/src/Psl/Type/Internal/IntersectionType.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Str;
+use Psl\Type\Exception\TypeAssertException;
+use Psl\Type\Exception\TypeCoercionException;
+use Psl\Type\Exception\TypeException;
+use Psl\Type\Type;
+
+/**
+ * @template Tl
+ * @template Tr
+ *
+ * @extends Type<Tl&Tr>
+ *
+ * @internal
+ */
+final class IntersectionType extends Type
+{
+    /**
+     * @psalm-var Type<Tl>
+     */
+    private Type $left_type_spec;
+
+    /**
+     * @psalm-var Type<Tr>
+     */
+    private Type $right_type_spec;
+
+    /**
+     * @psalm-param Type<Tl> $left_type_spec
+     * @psalm-param Type<Tr> $right_type_spec
+     */
+    public function __construct(
+        Type $left_type_spec,
+        Type $right_type_spec
+    ) {
+        $this->left_type_spec = $left_type_spec;
+        $this->right_type_spec = $right_type_spec;
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return Tl&Tr
+     *
+     * @throws TypeCoercionException
+     */
+    public function coerce($value)
+    {
+        try {
+            return $this->assert($value);
+        } catch (TypeAssertException $_e) {
+            // ignore
+        }
+
+        try {
+            /** @psalm-var Tl $value */
+            $value = $this->left_type_spec->coerce($value);
+            /** @psalm-var Tl&Tr $value */
+            $value = $this->right_type_spec->assert($value);
+
+            return $value;
+        } catch (TypeException $_e) {
+            // ignore
+        }
+
+        try {
+            /** @psalm-var Tr $value */
+            $value = $this->right_type_spec->coerce($value);
+            /** @psalm-var Tr&Tl $value */
+            $value = $this->left_type_spec->assert($value);
+
+            return $value;
+        } catch (TypeException $_e) {
+            // ignore
+        }
+
+        throw TypeCoercionException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return Tl&Tr
+     *
+     * @throws TypeAssertException
+     */
+    public function assert($value)
+    {
+        try {
+            /** @psalm-var Tl $value */
+            $value = $this->left_type_spec->assert($value);
+            /** @psalm-var Tl&Tr $value */
+            $value = $this->right_type_spec->assert($value);
+
+            return $value;
+        } catch (TypeAssertException $_e) {
+            throw TypeAssertException::withValue($value, $this->toString(), $this->getTrace());
+        }
+    }
+
+    public function toString(): string
+    {
+        $left = $this->left_type_spec->toString();
+        $right = $this->right_type_spec->toString();
+        /** @psalm-suppress MissingThrowsDocblock - offset is within bound. */
+        if (Str\contains($left, '|')) {
+            $left = Str\format('(%s)', $left);
+        }
+        /** @psalm-suppress MissingThrowsDocblock - offset is within bound. */
+        if (Str\contains($right, '|')) {
+            $right = Str\format('(%s)', $right);
+        }
+
+        return Str\format('%s&%s', $left, $right);
+    }
+}

--- a/src/Psl/Type/Internal/IterableType.php
+++ b/src/Psl/Type/Internal/IterableType.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Iter;
+use Psl\Str;
+use Psl\Type\Exception\TypeAssertException;
+use Psl\Type\Exception\TypeCoercionException;
+use Psl\Type\Type;
+
+/**
+ * @template Tk
+ * @template Tv
+ *
+ * @extends Type<iterable<Tk, Tv>>
+ *
+ * @internal
+ */
+final class IterableType extends Type
+{
+    /**
+     * @psalm-var Type<Tk>
+     */
+    private Type $key_type_spec;
+
+    /**
+     * @psalm-var Type<Tv>
+     */
+    private Type $value_type_spec;
+
+    /**
+     * @psalm-param Type<Tk> $key_type_spec
+     * @psalm-param Type<Tv> $value_type_spec
+     */
+    public function __construct(
+        Type $key_type_spec,
+        Type $value_type_spec
+    ) {
+        $this->key_type_spec = $key_type_spec;
+        $this->value_type_spec = $value_type_spec;
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return iterable<Tk, Tv>
+     *
+     * @throws TypeCoercionException
+     */
+    public function coerce($value): iterable
+    {
+        if (Iter\is_iterable($value)) {
+            $key_trace = $this->getTrace()->withFrame(Str\format('iterable<%s, _>', $this->key_type_spec->toString()));
+            $value_trace = $this->getTrace()->withFrame(Str\format('iterable<_, %s>', $this->value_type_spec->toString()));
+
+            /** @psalm-var Type<Tk> $key_type_spec */
+            $key_type_spec = $this->key_type_spec->withTrace($key_trace);
+            /** @psalm-var Type<Tv> $value_type_speec */
+            $value_type_spec = $this->value_type_spec->withTrace($value_trace);
+
+            /**
+             * @psalm-var list<array{0: Tk, 1: Tv}> $entries
+             */
+            $entries = [];
+            /**
+             * @psalm-var mixed $k
+             * @psalm-var mixed $v
+             */
+            foreach ($value as $k => $v) {
+                /** @psalm-var Tk $k */
+                $k = $key_type_spec->coerce($k);
+                /** @psalm-var Tv $v */
+                $v = $value_type_spec->coerce($v);
+                $entries[] = [$k, $v];
+            }
+
+            /** @psalm-var Iter\Iterator<Tk, Tv> $iterator */
+            $iterator = Iter\from_entries($entries);
+
+            return $iterator;
+        }
+
+        throw TypeCoercionException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return iterable<Tk, Tv>
+     *
+     * @throws TypeAssertException
+     */
+    public function assert($value): iterable
+    {
+        if (Iter\is_iterable($value)) {
+            $key_trace = $this->getTrace()->withFrame(Str\format('iterable<%s, _>', $this->key_type_spec->toString()));
+            $value_trace = $this->getTrace()->withFrame(Str\format('iterable<_, %s>', $this->value_type_spec->toString()));
+
+            /** @psalm-var Type<Tk> $key_type_spec */
+            $key_type_spec = $this->key_type_spec->withTrace($key_trace);
+            /** @psalm-var Type<Tv> $value_type_spec */
+            $value_type_spec = $this->value_type_spec->withTrace($value_trace);
+
+            /**
+             * @psalm-var list<array{0: Tk, 1: Tv}> $entries
+             */
+            $entries = [];
+            /**
+             * @psalm-var mixed $k
+             * @psalm-var mixed $v
+             */
+            foreach ($value as $k => $v) {
+                /** @psalm-var Tk $k */
+                $k = $key_type_spec->assert($k);
+                /** @psalm-var Tv $v */
+                $v = $value_type_spec->assert($v);
+                $entries[] = [$k, $v];
+            }
+
+            /** @psalm-var Iter\Iterator<Tk, Tv> $iterator */
+            $iterator = Iter\from_entries($entries);
+
+            return $iterator;
+        }
+
+        throw TypeAssertException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    public function toString(): string
+    {
+        return Str\format('iterable<%s, %s>', $this->key_type_spec->toString(), $this->value_type_spec->toString());
+    }
+}

--- a/src/Psl/Type/Internal/MixedType.php
+++ b/src/Psl/Type/Internal/MixedType.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Type\Type;
+
+/**
+ * @extends Type<mixed>
+ *
+ * @internal
+ */
+final class MixedType extends Type
+{
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return mixed
+     */
+    public function coerce($value)
+    {
+        return $value;
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return mixed
+     */
+    public function assert($value)
+    {
+        return $value;
+    }
+
+    public function toString(): string
+    {
+        return 'mixed';
+    }
+}

--- a/src/Psl/Type/Internal/NullType.php
+++ b/src/Psl/Type/Internal/NullType.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Type\Exception\TypeAssertException;
+use Psl\Type\Exception\TypeCoercionException;
+use Psl\Type\Type;
+
+/**
+ * @extends Type<null>
+ *
+ * @internal
+ */
+final class NullType extends Type
+{
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return null
+     */
+    public function coerce($value)
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        throw TypeCoercionException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return null
+     */
+    public function assert($value)
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        throw TypeAssertException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    public function toString(): string
+    {
+        return 'null';
+    }
+}

--- a/src/Psl/Type/Internal/NumType.php
+++ b/src/Psl/Type/Internal/NumType.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+/**
+ * @extends UnionType<int, float>
+ *
+ * @internal
+ */
+final class NumType extends UnionType
+{
+    public function __construct()
+    {
+        parent::__construct(new IntType(), new FloatType());
+    }
+
+    public function toString(): string
+    {
+        return 'num';
+    }
+}

--- a/src/Psl/Type/Internal/ObjectType.php
+++ b/src/Psl/Type/Internal/ObjectType.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Type\Exception\TypeAssertException;
+use Psl\Type\Exception\TypeCoercionException;
+use Psl\Type\Type;
+
+/**
+ * @template T as object
+ *
+ * @extends Type<T>
+ *
+ * @internal
+ */
+final class ObjectType extends Type
+{
+    /**
+     * @psalm-var class-string<T> $classname
+     */
+    private string $classname;
+
+    /**
+     * @psalm-param class-string<T> $classname
+     */
+    public function __construct(
+        string $classname
+    ) {
+        $this->classname = $classname;
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return T
+     *
+     * @throws TypeCoercionException
+     */
+    public function coerce($value): object
+    {
+        if ($value instanceof $this->classname) {
+            return $value;
+        }
+
+        throw TypeCoercionException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return T
+     *
+     * @throws TypeAssertException
+     */
+    public function assert($value): object
+    {
+        if ($value instanceof $this->classname) {
+            return $value;
+        }
+
+        throw TypeAssertException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    public function toString(): string
+    {
+        return $this->classname;
+    }
+}

--- a/src/Psl/Type/Internal/ResourceType.php
+++ b/src/Psl/Type/Internal/ResourceType.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Str;
+use Psl\Type\Exception\TypeAssertException;
+use Psl\Type\Exception\TypeCoercionException;
+use Psl\Type\Type;
+
+/**
+ * @extends Type<resource>
+ *
+ * @internal
+ */
+final class ResourceType extends Type
+{
+    private ?string $kind;
+
+    public function __construct(?string $kind = null)
+    {
+        $this->kind = $kind;
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return resource
+     */
+    public function coerce($value)
+    {
+        if (is_resource($value)) {
+            $kind = $this->kind;
+            if (null === $kind) {
+                return $value;
+            }
+
+            if (get_resource_type($value) === $kind) {
+                return $value;
+            }
+        }
+
+        throw TypeCoercionException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return resource
+     */
+    public function assert($value)
+    {
+        if (is_resource($value)) {
+            $kind = $this->kind;
+            if (null === $kind) {
+                return $value;
+            }
+
+            if (get_resource_type($value) === $kind) {
+                return $value;
+            }
+        }
+
+        throw TypeAssertException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    public function toString(): string
+    {
+        if (null === $this->kind) {
+            return 'resource';
+        }
+
+        return Str\format('resource<%s>', $this->kind);
+    }
+}

--- a/src/Psl/Type/Internal/ScalarType.php
+++ b/src/Psl/Type/Internal/ScalarType.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+/**
+ * @extends UnionType<string|bool, int|float>
+ *
+ * @internal
+ */
+final class ScalarType extends UnionType
+{
+    public function __construct()
+    {
+        parent::__construct(
+            new UnionType(new StringType(), new BoolType()),
+            new NumType()
+        );
+    }
+
+    public function toString(): string
+    {
+        return 'scalar';
+    }
+}

--- a/src/Psl/Type/Internal/StringType.php
+++ b/src/Psl/Type/Internal/StringType.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Str;
+use Psl\Type\Exception\TypeAssertException;
+use Psl\Type\Exception\TypeCoercionException;
+use Psl\Type\Type;
+
+/**
+ * @extends Type<string>
+ *
+ * @internal
+ */
+final class StringType extends Type
+{
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return string
+     *
+     * @throws TypeCoercionException
+     */
+    public function coerce($value): string
+    {
+        if (Str\is_string($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return (string)$value;
+        }
+
+        if (is_object($value) && method_exists($value, '__toString')) {
+            return (string)$value;
+        }
+
+        throw TypeCoercionException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return string
+     *
+     * @throws TypeAssertException
+     */
+    public function assert($value): string
+    {
+        if (Str\is_string($value)) {
+            return $value;
+        }
+
+        throw TypeAssertException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    public function toString(): string
+    {
+        return 'string';
+    }
+}

--- a/src/Psl/Type/Internal/TypeTraceTrait.php
+++ b/src/Psl/Type/Internal/TypeTraceTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Type\Exception\TypeTrace;
+
+trait TypeTraceTrait
+{
+    private ?TypeTrace $trace = null;
+
+    final protected function getTrace(): TypeTrace
+    {
+        return $this->trace ?? new TypeTrace();
+    }
+
+    final protected function withTrace(TypeTrace $trace): self
+    {
+        $new = clone $this;
+        $new->trace = $trace;
+        return $new;
+    }
+}

--- a/src/Psl/Type/Internal/UnionType.php
+++ b/src/Psl/Type/Internal/UnionType.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Str;
+use Psl\Type\Exception\TypeAssertException;
+use Psl\Type\Exception\TypeCoercionException;
+use Psl\Type\Type;
+
+/**
+ * @template Tl
+ * @template Tr
+ *
+ * @extends Type<Tl|Tr>
+ *
+ * @internal
+ */
+class UnionType extends Type
+{
+    /**
+     * @psalm-var Type<Tl>
+     */
+    private Type $left_type_spec;
+
+    /**
+     * @psalm-var Type<Tr>
+     */
+    private Type $right_type_spec;
+
+    /**
+     * @psalm-param Type<Tl> $left_type_spec
+     * @psalm-param Type<Tr> $right_type_spec
+     */
+    public function __construct(
+        Type $left_type_spec,
+        Type $right_type_spec
+    ) {
+        $this->left_type_spec = $left_type_spec;
+        $this->right_type_spec = $right_type_spec;
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return Tl|Tr
+     *
+     * @throws TypeCoercionException
+     */
+    public function coerce($value)
+    {
+        try {
+            return $this->assert($value);
+        } catch (TypeAssertException $_e) {
+            // ignore
+        }
+
+        try {
+            return $this->left_type_spec->coerce($value);
+        } catch (TypeCoercionException $_e) {
+            // ignore
+        }
+
+        try {
+            return $this->right_type_spec->coerce($value);
+        } catch (TypeCoercionException $_e) {
+            // ignore
+        }
+
+        throw TypeCoercionException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return Tl|Tr
+     *
+     * @throws TypeAssertException
+     */
+    public function assert($value)
+    {
+        try {
+            return $this->left_type_spec->assert($value);
+        } catch (TypeAssertException $_e) {
+            // ignore
+        }
+
+        try {
+            return $this->right_type_spec->assert($value);
+        } catch (TypeAssertException $_e) {
+            // ignore
+        }
+
+        throw TypeAssertException::withValue($value, $this->toString(), $this->getTrace());
+    }
+
+    public function toString(): string
+    {
+        $left = $this->left_type_spec->toString();
+        $right = $this->right_type_spec->toString();
+        /** @psalm-suppress MissingThrowsDocblock - offset is within bound. */
+        if (Str\contains($left, '&')) {
+            $left = Str\format('(%s)', $left);
+        }
+        /** @psalm-suppress MissingThrowsDocblock - offset is within bound. */
+        if (Str\contains($right, '&')) {
+            $right = Str\format('(%s)', $right);
+        }
+
+        return Str\format('%s|%s', $left, $right);
+    }
+}

--- a/src/Psl/Type/Type.php
+++ b/src/Psl/Type/Type.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+use Psl\Type\Exception\TypeAssertException;
+use Psl\Type\Exception\TypeCoercionException;
+use Psl\Type\Exception\TypeTrace;
+use Psl\Type\Internal\TypeTraceTrait;
+
+/**
+ * @template T
+ */
+abstract class Type
+{
+    use TypeTraceTrait;
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return T
+     *
+     * @throws TypeCoercionException
+     */
+    abstract public function coerce($value);
+
+    /**
+     * @psalm-param mixed $value
+     *
+     * @psalm-return T
+     *
+     * @throws TypeAssertException
+     */
+    abstract public function assert($value);
+
+    /**
+     * Returns a string representation of the type.
+     */
+    abstract public function toString(): string;
+}

--- a/src/Psl/Type/arr.php
+++ b/src/Psl/Type/arr.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @template Tk of array-key
+ * @template Tv
+ *
+ * @psalm-param Type<Tk> $key_type_spec
+ * @psalm-param Type<Tv> $value_type_spec
+ *
+ * @psalm-return Type<array<Tk, Tv>>
+ */
+function arr(Type $key_type_spec, Type $value_type_spec): Type
+{
+    return new Internal\ArrayType($key_type_spec, $value_type_spec);
+}

--- a/src/Psl/Type/array_key.php
+++ b/src/Psl/Type/array_key.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @psalm-return Type<array-key>
+ */
+function array_key(): Type
+{
+    return new Internal\ArrayKeyType();
+}

--- a/src/Psl/Type/bool.php
+++ b/src/Psl/Type/bool.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @psalm-return Type<bool>
+ */
+function bool(): Type
+{
+    return new Internal\BoolType();
+}

--- a/src/Psl/Type/float.php
+++ b/src/Psl/Type/float.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @psalm-return Type<float>
+ */
+function float(): Type
+{
+    return new Internal\FloatType();
+}

--- a/src/Psl/Type/int.php
+++ b/src/Psl/Type/int.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @psalm-return Type<int>
+ */
+function int(): Type
+{
+    return new Internal\IntType();
+}

--- a/src/Psl/Type/intersection.php
+++ b/src/Psl/Type/intersection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @template Tl
+ * @template Tr
+ *
+ * @psalm-param Type<Tl> $left_type_spec
+ * @psalm-param Type<Tr> $right_type_spec
+ *
+ * @psalm-return Type<Tl&Tr>
+ */
+function intersection(
+    Type $left_type_spec,
+    Type $right_type_spec
+): Type {
+    /** @psalm-var Type<Tl&Tr> */
+    return new Internal\IntersectionType($left_type_spec, $right_type_spec);
+}

--- a/src/Psl/Type/iterable.php
+++ b/src/Psl/Type/iterable.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @template Tk
+ * @template Tv
+ *
+ * @psalm-param Type<Tk> $key_type_spec
+ * @psalm-param Type<Tv> $value_type_spec
+ *
+ * @psalm-return Type<iterable<Tk, Tv>>
+ */
+function iterable(Type $key_type_spec, Type $value_type_spec): Type
+{
+    return new Internal\IterableType($key_type_spec, $value_type_spec);
+}

--- a/src/Psl/Type/mixed.php
+++ b/src/Psl/Type/mixed.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @psalm-return Type<mixed>
+ */
+function mixed(): Type
+{
+    return new Internal\MixedType();
+}

--- a/src/Psl/Type/null.php
+++ b/src/Psl/Type/null.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @psalm-return Type<null>
+ */
+function null(): Type
+{
+    return new Internal\NullType();
+}

--- a/src/Psl/Type/nullable.php
+++ b/src/Psl/Type/nullable.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @template T
+ *
+ * @psalm-param Type<T> $spec
+ *
+ * @psalm-return Type<null|T>
+ */
+function nullable(Type $spec): Type
+{
+    return new Internal\UnionType(null(), $spec);
+}

--- a/src/Psl/Type/num.php
+++ b/src/Psl/Type/num.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @psalm-return Type<int|float>
+ */
+function num(): Type
+{
+    return new Internal\NumType();
+}

--- a/src/Psl/Type/object.php
+++ b/src/Psl/Type/object.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @template T
+ *
+ * @psalm-param class-string<T> $classname
+ *
+ * @psalm-return Type<T>
+ */
+function object(string $classname): Type
+{
+    return new Internal\ObjectType($classname);
+}

--- a/src/Psl/Type/resource.php
+++ b/src/Psl/Type/resource.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @param ?string $kind The resource kind, if null, the resource type won't be validated.
+ *
+ * @psalm-return Type<resource>
+ */
+function resource(?string $kind = null): Type
+{
+    return new Internal\ResourceType($kind);
+}

--- a/src/Psl/Type/scalar.php
+++ b/src/Psl/Type/scalar.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @psalm-return Type<string|bool|int|float>
+ */
+function scalar(): Type
+{
+    return new Internal\ScalarType();
+}

--- a/src/Psl/Type/string.php
+++ b/src/Psl/Type/string.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @psalm-return Type<string>
+ */
+function string(): Type
+{
+    return new Internal\StringType();
+}

--- a/src/Psl/Type/union.php
+++ b/src/Psl/Type/union.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @template Tl
+ * @template Tr
+ *
+ * @psalm-param Type<Tl> $left_type_spec
+ * @psalm-param Type<Tr> $right_type_spec
+ *
+ * @psalm-return Type<Tl|Tr>
+ */
+function union(
+    Type $left_type_spec,
+    Type $right_type_spec
+): Type {
+    return new Internal\UnionType($left_type_spec, $right_type_spec);
+}

--- a/tests/Psl/Type/ArrayKeyTypeTest.php
+++ b/tests/Psl/Type/ArrayKeyTypeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Type;
+
+class ArrayKeyTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\array_key();
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [123, 123];
+        yield [0, 0];
+        yield ['0', '0'];
+        yield ['123', '123'];
+        yield ['1e23', '1e23'];
+        yield [$this->stringable('123'), '123'];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [1.0];
+        yield [1.23];
+        yield [[]];
+        yield [[1]];
+        yield [Type\bool()];
+        yield [null];
+        yield [false];
+        yield [true];
+        yield [STDIN];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'array-key'];
+    }
+}

--- a/tests/Psl/Type/ArrayTypeTest.php
+++ b/tests/Psl/Type/ArrayTypeTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Gen;
+use Psl\Iter;
+use Psl\Str;
+use Psl\Type;
+
+class ArrayTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\arr(Type\int(), Type\int());
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]];
+        yield [Iter\range(1, 10), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]];
+        yield [Gen\range(1, 10), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]];
+        yield [
+            Iter\map(Iter\range(1, 10), fn (int $value): string => (string) $value),
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        ];
+        yield [
+            Iter\map_keys(Iter\range(1, 10), fn (int $key): string => (string) $key),
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        ];
+        yield [
+            Iter\map(Iter\range(1, 10), fn (int $value): string => Str\format('00%d', $value)),
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        ];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [1.0];
+        yield [1.23];
+        yield [Type\bool()];
+        yield [null];
+        yield [false];
+        yield [true];
+        yield [STDIN];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'array<int, int>'];
+        yield [Type\arr(Type\array_key(), Type\int()), 'array<array-key, int>'];
+        yield [Type\arr(Type\array_key(), Type\string()), 'array<array-key, string>'];
+        yield [Type\arr(Type\array_key(), Type\object(Iter\Iterator::class)), 'array<array-key, Psl\Iter\Iterator>'];
+    }
+}

--- a/tests/Psl/Type/BoolTypeTest.php
+++ b/tests/Psl/Type/BoolTypeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Type;
+
+class BoolTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\bool();
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [false, false];
+        yield [0, false];
+        yield [true, true];
+        yield [1, true];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [null];
+        yield ['true'];
+        yield ['false'];
+        yield [1.2];
+        yield [Type\bool()];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'bool'];
+    }
+}

--- a/tests/Psl/Type/Exception/TypeCoercionExceptionTest.php
+++ b/tests/Psl/Type/Exception/TypeCoercionExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Arr;
+use Psl\Collection;
+use Psl\Str;
+use Psl\Type;
+
+class TypeCoercionExceptionTest extends TestCase
+{
+    public function testIncorrectIterableKey(): void
+    {
+        $type = Type\iterable(Type\bool(), Type\object(Collection\ICollection::class));
+
+        try {
+            $type->coerce([
+                4 => new Collection\Vector([1, 2, 3])
+            ]);
+
+            self::fail(Str\format('Expected "%s" exception to be thrown.', Type\Exception\TypeCoercionException::class));
+        } catch (Type\Exception\TypeCoercionException $e) {
+            static::assertSame('bool', $e->getTargetType());
+            static::assertSame('int', $e->getActualType());
+            static::assertSame('Could not coerce "int" to type "bool".', $e->getMessage());
+
+            $trace = $e->getTypeTrace();
+            $frames = $trace->getFrames();
+
+            static::assertCount(1, $frames);
+            static::assertSame('iterable<bool, _>', Arr\first($frames));
+        }
+    }
+
+    public function testIncorrectResourceType(): void
+    {
+        $type = Type\resource('curl');
+
+        try {
+            $type->coerce(new Collection\Map(['hello' => 'foo']));
+
+            self::fail(Str\format('Expected "%s" exception to be thrown.', Type\Exception\TypeCoercionException::class));
+        } catch (Type\Exception\TypeCoercionException $e) {
+            static::assertSame('resource<curl>', $e->getTargetType());
+            static::assertSame(Collection\Map::class, $e->getActualType());
+            static::assertSame(Str\format('Could not coerce "%s" to type "resource<curl>".', Collection\Map::class), $e->getMessage());
+
+            $trace = $e->getTypeTrace();
+            $frames = $trace->getFrames();
+
+            static::assertCount(0, $frames);
+        }
+    }
+}

--- a/tests/Psl/Type/FloatTypeTest.php
+++ b/tests/Psl/Type/FloatTypeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Math;
+use Psl\Type;
+
+class FloatTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\float();
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [123, 123.0];
+        yield [0, 0.0];
+        yield ['0', 0.0];
+        yield ['123', 123.0];
+        yield [$this->stringable('123'), 123.0];
+        yield ['1e2', 1e2];
+        yield [$this->stringable('1e2'), 1e2];
+        yield ['1.23e45', 1.23e45];
+        yield ['.23', .23];
+        yield [$this->stringable('1.23'), 1.23];
+        yield [Math\INT64_MAX, (float) Math\INT64_MAX];
+        yield [(string)Math\INT64_MAX, (float) Math\INT64_MAX];
+        yield [$this->stringable((string)Math\INT64_MAX), (float) Math\INT64_MAX];
+        yield ['9223372036854775808', 9223372036854775808.0];
+        yield ['007', 7.0];
+        yield ['-0.1', -0.1];
+        yield ['-.5', -.5];
+        yield ['-.9e2', -.9e2];
+        yield ['-0.7e2', -0.7e2];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield ['foo'];
+        yield [null];
+        yield [false];
+        yield [new class() {
+        }];
+        yield [$this->stringable('foo')];
+        yield ['0xFF'];
+        yield ['1a'];
+        yield ['e1'];
+        yield ['1e'];
+        yield ['ee7'];
+        yield ['1e2e1'];
+        yield ['1ee1'];
+        yield ['1,2'];
+        yield ['+1'];
+        yield ['3.'];
+        yield [''];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'float'];
+    }
+}

--- a/tests/Psl/Type/IntTypeTest.php
+++ b/tests/Psl/Type/IntTypeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Math;
+use Psl\Type;
+
+class IntTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\int();
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [123, 123];
+        yield [0, 0];
+        yield ['0', 0];
+        yield ['123', 123];
+        yield [$this->stringable('123'), 123];
+        yield [$this->stringable((string) Math\INT16_MAX), Math\INT16_MAX];
+        yield [$this->stringable((string) Math\INT64_MAX), Math\INT64_MAX];
+        yield [(string) Math\INT64_MAX, Math\INT64_MAX];
+        yield [Math\INT64_MAX, Math\INT64_MAX];
+        yield [$this->stringable('-321'), -321];
+        yield ['-321', -321];
+        yield [-321, -321];
+        yield ['7', 7];
+        yield ['07', 7];
+        yield ['007', 7];
+        yield ['000', 0];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield ['1.23'];
+        yield ['1e123'];
+        yield [''];
+        yield [1.0];
+        yield [1.23];
+        yield [[]];
+        yield [[123]];
+        yield [null];
+        yield [false];
+        yield [$this->stringable('1.23')];
+        yield [$this->stringable('-007')];
+        yield ['-007'];
+        yield ['9223372036854775808'];
+        yield [$this->stringable('9223372036854775808')];
+        yield ['-9223372036854775809'];
+        yield [$this->stringable('-9223372036854775809')];
+        yield ['0xFF'];
+        yield [''];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'int'];
+    }
+}

--- a/tests/Psl/Type/IntersectionTypeTest.php
+++ b/tests/Psl/Type/IntersectionTypeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Collection\ICollection;
+use Psl\Collection\IIndexAccess;
+use Psl\Type;
+
+class IntersectionTypeTest extends TypeTest
+{
+    public function testIntersectionLeft(): void
+    {
+        $intersection = Type\intersection(Type\array_key(), Type\int());
+
+        self::assertSame(1, $intersection->coerce('1'));
+    }
+
+    public function getType(): Type\Type
+    {
+        return Type\intersection(Type\int(), Type\array_key());
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [1, 1];
+        yield ['1', 1];
+        yield ['123', 123];
+        yield [$this->stringable('123'), 123];
+        yield [$this->stringable('000'), 0];
+        yield [$this->stringable('0007'), 7];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [null];
+        yield [STDIN];
+        yield ['hello'];
+        yield [$this->stringable('foo')];
+        yield [new class {
+        }];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [Type\intersection(Type\object(IIndexAccess::class), Type\object(ICollection::class)), 'Psl\Collection\IIndexAccess&Psl\Collection\ICollection'];
+
+        yield [Type\intersection(
+            Type\object(IIndexAccess::class),
+            Type\union(Type\object(ICollection::class), Type\object(\Iterator::class))
+        ), 'Psl\Collection\IIndexAccess&(Psl\Collection\ICollection|Iterator)'];
+
+        yield [Type\intersection(
+            Type\union(Type\object(ICollection::class), Type\object(\Iterator::class)),
+            Type\object(IIndexAccess::class)
+        ), '(Psl\Collection\ICollection|Iterator)&Psl\Collection\IIndexAccess'];
+    }
+}

--- a/tests/Psl/Type/IterableTypeTest.php
+++ b/tests/Psl/Type/IterableTypeTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Gen;
+use Psl\Iter;
+use Psl\Str;
+use Psl\Type;
+
+/**
+ * @extends TypeTest<iterable<int, int>>
+ */
+class IterableTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\iterable(Type\int(), Type\int());
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]];
+        yield [Iter\range(1, 10), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]];
+        yield [Gen\range(1, 10), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]];
+
+        yield [
+            Iter\map(Iter\range(1, 10), fn (int $value): string => (string) $value),
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        ];
+
+        yield [
+            Iter\map_keys(Iter\range(1, 10), fn (int $key): string => (string) $key),
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        ];
+
+        yield [
+            Iter\map(Iter\range(1, 10), fn (int $value): string => Str\format('00%d', $value)),
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        ];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [1.0];
+        yield [1.23];
+        yield [Type\bool()];
+        yield [null];
+        yield [false];
+        yield [true];
+        yield [STDIN];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'iterable<int, int>'];
+        yield [Type\iterable(Type\array_key(), Type\int()), 'iterable<array-key, int>'];
+        yield [Type\iterable(Type\array_key(), Type\string()), 'iterable<array-key, string>'];
+        yield [Type\iterable(Type\array_key(), Type\object(Iter\Iterator::class)), 'iterable<array-key, Psl\Iter\Iterator>'];
+    }
+
+    /**
+     * @param iterable<int, int> $a
+     * @param iterable<int, int> $b
+     * @return bool
+     */
+    protected function equals($a, $b): bool
+    {
+        $a = Iter\to_array_with_keys($a);
+        $b = Iter\to_array_with_keys($b);
+
+        return $a === $b;
+    }
+}

--- a/tests/Psl/Type/MixedTypeTest.php
+++ b/tests/Psl/Type/MixedTypeTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Math;
+use Psl\Type;
+
+class MixedTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\mixed();
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [123, 123];
+        yield [0, 0];
+        yield ['0', '0'];
+        yield ['123', '123'];
+        yield [$_ = $this->stringable('123'), $_];
+        yield [$_ = $this->stringable((string) Math\INT16_MAX), $_];
+        yield [$_ = $this->stringable((string) Math\INT64_MAX), $_];
+        yield [(string) Math\INT64_MAX, (string) Math\INT64_MAX];
+        yield [Math\INT64_MAX, Math\INT64_MAX];
+        yield [$_ = $this->stringable('-321'), $_];
+        yield ['-321', '-321'];
+        yield [-321, -321];
+        yield ['7', '7'];
+        yield ['07', '07'];
+        yield ['007', '007'];
+        yield ['000', '000'];
+        yield [$_ = $this->stringable('123'), $_];
+        yield ['1e2', '1e2'];
+        yield [$_ = $this->stringable('1e2'), $_];
+        yield ['1.23e45', '1.23e45'];
+        yield ['.23', '.23'];
+        yield [$_ = $this->stringable('1.23'), $_];
+        yield [(float) Math\INT64_MAX, (float) Math\INT64_MAX];
+        yield ['9223372036854775808', '9223372036854775808'];
+        yield ['-.9e2', '-.9e2'];
+        yield ['-0.7e2', '-0.7e2'];
+        yield [false, false];
+        yield [0, 0];
+        yield [1, 1];
+        yield [true, true];
+        yield [[], []];
+        yield [$_ = new class {
+        }, $_];
+        yield [null, null];
+        yield [STDIN, STDIN];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [null];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'mixed'];
+    }
+
+    /**
+     * @dataProvider getInvalidValues
+     */
+    public function testInvalidAssertion($value): void
+    {
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @dataProvider getInvalidCoercions
+     */
+    public function testInvalidCoercion($value): void
+    {
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Psl/Type/NullTypeTest.php
+++ b/tests/Psl/Type/NullTypeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Type;
+
+class NullTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\null();
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [null, null];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [Type\bool()];
+        yield [1];
+        yield [0];
+        yield [false];
+        yield [true];
+        yield [''];
+        yield ['null'];
+        yield ['foo'];
+        yield [[null]];
+        yield [[]];
+        yield [[1, 2, 3]];
+        yield [$this->stringable('')];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'null'];
+    }
+}

--- a/tests/Psl/Type/NullableTypeTest.php
+++ b/tests/Psl/Type/NullableTypeTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Type;
+
+class NullableTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\nullable(Type\string());
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield ['hello', 'hello'];
+        yield [$this->stringable('hello'), 'hello'];
+        yield [123, '123'];
+        yield [0, '0'];
+        yield ['0', '0'];
+        yield ['123', '123'];
+        yield ['1e23', '1e23'];
+        yield [$this->stringable('123'), '123'];
+        yield [null, null];
+        yield ['null', 'null'];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [1.0];
+        yield [1.23];
+        yield [[]];
+        yield [[1]];
+        yield [Type\bool()];
+        yield [false];
+        yield [true];
+        yield [STDIN];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'null|string'];
+    }
+}

--- a/tests/Psl/Type/NumTypeTest.php
+++ b/tests/Psl/Type/NumTypeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Math;
+use Psl\Type;
+
+class NumTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\num();
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [123, 123];
+        yield [0, 0];
+        yield ['0', 0];
+        yield ['123', 123];
+        yield [$this->stringable('123'), 123];
+        yield [$this->stringable((string) Math\INT16_MAX), Math\INT16_MAX];
+        yield [$this->stringable((string) Math\INT64_MAX), Math\INT64_MAX];
+        yield [(string) Math\INT64_MAX, Math\INT64_MAX];
+        yield [Math\INT64_MAX, Math\INT64_MAX];
+        yield [$this->stringable('-321'), -321];
+        yield ['-321', -321];
+        yield [-321, -321];
+        yield ['7', 7];
+        yield ['07', 7];
+        yield ['007', 7];
+        yield ['000', 0];
+        yield ['0', 0];
+        yield ['123', 123];
+        yield [$this->stringable('123'), 123];
+        yield ['1e2', 1e2];
+        yield [$this->stringable('1e2'), 1e2];
+        yield ['1.23e45', 1.23e45];
+        yield ['.23', .23];
+        yield [$this->stringable('1.23'), 1.23];
+        yield [Math\INT64_MAX, Math\INT64_MAX];
+        yield [(string)Math\INT64_MAX, Math\INT64_MAX];
+        yield [$this->stringable((string)Math\INT64_MAX), Math\INT64_MAX];
+        yield ['9223372036854775808', 9223372036854775808.0];
+        yield ['007', 7];
+        yield ['-0.1', -0.1];
+        yield ['-.5', -.5];
+        yield ['-.9e2', -.9e2];
+        yield ['-0.7e2', -0.7e2];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield ['foo'];
+        yield [null];
+        yield [false];
+        yield [new class() {
+        }];
+        yield [$this->stringable('foo')];
+        yield ['0xFF'];
+        yield ['1a'];
+        yield ['e1'];
+        yield ['1e'];
+        yield ['ee7'];
+        yield ['1e2e1'];
+        yield ['1ee1'];
+        yield ['1,2'];
+        yield ['+1'];
+        yield ['3.'];
+        yield [''];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'num'];
+    }
+}

--- a/tests/Psl/Type/ObjectTypeTest.php
+++ b/tests/Psl/Type/ObjectTypeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Collection;
+use Psl\Collection\ICollection;
+use Psl\Type;
+
+class ObjectTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\object(Collection\ICollection::class);
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [$_ = new Collection\Vector([1, 2]), $_];
+        yield [$_ = new Collection\MutableVector([1, 2]), $_];
+        yield [$_ = new Collection\Map([1 => 'hey', 2 => 'hello']), $_];
+        yield [$_ = new Collection\MutableMap([1 => 'hey', 2 => 'hello']), $_];
+        yield [$_ = $this->createStub(ICollection::class), $_];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [null];
+        yield [STDIN];
+        yield ['hello'];
+        yield [$this->stringable('foo')];
+        yield [new class {
+        }];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [Type\object(Collection\IMap::class), Collection\IMap::class];
+        yield [Type\object(Collection\IVector::class), Collection\IVector::class];
+        yield [Type\object(Collection\Vector::class), Collection\Vector::class];
+        yield [Type\object(Collection\Map::class), Collection\Map::class];
+    }
+}

--- a/tests/Psl/Type/ResourceSpecTest.php
+++ b/tests/Psl/Type/ResourceSpecTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Math;
+use Psl\Type;
+
+class ResourceSpecTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\resource('stream');
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [STDIN, STDIN];
+        yield [STDOUT, STDOUT];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [null];
+        yield ['hello'];
+        yield ['https://void.tn'];
+        yield [__FILE__];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'resource<stream>'];
+        yield [Type\resource('curl'), 'resource<curl>'];
+        yield [Type\resource(), 'resource'];
+    }
+
+    public function testCurlResourceDisallowsStream(): void
+    {
+        $spec = Type\resource('curl');
+
+        $this->expectException(Type\Exception\TypeAssertException::class);
+
+        $spec->assert(STDIN);
+    }
+
+    public function testNoKind(): void
+    {
+        $spec = Type\resource();
+
+        $value = $spec->assert(STDIN);
+        self::assertSame(STDIN, $value);
+
+        $value = $spec->coerce(STDIN);
+        self::assertSame(STDIN, $value);
+    }
+}

--- a/tests/Psl/Type/ResourceTypeTest.php
+++ b/tests/Psl/Type/ResourceTypeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Math;
+use Psl\Type;
+
+class ResourceTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\scalar();
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [123, 123];
+        yield [0, 0];
+        yield ['0', '0'];
+        yield ['123', '123'];
+        yield [$this->stringable('123'), '123'];
+        yield [$this->stringable((string) Math\INT16_MAX), (string) Math\INT16_MAX];
+        yield [$this->stringable((string) Math\INT64_MAX), (string) Math\INT64_MAX];
+        yield [(string) Math\INT64_MAX, (string) Math\INT64_MAX];
+        yield [Math\INT64_MAX, Math\INT64_MAX];
+        yield [$this->stringable('-321'), '-321'];
+        yield ['-321', '-321'];
+        yield [-321, -321];
+        yield ['7', '7'];
+        yield ['07', '07'];
+        yield ['007', '007'];
+        yield ['000', '000'];
+        yield [$this->stringable('123'), '123'];
+        yield ['1e2', '1e2'];
+        yield [$this->stringable('1e2'), '1e2'];
+        yield ['1.23e45', '1.23e45'];
+        yield ['.23', '.23'];
+        yield [$this->stringable('1.23'), '1.23'];
+        yield [(float) Math\INT64_MAX, (float) Math\INT64_MAX];
+        yield ['9223372036854775808', '9223372036854775808'];
+        yield ['-.9e2', '-.9e2'];
+        yield ['-0.7e2', '-0.7e2'];
+        yield [false, false];
+        yield [0, 0];
+        yield [1, 1];
+        yield [true, true];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [null];
+        yield [new class {
+        }];
+        yield [STDIN];
+        yield [[]];
+        yield [(fn () => yield 'hello')()];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'scalar'];
+    }
+}

--- a/tests/Psl/Type/StringTypeTest.php
+++ b/tests/Psl/Type/StringTypeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Type;
+
+class StringTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\string();
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield ['hello', 'hello'];
+        yield [$this->stringable('hello'), 'hello'];
+        yield [123, '123'];
+        yield [0, '0'];
+        yield ['0', '0'];
+        yield ['123', '123'];
+        yield ['1e23', '1e23'];
+        yield [$this->stringable('123'), '123'];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [1.0];
+        yield [1.23];
+        yield [[]];
+        yield [[1]];
+        yield [Type\bool()];
+        yield [null];
+        yield [false];
+        yield [true];
+        yield [STDIN];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'string'];
+    }
+}

--- a/tests/Psl/Type/TypeTest.php
+++ b/tests/Psl/Type/TypeTest.php
@@ -1,0 +1,156 @@
+<?php declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Arr;
+use Psl\Iter;
+use Psl\Type\Exception\TypeAssertException;
+use Psl\Type\Exception\TypeCoercionException;
+use Psl\Type\Type;
+
+/**
+ * @template T
+ */
+abstract class TypeTest extends TestCase
+{
+
+    /**
+     * @psalm-return Type<T>
+     */
+    abstract public function getType(): Type;
+
+    /**
+     * @psalm-return iterable<array{0: mixed, 1: T}>
+     */
+    abstract public function getValidCoercions(): iterable;
+
+    /**
+     * @psalm-return iterable<array{0: mixed}>
+     */
+    abstract public function getInvalidCoercions(): iterable;
+
+    /**
+     * @psalm-return iterable<array{0: Type<mixed>, 1: string}>
+     */
+    abstract public function getToStringExamples(): iterable;
+
+    /**
+     * @psalm-return list<array{0: T}>
+     */
+    public function getValidValues(): array
+    {
+        $non_unique = $this->getValidCoercions();
+        $non_unique = Iter\map($non_unique, fn ($tuple) => $tuple[1]);
+
+        $out = [];
+        foreach ($non_unique as $v) {
+            foreach ($out as $value) {
+                if ($this->equals($value, $v)) {
+                    break;
+                }
+            }
+
+            $out[] = [$v];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @psalm-return list<array{0: mixed}>
+     */
+    public function getInvalidValues(): array
+    {
+        $rows = $this->getInvalidCoercions();
+        $rows = Iter\to_array($rows);
+        foreach ($this->getValidCoercions() as $arr) {
+            [$value, $v] = $arr;
+            if ($this->equals($v, $value)) {
+                continue;
+            }
+
+            $rows[] = [$value];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @psalm-param mixed $value
+     * @psalm-param T     $expected
+     *
+     * @dataProvider getValidCoercions
+     */
+    final public function testValidCoercion($value, $expected): void
+    {
+        $actual = $this->getType()->coerce($value);
+
+        self::assertTrue($this->equals($expected, $actual));
+        self::assertTrue($this->equals($actual, $this->getType()->coerce($actual)));
+    }
+
+    /**
+     * @dataProvider getInvalidCoercions
+     */
+    public function testInvalidCoercion($value): void
+    {
+        $this->expectException(TypeCoercionException::class);
+
+        $this->getType()->coerce($value);
+    }
+
+    /**
+     * @dataProvider getValidValues
+     */
+    final public function testValidAssertion($value): void
+    {
+        $out = $this->getType()->assert($value);
+
+        self::assertTrue($this->equals($out, $value));
+    }
+
+    /**
+     * @dataProvider getInvalidValues
+     */
+    public function testInvalidAssertion($value): void
+    {
+        $this->expectException(TypeAssertException::class);
+
+        $this->getType()->assert($value);
+    }
+
+    /**
+     * @dataProvider getToStringExamples
+     */
+    final public function testToString(Type $ts, string $expected): void
+    {
+        self::assertSame($expected, $ts->toString());
+    }
+
+    /**
+     * @psalm-param T $a
+     * @psalm-param T $b
+     */
+    protected function equals($a, $b): bool
+    {
+        return $a === $b;
+    }
+
+    protected function stringable(string $value): object
+    {
+        return new class($value) {
+            private string $value;
+
+            public function __construct(string $value)
+            {
+                $this->value = $value;
+            }
+
+            public function __toString(): string
+            {
+                return $this->value;
+            }
+        };
+    }
+}

--- a/tests/Psl/Type/UnionTypeTest.php
+++ b/tests/Psl/Type/UnionTypeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Type;
+
+use Psl\Collection\ICollection;
+use Psl\Collection\IIndexAccess;
+use Psl\Type;
+
+class UnionTypeTest extends TypeTest
+{
+    public function getType(): Type\Type
+    {
+        return Type\union(Type\int(), Type\bool());
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [1, 1];
+        yield ['1', 1];
+        yield ['123', 123];
+        yield [true, true];
+        yield [false, false];
+        yield [$this->stringable('123'), 123];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [null];
+        yield [STDIN];
+        yield ['hello'];
+        yield [$this->stringable('foo')];
+        yield [new class {
+        }];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [Type\union(Type\bool(), Type\string()), 'bool|string'];
+        yield [Type\union(Type\bool(), Type\float()), 'bool|float'];
+        yield [Type\union(Type\bool(), Type\union(Type\float(), Type\int())), 'bool|float|int'];
+        yield [Type\union(Type\bool(), Type\num()), 'bool|num'];
+        yield [Type\union(Type\bool(), Type\array_key()), 'bool|array-key'];
+        yield [Type\union(Type\bool(), Type\intersection(Type\object(IIndexAccess::class), Type\object(ICollection::class))), 'bool|(Psl\Collection\IIndexAccess&Psl\Collection\ICollection)'];
+        yield [Type\union(Type\intersection(Type\object(IIndexAccess::class), Type\object(ICollection::class)), Type\bool()), '(Psl\Collection\IIndexAccess&Psl\Collection\ICollection)|bool'];
+    }
+}


### PR DESCRIPTION
closes #42 

```php
<?php

require_once __DIR__ . '/../vendor/autoload.php';

use Psl\Type;
use Psl\Collection;

/** @psalm-var Type<iterable<array<int, array<int|string, string>>, Collection\ICollection&Collection\IIndexAccess> $spec */
$spec = Type\iterable(
    Type\arr(Type\int(), Type\arr(Type\array_key(), Type\string())),
    Type\intersection(
        Type\instance_of(Collection\ICollection::class),
        Type\instance_of(Collection\IIndexAccess::class)
    )
);

/**
 * @var null|iterable<array<int, array<int|string, string>>, Collection\ICollection&Collection\IIndexAccess> $value
 */
$value = Type\nullable($spec)->assert(null);

$value = Type\nullable($spec)->assert((static function () {
    yield [4 => ['bar' => 'baz', 1337 => 'qux']] => new Collection\Map([]);
})());

$value = $spec->assert((static function () {
    yield [4 => ['bar' => 'baz', 1337 => 'qux']] => new Collection\Map([]);
})());

try {
    $value = $spec->assert((static function () {
        yield [4 => ['bar' => 'baz', 1337 => 13]] => new Collection\Vector([]);
    })());
} catch (Type\Exception\TypeAssertException $e) {
    //    Expected "string", got "integer".
    print $e->getMessage();
}

try {
    $value = $spec->assert((static function () {
        yield [4 => ['bar' => 'baz', 1337 => 'f']] => new stdClass();
    })());
} catch (Type\Exception\TypeAssertException $e) {
    //    Expected "Psl\Collection\ICollection&Psl\Collection\IIndexAccess", got "stdClass".
    print $e->getMessage();
}

// iterable<array<int, array<array-key, string>>, Psl\Collection\ICollection&Psl\Collection\IIndexAccess>
print $spec->toString();
```