### PR TITLE
[Iter] Make reducers consistent

### DIFF
--- a/src/Psl/Iter/reduce_keys.php
+++ b/src/Psl/Iter/reduce_keys.php
@@ -24,13 +24,13 @@ namespace Psl\Iter;
  * @psalm-template Tv
  * @psalm-template Ts
  *
- * @psalm-param iterable<Tk, Tv>        $iterable
- * @psalm-param (callable(?Ts, Tk): Ts) $function
- * @psalm-param Ts|null                 $initial
+ * @psalm-param iterable<Tk, Tv>       $iterable
+ * @psalm-param (callable(Ts, Tk): Ts) $function
+ * @psalm-param Ts                     $initial
  *
- * @psalm-return Ts|null
+ * @psalm-return Ts
  */
-function reduce_keys(iterable $iterable, callable $function, $initial = null)
+function reduce_keys(iterable $iterable, callable $function, $initial)
 {
     $accumulator = $initial;
     foreach ($iterable as $k => $v) {

--- a/src/Psl/Iter/reduce_with_keys.php
+++ b/src/Psl/Iter/reduce_with_keys.php
@@ -31,13 +31,13 @@ namespace Psl\Iter;
  * @psalm-template Tv
  * @psalm-template Ts
  *
- * @psalm-param iterable<Tk, Tv>                $iterable
- * @psalm-param (callable(?Ts, Tk, Tv): Ts)     $function
- * @psalm-param Ts|null                         $initial
+ * @psalm-param iterable<Tk, Tv>           $iterable
+ * @psalm-param (callable(Ts, Tk, Tv): Ts) $function
+ * @psalm-param Ts                         $initial
  *
- * @psalm-return Ts|null
+ * @psalm-return Ts
  */
-function reduce_with_keys(iterable $iterable, callable $function, $initial = null)
+function reduce_with_keys(iterable $iterable, callable $function, $initial)
 {
     $accumulator = $initial;
     foreach ($iterable as $k => $v) {


### PR DESCRIPTION
Whilst using the `reduce_with_keys` function, I noticed it has a different signature then the regular `reduce` function.
I removed the default null value to make it consistent with the changes from #98.