### PR TITLE
[XML] Basic error handling

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -16,7 +16,7 @@ jobs:
           php-version: "7.4"
           ini-values: memory_limit=-1
           tools: composer:v2, cs2pr
-          extensions: bcmath, mbstring, intl, sodium, json
+          extensions: bcmath, mbstring, intl, sodium, json, libxml, simplexml
 
       - name: "installing dependencies"
         run: "composer update --no-interaction --no-progress"

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -16,7 +16,7 @@ jobs:
           php-version: "7.4"
           ini-values: memory_limit=-1
           tools: composer:v2, cs2pr
-          extensions: bcmath, mbstring, intl, sodium, json
+          extensions: bcmath, mbstring, intl, sodium, json, libxml, simplexml
 
       - name: "installing dependencies"
         run: "composer update --no-interaction --no-progress"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,7 +16,7 @@ jobs:
           php-version: "7.4"
           ini-values: memory_limit=-1
           tools: composer:v2, cs2pr
-          extensions: bcmath, mbstring, intl, sodium, json
+          extensions: bcmath, mbstring, intl, sodium, json, libxml, simplexml
 
       - name: "installing dependencies"
         run: "composer update --no-interaction --no-progress"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,7 +28,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           ini-values: memory_limit=-1
           tools: composer:v2, cs2pr
-          extensions: bcmath, mbstring, intl, sodium, json
+          extensions: bcmath, mbstring, intl, sodium, json, libxml, simplexml
 
       - name: "caching dependencies"
         uses: "actions/cache@v2"

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,12 @@
         "php": "^7.4 | ^8.0",
         "ext-bcmath": "*",
         "ext-json": "*",
+        "ext-libxml": "*",
         "ext-mbstring": "*",
         "ext-sodium": "*"
     },
     "require-dev": {
+        "ext-simplexml": "*",
         "phpunit/phpunit": "^9.0",
         "php-coveralls/php-coveralls": "^2.2",
         "friendsofphp/php-cs-fixer": "^2.16",

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -336,6 +336,10 @@ final class Loader
         'Psl\Hash\equals',
         'Psl\Hash\Hmac\hash',
         'Psl\Hash\Hmac\algorithms',
+        'Psl\Xml\Internal\detect_errors',
+        'Psl\Xml\Internal\issue_collection_from_xml_errors',
+        'Psl\Xml\Internal\issue_from_xml_error',
+        'Psl\Xml\Internal\issue_level_from_xml_error',
     ];
 
     public const INTERFACES = [
@@ -353,6 +357,7 @@ final class Loader
         'Psl\Observer\SubjectInterface',
         'Psl\Observer\ObserverInterface',
         'Psl\Result\ResultInterface',
+        'Psl\Xml\Exception\ExceptionInterface',
     ];
 
     public const TRAITS = [
@@ -393,6 +398,10 @@ final class Loader
         'Psl\Json\Exception\DecodeException',
         'Psl\Json\Exception\EncodeException',
         'Psl\Hash\Context',
+        'Psl\Xml\Issue\Issue',
+        'Psl\Xml\Issue\IssueCollection',
+        'Psl\Xml\Issue\Level',
+        'Psl\Xml\Exception\XmlException',
     ];
 
     private const TYPE_CONSTANTS = 1;

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -401,7 +401,7 @@ final class Loader
         'Psl\Xml\Issue\Issue',
         'Psl\Xml\Issue\IssueCollection',
         'Psl\Xml\Issue\Level',
-        'Psl\Xml\Exception\XmlException',
+        'Psl\Xml\Exception\RuntimeException',
     ];
 
     private const TYPE_CONSTANTS = 1;

--- a/src/Psl/Xml/Exception/ExceptionInterface.php
+++ b/src/Psl/Xml/Exception/ExceptionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Xml\Exception;
+
+use Psl\Exception\ExceptionInterface as PslExceptionInterface;
+
+interface ExceptionInterface extends PslExceptionInterface
+{
+}

--- a/src/Psl/Xml/Exception/RuntimeException.php
+++ b/src/Psl/Xml/Exception/RuntimeException.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Psl\Xml\Exception;
 
 use Exception;
