### PR TITLE
[Iter] split reduce into multiple functions

### DIFF
--- a/src/Psl/Fun/pipe.php
+++ b/src/Psl/Fun/pipe.php
@@ -43,7 +43,7 @@ function pipe(callable ...$stages): callable
          *
          * @psalm-return IO
          */
-        static fn ($input, int $key, callable $next) => $next($input),
+        static fn ($input, callable $next) => $next($input),
         $input
     );
 }

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -143,6 +143,8 @@ final class Loader
         'Psl\Iter\random',
         'Psl\Iter\range',
         'Psl\Iter\reduce',
+        'Psl\Iter\reduce_keys',
+        'Psl\Iter\reduce_with_keys',
         'Psl\Iter\reductions',
         'Psl\Iter\reindex',
         'Psl\Iter\repeat',

--- a/src/Psl/Iter/reduce_keys.php
+++ b/src/Psl/Iter/reduce_keys.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Psl\Iter;
 
 /**
- * Reduce iterable using a function.
+ * Reduce iterable keys using a function.
  *
  * The reduction function is passed an accumulator value and the current
  * iterator value and returns a new accumulator. The accumulator is initialized
@@ -13,27 +13,28 @@ namespace Psl\Iter;
  *
  * Examples:
  *
- *      Iter\reduce(Iter\range(1, 5), fn($accumulator, $value) => $accumulator + $value, 0)
- *      => 15
- *
- *      Iter\reduce(Iter\range(1, 5), fn($accumulator, $value) => $accumulator * $value, 1)
- *      => 120
+ *      Iter\reduce_keys(
+ *          Iter\range(1, 5),
+ *          static fn(int $accumulator, int $key): int => $accumulator + $key,
+ *          0,
+  *     )
+ *      => 10
  *
  * @psalm-template Tk
  * @psalm-template Tv
  * @psalm-template Ts
  *
  * @psalm-param iterable<Tk, Tv>        $iterable
- * @psalm-param (callable(?Ts, Tv): Ts) $function
+ * @psalm-param (callable(?Ts, Tk): Ts) $function
  * @psalm-param Ts|null                 $initial
  *
  * @psalm-return Ts|null
  */
-function reduce(iterable $iterable, callable $function, $initial = null)
+function reduce_keys(iterable $iterable, callable $function, $initial = null)
 {
     $accumulator = $initial;
-    foreach ($iterable as $v) {
-        $accumulator = $function($accumulator, $v);
+    foreach ($iterable as $k => $v) {
+        $accumulator = $function($accumulator, $k);
     }
 
     return $accumulator;

--- a/src/Psl/Iter/reduce_with_keys.php
+++ b/src/Psl/Iter/reduce_with_keys.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Iter;
+
+/**
+ * Reduce iterable with both values and keys using a function.
+ *
+ * The reduction function is passed an accumulator value and the current
+ * iterator value and returns a new accumulator. The accumulator is initialized
+ * to $initial.
+ *
+ * Examples:
+ *
+ *      Iter\reduce_with_keys(
+ *          Iter\range(1, 5),
+ *          static fn(int $accumulator, int $key, int $value): int => $accumulator + $value,
+ *          0,
+  *     )
+ *      => 15
+ *
+ *      Iter\reduce_with_keys(
+ *          Iter\range(1, 5),
+ *          static fn(int $accumulator, int $key, int $value): int => $accumulator * $value,
+ *          0,
+ *     )
+ *      => 120
+ *
+ * @psalm-template Tk
+ * @psalm-template Tv
+ * @psalm-template Ts
+ *
+ * @psalm-param iterable<Tk, Tv>                $iterable
+ * @psalm-param (callable(?Ts, Tk, Tv): Ts)     $function
+ * @psalm-param Ts|null                         $initial
+ *
+ * @psalm-return Ts|null
+ */
+function reduce_with_keys(iterable $iterable, callable $function, $initial = null)
+{
+    $accumulator = $initial;
+    foreach ($iterable as $k => $v) {
+        $accumulator = $function($accumulator, $k, $v);
+    }
+
+    return $accumulator;
+}

--- a/tests/Psl/Iter/ReduceKeysTest.php
+++ b/tests/Psl/Iter/ReduceKeysTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Iter;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Iter;
+
+final class ReduceKeysTest extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function testReduceKeys($expected, iterable $iterable, callable $function, $initial = null): void
+    {
+        self::assertSame($expected, Iter\reduce_keys($iterable, $function, $initial));
+    }
+
+    public function provideData(): iterable
+    {
+        yield [null, [], fn ($accumulator, $k) => $accumulator, null];
+        yield [3, [1, 2, 3], fn ($accumulator, $k) => $accumulator + $k, 0];
+        yield [3, Iter\to_iterator([1, 2, 3]), fn ($accumulator, $k) => $accumulator + $k, 0];
+    }
+}

--- a/tests/Psl/Iter/ReduceTest.php
+++ b/tests/Psl/Iter/ReduceTest.php
@@ -19,8 +19,8 @@ class ReduceTest extends TestCase
 
     public function provideData(): iterable
     {
-        yield [null, [], fn ($accumulator, $k, $v) => $accumulator, null];
-        yield [6, [1, 2, 3], fn ($accumulator, $k, $v) => $accumulator + $v, 0];
-        yield [6, Iter\to_iterator([1, 2, 3]), fn ($accumulator, $k, $v) => $accumulator + $v, 0];
+        yield [null, [], fn ($accumulator, $v) => $accumulator, null];
+        yield [6, [1, 2, 3], fn ($accumulator, $v) => $accumulator + $v, 0];
+        yield [6, Iter\to_iterator([1, 2, 3]), fn ($accumulator, $v) => $accumulator + $v, 0];
     }
 }

--- a/tests/Psl/Iter/ReduceWithKeysTest.php
+++ b/tests/Psl/Iter/ReduceWithKeysTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Iter;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Iter;
+
+class ReduceWithKeysTest extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function testReduceWithKeys($expected, iterable $iterable, callable $function, $initial = null): void
+    {
+        self::assertSame($expected, Iter\reduce_with_keys($iterable, $function, $initial));
+    }
+
+    public function provideData(): iterable
+    {
+        yield [null, [], fn ($accumulator, $k, $v) => $accumulator, null];
+        yield [6, [1, 2, 3], fn ($accumulator, $k, $v) => $accumulator + $v, 0];
+        yield [6, Iter\to_iterator([1, 2, 3]), fn ($accumulator, $k, $v) => $accumulator + $v, 0];
+    }
+}


### PR DESCRIPTION
Fixes #73

- [x] Iter\reduce
- [x] Iter\reduce_keys
- [x] Iter\reduce_with_keys