### PR TITLE
[Iter] Improve reduce signature

### DIFF
--- a/src/Psl/Iter/reduce.php
+++ b/src/Psl/Iter/reduce.php
@@ -24,12 +24,12 @@ namespace Psl\Iter;
  * @psalm-template Ts
  *
  * @psalm-param iterable<Tk, Tv>        $iterable
- * @psalm-param (callable(?Ts, Tv): Ts) $function
- * @psalm-param Ts|null                 $initial
+ * @psalm-param (callable(Ts, Tv): Ts)  $function
+ * @psalm-param Ts                      $initial
  *
- * @psalm-return Ts|null
+ * @psalm-return Ts
  */
-function reduce(iterable $iterable, callable $function, $initial = null)
+function reduce(iterable $iterable, callable $function, $initial)
 {
     $accumulator = $initial;
     foreach ($iterable as $v) {


### PR DESCRIPTION
I think it is safer to drop the initial value for reduce:

https://psalm.dev/r/a86386e5cc

I almost never use null for it and it messes up the types. By making it explicit, you can still pass null and the types are respected.