-use Psl\Exception\RuntimeException;
+use Psl\Exception\RuntimeException as PslRuntimeException;
 use Psl\Xml\Issue\IssueCollection;
 
-class XmlException extends RuntimeException implements ExceptionInterface
+final class RuntimeException extends PslRuntimeException implements ExceptionInterface
 {
     private function __construct(string $message, Exception $previous = null)
     {

--- a/src/Psl/Xml/Exception/XmlException.php
+++ b/src/Psl/Xml/Exception/XmlException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Xml\Exception;
+
+use Exception;
+use Psl\Exception\RuntimeException;
+use Psl\Xml\Issue\IssueCollection;
+
+class XmlException extends RuntimeException implements ExceptionInterface
+{
+    private function __construct(string $message, Exception $previous = null)
+    {
+        parent::__construct(
+            $message,
+            (int) ($previous ? $previous->getCode() : 0),
+            $previous
+        );
+    }
+
+    public static function combineExceptionWithIssues(Exception $exception, IssueCollection $errors): self
+    {
+        return new self(
+            $exception->getMessage() . PHP_EOL . $errors->toString(),
+            $exception
+        );
+    }
+}

--- a/src/Psl/Xml/Internal/detect_errors.php
+++ b/src/Psl/Xml/Internal/detect_errors.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Xml\Internal;
+
+use LibXMLError;
+use Psl\Exception\InvariantViolationException;
+use Psl\Result;
+use Psl\Result\ResultInterface;
+use Psl\Xml\Issue\IssueCollection;
+
+use function libxml_clear_errors;
+use function libxml_get_errors;
+use function libxml_use_internal_errors;
+
+/**
+ * You can wrap this detector around a function that interacts with xml, dom, simplexml, ...
+ * It wil return a result that contains the result or an exception if an error was encountered.
+ * Besides the result, you will receive a list of XML errors.
+ * No XML warnings will be displayed in the meantime.
+ *
+ * @internal
+ *
+ * @template Tr
+ *
+ * @psalm-param callable(): Tr $run
+ * @psalm-return array{ResultInterface<Tr>, IssueCollection}
+ *
+ * @throws InvariantViolationException
+ */
+function detect_errors(callable $run): array
+{
+    $previousErrorReporting = libxml_use_internal_errors(true);
+    libxml_clear_errors();
+
+    $result = Result\wrap($run);
+
+    /** @var list<LibXMLError> $errors */
+    $errors = libxml_get_errors();
+    libxml_clear_errors();
+    libxml_use_internal_errors($previousErrorReporting);
+
+    return [$result, issue_collection_from_xml_errors($errors)];
+}

--- a/src/Psl/Xml/Internal/issue_collection_from_xml_errors.php
+++ b/src/Psl/Xml/Internal/issue_collection_from_xml_errors.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Xml\Internal;
+
+use LibXMLError;
+use Psl\Arr;
+use Psl\Xml\Issue\Issue;
+use Psl\Xml\Issue\IssueCollection;
+
+/**
+ * @internal
+ *
+ * @psalm-param list<LibXMLError> $errors
+ */
+function issue_collection_from_xml_errors(array $errors): IssueCollection
+{
+    return new IssueCollection(
+        ...Arr\filter_nulls(Arr\map(
+            $errors,
+            static fn(LibXMLError $error): ?Issue => issue_from_xml_error($error)
+        ))
+    );
+}

--- a/src/Psl/Xml/Internal/issue_from_xml_error.php
+++ b/src/Psl/Xml/Internal/issue_from_xml_error.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Xml\Internal;
+
+use LibXMLError;
+use Psl\Xml\Issue\Issue;
+
+/**
+ * @internal
+ */
+function issue_from_xml_error(LibXMLError $error): ?Issue
+{
+    $level = issue_level_from_xml_error($error);
+    if ($level === null) {
+        return null;
+    }
+
+    return new Issue(
+        $level,
+        $error->code,
+        $error->column,
+        $error->message,
+        $error->file,
+        $error->line,
+    );
+}

--- a/src/Psl/Xml/Internal/issue_level_from_xml_error.php
+++ b/src/Psl/Xml/Internal/issue_level_from_xml_error.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Xml\Internal;
+
+use LibXMLError;
+use Psl\Xml\Issue\Level;
+
+/**
+ * @internal
+ */
+function issue_level_from_xml_error(LibXMLError $error): ?Level
+{
+    switch ($error->level) {
+        case LIBXML_ERR_ERROR:
+            return Level::error();
+        case LIBXML_ERR_FATAL:
+            return Level::fatal();
+        case LIBXML_ERR_WARNING:
+            return Level::warning();
+    }
+
+    return null;
+}

--- a/src/Psl/Xml/Issue/Issue.php
+++ b/src/Psl/Xml/Issue/Issue.php
@@ -6,6 +6,9 @@ namespace Psl\Xml\Issue;
 
 use Psl\Str;
 
+/**
+ * @psam-immutable
+ */
 final class Issue
 {
     private Level $level;

--- a/src/Psl/Xml/Issue/Issue.php
+++ b/src/Psl/Xml/Issue/Issue.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Xml\Issue;
+
+use Psl\Str;
+
+final class Issue
+{
+    private Level $level;
+    private int $code;
+    private int $column;
+    private string $message;
+    private string $file;
+    private int $line;
+
+    public function __construct(
+        Level $level,
+        int $code,
+        int $column,
+        string $message,
+        string $file,
+        int $line
+    ) {
+        $this->level = $level;
+        $this->code = $code;
+        $this->column = $column;
+        $this->message = $message;
+        $this->file = $file;
+        $this->line = $line;
+    }
+
+    public function level(): Level
+    {
+        return $this->level;
+    }
+
+    public function code(): int
+    {
+        return $this->code;
+    }
+
+    public function column(): int
+    {
+        return $this->column;
+    }
+
+    public function message(): string
+    {
+        return $this->message;
+    }
+
+    public function file(): string
+    {
+        return $this->file;
+    }
+
+    public function line(): int
+    {
+        return $this->line;
+    }
+
+    /**
+     * @psalm-suppress MissingThrowsDocblock
+     */
+    public function toString(): string
+    {
+        return Str\format(
+            '[%s] %s: %s (%s) on line %s,%s',
+            Str\uppercase($this->level->toString()),
+            $this->file,
+            $this->message,
+            $this->code,
+            $this->line,
+            $this->column
+        );
+    }
+}

--- a/src/Psl/Xml/Issue/IssueCollection.php
+++ b/src/Psl/Xml/Issue/IssueCollection.php
@@ -11,6 +11,11 @@ use Psl\Iter\Iterator;
 use Psl\Math;
 use Psl\Str;
 
+/**
+ * @template-implements IteratorAggregate<int, Issue>
+ *
+ * @psalm-immutable
+ */
 final class IssueCollection implements Countable, IteratorAggregate
 {
     /**

--- a/src/Psl/Xml/Issue/IssueCollection.php
+++ b/src/Psl/Xml/Issue/IssueCollection.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Xml\Issue;
+
+use Countable;
+use IteratorAggregate;
+use Psl\Arr;
+use Psl\Iter\Iterator;
+use Psl\Math;
+use Psl\Str;
+
+final class IssueCollection implements Countable, IteratorAggregate
+{
+    /**
+     * @var list<Issue>
+     */
+    private array $issues;
+
+    public function __construct(Issue ...$errors)
+    {
+        $this->issues = $errors;
+    }
+
+    /**
+     * @return Iterator<int, Issue>
+     */
+    public function getIterator(): Iterator
+    {
+        return Iterator::create($this->issues);
+    }
+
+    public function count(): int
+    {
+        return count($this->issues);
+    }
+
+    /**
+     * @param (callable(Issue): bool) $filter
+     */
+    public function filter(callable $filter): self
+    {
+        return new self(...Arr\filter($this->issues, $filter));
+    }
+
+    public function getHighestLevel(): ?Level
+    {
+        $issue = Math\max_by($this->issues, static fn(Issue $issue): int => $issue->level()->value());
+
+        return $issue ? $issue->level() : null;
+    }
+
+    public function toString(): string
+    {
+        $values = Arr\values(Arr\map($this->issues, static fn (Issue $error): string => $error->toString()));
+
+        return Str\join($values, PHP_EOL);
+    }
+}

--- a/src/Psl/Xml/Issue/Level.php
+++ b/src/Psl/Xml/Issue/Level.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Xml\Issue;
+
+/**
+ * @psalm-immutable
+ */
+final class Level
+{
+    private const LEVEL_WARNING = 1;
+    private const LEVEL_ERROR = 2;
+    private const LEVEL_FATAL = 3;
+
+    private int $value;
+
+    private function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function error(): self
+    {
+        return new self(self::LEVEL_ERROR);
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function fatal(): self
+    {
+        return new self(self::LEVEL_FATAL);
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function warning(): self
+    {
+        return new self(self::LEVEL_WARNING);
+    }
+
+    public function value(): int
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return 'warning'|'fatal'|'error'
+     */
+    public function toString(): string
+    {
+        if ($this->isWarning()) {
+            return 'warning';
+        }
+
+        if ($this->isError()) {
+            return 'error';
+        }
+
+        return 'fatal';
+    }
+
+    public function matches(Level $level): bool
+    {
+        return $level->value() === $this->value;
+    }
+
+    public function isError(): bool
+    {
+        return $this->matches(self::error());
+    }
+
+    public function isFatal(): bool
+    {
+        return $this->matches(self::fatal());
+    }
+
+    public function isWarning(): bool
+    {
+        return $this->matches(self::warning());
+    }
+}

--- a/tests/Psl/Xml/Exception/XmlExceptionTest.php
+++ b/tests/Psl/Xml/Exception/XmlExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Xml\Exception;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Psl\Tests\Xml\Issue\UseIssueTrait;
+use Psl\Xml\Exception\ExceptionInterface;
+use Psl\Xml\Exception\XmlException;
+use Psl\Xml\Issue\IssueCollection;
+use Psl\Xml\Issue\Level;
+
+final class XmlExceptionTest extends TestCase
+{
+    use UseIssueTrait;
+
+    public function testItCanThrowAnExceptionContainingXmlErrors(): void
+    {
+        $exception = new Exception('nonono');
+        $issues = new IssueCollection(
+            $this->createIssue(Level::fatal()),
+            $this->createIssue(Level::warning())
+        );
+
+        $this->expectException(XmlException::class);
+        $this->expectException(ExceptionInterface::class);
+        $this->expectExceptionMessage($exception->getMessage() . PHP_EOL . $issues->toString());
+
+        throw XmlException::combineExceptionWithIssues($exception, $issues);
+    }
+}

--- a/tests/Psl/Xml/Exception/XmlExceptionTest.php
+++ b/tests/Psl/Xml/Exception/XmlExceptionTest.php
@@ -8,11 +8,11 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 use Psl\Tests\Xml\Issue\UseIssueTrait;
 use Psl\Xml\Exception\ExceptionInterface;
-use Psl\Xml\Exception\XmlException;
+use Psl\Xml\Exception\RuntimeException;
 use Psl\Xml\Issue\IssueCollection;
 use Psl\Xml\Issue\Level;
 
-final class XmlExceptionTest extends TestCase
+final class RuntimeExceptionTest extends TestCase
 {
     use UseIssueTrait;
 
@@ -21,13 +21,13 @@ final class XmlExceptionTest extends TestCase
         $exception = new Exception('nonono');
         $issues = new IssueCollection(
             $this->createIssue(Level::fatal()),
-            $this->createIssue(Level::warning())
+            $this->createIssue(Level::warning()),
         );
 
-        $this->expectException(XmlException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectException(ExceptionInterface::class);
         $this->expectExceptionMessage($exception->getMessage() . PHP_EOL . $issues->toString());
 
-        throw XmlException::combineExceptionWithIssues($exception, $issues);
+        throw RuntimeException::combineExceptionWithIssues($exception, $issues);
     }
 }

--- a/tests/Psl/Xml/Internal/DetectErrorsTest.php
+++ b/tests/Psl/Xml/Internal/DetectErrorsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Xml\Internal;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Psl\Xml\Internal;
+
+use function libxml_use_internal_errors;
+use function simplexml_load_string;
+
+final class DetectErrorsTest extends TestCase
+{
+    public function testItCanContinueWhenNoErrorsAreDetects(): void
+    {
+        [$result, $errors] = Internal\detect_errors(
+            static function (): string {
+                self::assertTrue(libxml_use_internal_errors());
+
+                return 'ok';
+            }
+        );
+
+        static::assertTrue($result->isSucceeded());
+        static::assertSame('ok', $result->getResult());
+        static::assertCount(0, $errors);
+    }
+
+    public function testItCanDetectXmlErrorsInsideCallableAndReturnOk(): void
+    {
+        [$result, $errors] = Internal\detect_errors(
+            static function (): string {
+                simplexml_load_string('<notvalidxml');
+
+                return 'ok';
+            }
+        );
+
+        static::assertTrue($result->isSucceeded());
+        static::assertSame('ok', $result->getResult());
+        static::assertCount(1, $errors);
+    }
+
+    public function testItCanDetectXmlErrorsInsideCallableAndReturnAFailure(): void
+    {
+        $exception = new Exception('nonono');
+        [$result, $errors] = Internal\detect_errors(
+            static function () use ($exception) {
+                simplexml_load_string('<notvalidxml');
+
+                throw $exception;
+            }
+        );
+
+        static::assertTrue($result->isFailed());
+        static::assertSame($exception, $result->getException());
+        static::assertCount(1, $errors);
+    }
+
+    public function testItDoesNotUsePreviouslyOccuredExceptions(): void
+    {
+        libxml_use_internal_errors(true);
+        simplexml_load_string('<notvalidxml');
+
+        [$result, $errors] = Internal\detect_errors(
+            static function (): string {
+                simplexml_load_string('<notvalidxml');
+
+                return 'ok';
+            }
+        );
+
+        static::assertTrue($result->isSucceeded());
+        static::assertSame('ok', $result->getResult());
+        static::assertCount(1, $errors);
+    }
+
+    public function testItCanUseInternalXmlErrorsDuringAFunctionCall(): void
+    {
+        libxml_use_internal_errors(false);
+
+        [$result, $errors] = Internal\detect_errors(
+            static function () {
+                self::assertTrue(libxml_use_internal_errors());
+
+                return 'ok';
+            }
+        );
+
+        static::assertFalse(libxml_use_internal_errors());
+        static::assertTrue($result->isSucceeded());
+        static::assertSame('ok', $result->getResult());
+        static::assertCount(0, $errors);
+    }
+}

--- a/tests/Psl/Xml/Internal/IssueCollectionFromXmlErrorsTest.php
+++ b/tests/Psl/Xml/Internal/IssueCollectionFromXmlErrorsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Xml\Internal;
+
+use LibXMLError;
+use PHPUnit\Framework\TestCase;
+use Psl\Xml\Issue\Level;
+
+use function Psl\Xml\Internal\issue_collection_from_xml_errors;
+
+class IssueCollectionFromXmlErrorsTest extends TestCase
+{
+    public function testItCanConstructIssueCollectionFromLibXmlErrors(): void
+    {
+        $errors = [
+            $error1 = $this->createError(LIBXML_ERR_WARNING),
+            $error2 = $this->createError(LIBXML_ERR_FATAL),
+            $error3 = $this->createError(90000),
+        ];
+
+        $issues = issue_collection_from_xml_errors($errors);
+        $extracted = [...$issues];
+
+        static::assertCount(2, $issues);
+        static::assertTrue($extracted[0]->level()->matches(Level::warning()));
+        static::assertTrue($extracted[1]->level()->matches(Level::fatal()));
+    }
+
+    private function createError(int $level): LibXMLError
+    {
+        $error = new LibXMLError();
+        $error->level   = $level;
+        $error->file     = 'file.xml';
+        $error->message = 'message';
+        $error->line    = 99;
+        $error->code    = 1;
+        $error->column  = 10;
+
+        return $error;
+    }
+}

--- a/tests/Psl/Xml/Internal/IssueFromXmlErrorTest.php
+++ b/tests/Psl/Xml/Internal/IssueFromXmlErrorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Xml\Internal;
+
+use LibXMLError;
+use PHPUnit\Framework\TestCase;
+use Psl\Xml\Issue\Level;
+
+use function Psl\Xml\Internal\issue_from_xml_error;
+
+class IssueFromXmlErrorTest extends TestCase
+{
+    public function testItCanConstructIssueFromLibXmlError(): void
+    {
+        $error = new LibXMLError();
+        $error->level   = Level::error()->value();
+        $error->file     = 'file.xml';
+        $error->message = 'message';
+        $error->line    = 99;
+        $error->code    = 1;
+        $error->column  = 10;
+
+        $issue = issue_from_xml_error($error);
+
+        static::assertSame($error->level, $issue->level()->value());
+        static::assertSame($error->file, $issue->file());
+        static::assertSame($error->message, $issue->message());
+        static::assertSame($error->line, $issue->line());
+        static::assertSame($error->code, $issue->code());
+        static::assertSame($error->column, $issue->column());
+    }
+
+    public function testItReturnsNullOnInvalidLevel(): void
+    {
+        $error = new LibXMLError();
+        $error->level = 9000;
+        $issue = issue_from_xml_error($error);
+
+        static::assertNull($issue);
+    }
+}

--- a/tests/Psl/Xml/Internal/IssueLevelFromXmlErrorTest.php
+++ b/tests/Psl/Xml/Internal/IssueLevelFromXmlErrorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Xml\Internal;
+
+use LibXMLError;
+use PHPUnit\Framework\TestCase;
+use Psl\Xml\Issue\Level;
+
+use function Psl\Xml\Internal\issue_level_from_xml_error;
+
+class IssueLevelFromXmlErrorTest extends TestCase
+{
+    /**
+     * @dataProvider provideErrors
+     */
+    public function testItCanConstructLevelFromLibXmlError(int $code, ?Level $expected): void
+    {
+        $error = new LibXMLError();
+        $error->level = $code;
+
+        $actual = issue_level_from_xml_error($error);
+        if (!$expected) {
+            static::assertNull($actual);
+            return;
+        }
+
+        static::assertTrue($expected->matches($actual));
+    }
+
+    public function provideErrors()
+    {
+        yield 'error' => [
+            LIBXML_ERR_ERROR,
+            Level::error()
+        ];
+        yield 'fatal' => [
+            LIBXML_ERR_FATAL,
+            Level::fatal()
+        ];
+        yield 'warning' => [
+            LIBXML_ERR_WARNING,
+            Level::warning()
+        ];
+        yield 'unknown' => [
+            90000,
+            null
+        ];
+    }
+}

--- a/tests/Psl/Xml/Issue/IssueCollectionTest.php
+++ b/tests/Psl/Xml/Issue/IssueCollectionTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Xml\Issue;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Xml\Issue\Issue;
+use Psl\Xml\Issue\IssueCollection;
+use Psl\Xml\Issue\Level;
+
+class IssueCollectionTest extends TestCase
+{
+    use UseIssueTrait;
+
+    public function testItActsAsAnIterator(): void
+    {
+        $issues = new IssueCollection(
+            $issue1 = $this->createIssue(Level::warning()),
+            $issue2 = $this->createIssue(Level::fatal()),
+        );
+
+        static::assertCount(2, $issues);
+        static::assertSame([$issue1, $issue2], [...$issues]);
+    }
+
+    public function testItCanConvertToString(): void
+    {
+        $issues = new IssueCollection(
+            $issue1 = $this->createIssue(Level::warning()),
+            $issue2 = $this->createIssue(Level::fatal()),
+        );
+
+        $expected = implode(PHP_EOL, [
+            '[WARNING] file.xml: message (1) on line 99,10',
+            '[FATAL] file.xml: message (1) on line 99,10',
+        ]);
+
+        static::assertSame($expected, $issues->toString());
+    }
+
+    public function testItCanFilter(): void
+    {
+        $issues = new IssueCollection(
+            $issue1 = $this->createIssue(Level::warning()),
+            $issue2 = $this->createIssue(Level::fatal()),
+        );
+        $filtered = $issues->filter(static fn (Issue $issue): bool => !$issue->level()->isWarning());
+
+        static::assertNotSame($issues, $filtered);
+        static::assertCount(1, $filtered);
+        static::assertSame([$issue2], [...$filtered]);
+    }
+
+    public function testItCanDetectTheHighestLevel(): void
+    {
+        $issues = new IssueCollection(
+            $issue1 = $this->createIssue(Level::warning()),
+            $issue2 = $this->createIssue(Level::fatal()),
+        );
+
+        static::assertTrue($issues->getHighestLevel()->isFatal());
+    }
+
+    public function testItCanDetectTheHighestLevelOnAnEmptyCollection(): void
+    {
+        $issues = new IssueCollection();
+
+        static::assertNull($issues->getHighestLevel());
+    }
+}

--- a/tests/Psl/Xml/Issue/IssueTest.php
+++ b/tests/Psl/Xml/Issue/IssueTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Xml\Issue;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Xml\Issue\Level;
+
+class IssueTest extends TestCase
+{
+    use UseIssueTrait;
+
+    public function testItHasLoadsOfAccessors(): void
+    {
+        $error = $this->createIssue(Level::warning());
+
+        static::assertTrue($error->level()->isWarning());
+        static::assertSame('file.xml', $error->file());
+        static::assertSame('message', $error->message());
+        static::assertSame(99, $error->line());
+        static::assertSame(1, $error->code());
+        static::assertSame(10, $error->column());
+        static::assertSame('[WARNING] file.xml: message (1) on line 99,10', $error->toString());
+    }
+}

--- a/tests/Psl/Xml/Issue/LevelTest.php
+++ b/tests/Psl/Xml/Issue/LevelTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Test\Xml\Issue;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Tests\Xml\Issue\UseIssueTrait;
+use Psl\Xml\Issue\Level;
+
+class LevelTest extends TestCase
+{
+    use UseIssueTrait;
+
+    public function testItCanBeError()
+    {
+        $level = Level::error();
+
+        static::assertTrue($level->matches(Level::error()));
+        static::assertTrue($level->isError());
+        static::assertSame(LIBXML_ERR_ERROR, $level->value());
+        static::assertSame('error', $level->toString());
+
+        static::assertFalse($level->isFatal());
+        static::assertFalse($level->isWarning());
+    }
+
+    public function testItCanBeFatal()
+    {
+        $level = Level::fatal();
+
+        static::assertTrue($level->matches(Level::fatal()));
+        static::assertTrue($level->isFatal());
+        static::assertSame(LIBXML_ERR_FATAL, $level->value());
+        static::assertSame('fatal', $level->toString());
+
+        static::assertFalse($level->isError());
+        static::assertFalse($level->isWarning());
+    }
+
+    public function testItCanBeWarning()
+    {
+        $level = Level::warning();
+
+        static::assertTrue($level->matches(Level::warning()));
+        static::assertTrue($level->isWarning());
+        static::assertSame(LIBXML_ERR_WARNING, $level->value());
+        static::assertSame('warning', $level->toString());
+
+        static::assertFalse($level->isError());
+        static::assertFalse($level->isFatal());
+    }
+}

--- a/tests/Psl/Xml/Issue/UseIssueTrait.php
+++ b/tests/Psl/Xml/Issue/UseIssueTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Xml\Issue;
+
+use Psl\Xml\Issue\Issue;
+use Psl\Xml\Issue\Level;
+
+trait UseIssueTrait
+{
+    private function createIssue(Level $level): Issue
+    {
+        return new Issue(
+            $level,
+            $code    = 1,
+            $column  = 10,
+            $message = 'message',
+            $file     = 'file.xml',
+            $line    = 99
+        );
+    }
+}


### PR DESCRIPTION
This PR provides some functions to safely handle libxml errors whilst using dom, simplexml, xmlreader, ...
It can be used inside for building an XML component (#60)
