### PR TITLE
[Result] don't wrap results on success.

### DIFF
--- a/src/Psl/Result/wrap.php
+++ b/src/Psl/Result/wrap.php
@@ -12,7 +12,7 @@ use Exception;
  *
  * @template     T
  *
- * @psalm-param  (callable(): T) $fun
+ * @psalm-param  (callable(): (T|ResultInterface<T>)) $fun
  *
  * @psalm-return ResultInterface<T>
  */
@@ -20,7 +20,7 @@ function wrap(callable $fun): ResultInterface
 {
     try {
         $result = $fun();
-        return new Success($result);
+        return $result instanceof ResultInterface ? $result : new Success($result);
     } catch (Exception $e) {
         return new Failure($e);
     }

--- a/tests/Psl/Result/WrapTest.php
+++ b/tests/Psl/Result/WrapTest.php
@@ -40,4 +40,14 @@ final class WrapTest extends TestCase
 
         $wrapper->getException();
     }
+
+    public function testWrapOtherResult(): void
+    {
+        $wrapper = Result\wrap(static function (): Result\ResultInterface {
+            return new Result\Success('foo');
+        });
+        static::assertTrue($wrapper->isSucceeded());
+        static::assertFalse($wrapper->isFailed());
+        static::assertSame('foo', $wrapper->getResult());
+    }
 }


### PR DESCRIPTION
This PR makes sure that a ResultInterface isn't wrapped in another ResultInterface. 
Similar to how promises work:


```php
wrap(
    static fn() => new Success('ok')
)->then(
    static fn (string $ok) => new Failure(ItsNotOk::really()),
    static fn (Exception $e) => new Success('ok')
);
```

This gives you the benifit of wrapping a function that already produces a result.
