### PR TITLE
[Regex] Introduce Regex component

### DIFF
--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -136,6 +136,7 @@ final class Loader
         'Psl\Fun\when',
         'Psl\Internal\boolean',
         'Psl\Internal\type',
+        'Psl\Internal\suppress',
         'Psl\Internal\validate_offset',
         'Psl\Internal\validate_offset_lower_bound',
         'Psl\Internal\internal_encoding',
@@ -244,6 +245,12 @@ final class Loader
         'Psl\Math\tan',
         'Psl\Math\to_base',
         'Psl\Result\wrap',
+        'Psl\Regex\split',
+        'Psl\Regex\matches',
+        'Psl\Regex\replace',
+        'Psl\Regex\replace_every',
+        'Psl\Regex\Internal\get_prec_error',
+        'Psl\Regex\Internal\call_preg',
         'Psl\SecureRandom\bytes',
         'Psl\SecureRandom\float',
         'Psl\SecureRandom\int',
@@ -464,6 +471,8 @@ final class Loader
         'Psl\Result\ResultInterface',
         'Psl\Encoding\Exception\ExceptionInterface',
         'Psl\Type\TypeInterface',
+        'Psl\Type\Exception\ExceptionInterface',
+        'Psl\Regex\Exception\ExceptionInterface',
     ];
 
     public const TRAITS = [];
@@ -511,6 +520,7 @@ final class Loader
         'Psl\Hash\Context',
         'Psl\Encoding\Exception\IncorrectPaddingException',
         'Psl\Encoding\Exception\RangeException',
+        'Psl\Regex\Exception\InvalidPatternException',
     ];
 
     private const TYPE_CONSTANTS = 1;

--- a/src/Psl/Internal/suppress.php
+++ b/src/Psl/Internal/suppress.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Internal;
+
+use function error_reporting;
+
+/**
+ * @psalm-template T
+ *
+ * @psalm-param (pure-callable(): T) $fun
+ *
+ * @psalm-return T
+ *
+ * @psalm-pure
+ *
+ * @internal
+ */
+function suppress(callable $fun)
+{
+    /** @psalm-suppress ImpureFunctionCall */
+    $previous_level = error_reporting(0);
+
+    try {
+        return $fun();
+    } finally {
+        /** @psalm-suppress ImpureFunctionCall */
+        error_reporting($previous_level);
+    }
+}

--- a/src/Psl/Regex/Exception/ExceptionInterface.php
+++ b/src/Psl/Regex/Exception/ExceptionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Regex\Exception;
+
+use Psl\Exception;
+
+interface ExceptionInterface extends Exception\ExceptionInterface
+{
+}

--- a/src/Psl/Regex/Exception/InvalidPatternException.php
+++ b/src/Psl/Regex/Exception/InvalidPatternException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Regex\Exception;
+
+use Psl\Exception\InvalidArgumentException;
+
+final class InvalidPatternException extends InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Psl/Regex/Exception/RuntimeException.php
+++ b/src/Psl/Regex/Exception/RuntimeException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Regex\Exception;
+
+use Psl\Exception;
+
+final class RuntimeException extends Exception\RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Psl/Regex/Internal/call_preg.php
+++ b/src/Psl/Regex/Internal/call_preg.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Regex\Internal;
+
+use Psl\Internal;
+use Psl\Regex\Exception;
+
+/**
+ * @template T
+ *
+ * @param non-empty-string      $function
+ * @param (pure-callable(): T)  $callable
+ *
+ * @return T
+ *
+ * @throws Exception\InvalidPatternException
+ * @throws Exception\RuntimeException
+ *
+ * @psalm-pure
+ *
+ * @internal
+ */
+function call_preg(string $function, callable $callable)
+{
+    /** @psalm-suppress ImpureFunctionCall */
+    error_clear_last();
+
+    /**
+     * @psalm-suppress InvalidArgument - callable is not "pure", because keys() and values()
+     *      are conditionally pure, in this context, we know they are.
+     */
+    $result = Internal\suppress($callable);
+    $error = get_prec_error($function);
+    // @codeCoverageIgnoreStart
+    if (null !== $error) {
+        if (null !== $error['pattern_message']) {
+            throw new Exception\InvalidPatternException($error['pattern_message'], $error['code']);
+        }
+
+        throw new Exception\RuntimeException($error['message'], $error['code']);
+    }
+    // @codeCoverageIgnoreEnd
+
+    return $result;
+}

--- a/src/Psl/Regex/Internal/get_prec_error.php
+++ b/src/Psl/Regex/Internal/get_prec_error.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Regex\Internal;
+
+use Psl\Str;
+
+use const PREG_BACKTRACK_LIMIT_ERROR;
+use const PREG_BAD_UTF8_ERROR;
+use const PREG_BAD_UTF8_OFFSET_ERROR;
+use const PREG_INTERNAL_ERROR;
+use const PREG_JIT_STACKLIMIT_ERROR;
+use const PREG_NO_ERROR;
+use const PREG_RECURSION_LIMIT_ERROR;
+
+/**
+ * @psalm-pure
+ *
+ * @return null|array{message: string, code: int, pattern_message: null|string}
+ *
+ * @internal
+ */
+function get_prec_error(string $function): ?array
+{
+    /** @psalm-suppress ImpureFunctionCall */
+    $code = preg_last_error();
+    if ($code === PREG_NO_ERROR) {
+        return null;
+    }
+
+    $messages = [
+        PREG_INTERNAL_ERROR => 'Internal error',
+        PREG_BAD_UTF8_ERROR => 'Malformed UTF-8 characters, possibly incorrectly encoded',
+        PREG_BAD_UTF8_OFFSET_ERROR => 'The offset did not correspond to the beginning of a valid UTF-8 code point',
+        PREG_BACKTRACK_LIMIT_ERROR => 'Backtrack limit exhausted',
+        PREG_RECURSION_LIMIT_ERROR => 'Recursion limit exhausted',
+        PREG_JIT_STACKLIMIT_ERROR => 'JIT stack limit exhausted',
+    ];
+
+    $message = $messages[$code] ?? 'Unknown error';
+    $result = ['message' => $message, 'code' => $code, 'pattern_message' => null];
+
+    /** @psalm-suppress ImpureFunctionCall */
+    $error = error_get_last();
+    /** @psalm-suppress MissingThrowsDocblock */
+    if (null !== $error && Str\starts_with($error['message'], $function)) {
+        /** @psalm-suppress MissingThrowsDocblock */
+        $result['pattern_message'] = Str\strip_prefix($error['message'], Str\format('%s(): ', $function));
+    }
+
+    return $result;
+}

--- a/src/Psl/Regex/matches.php
+++ b/src/Psl/Regex/matches.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Regex;
+
+use function preg_match;
+
+/**
+ * Determine if $subject matches the given $pattern.
+ *
+ * @param non-empty-string  $pattern    The pattern to match against.
+ *
+ * @throws Exception\InvalidPatternException If $pattern is invalid.
+ * @throws Exception\RuntimeException        If an internal error accord.
+ *
+ * @psalm-pure
+ */
+function matches(string $subject, string $pattern, int $offset = 0): bool
+{
+    $_ = [];
+    $result = Internal\call_preg(
+        'preg_match',
+        static fn() => preg_match($pattern, $subject, $_, 0, $offset),
+    );
+
+    return $result === 1;
+}

--- a/src/Psl/Regex/replace.php
+++ b/src/Psl/Regex/replace.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Regex;
+
+use Psl\Type;
+
+use function preg_replace;
+
+/**
+ * Returns the '$haystack' string with all occurrences of `$pattern` replaced by
+ * `$replacement`.
+ *
+ * @param non-empty-string  $pattern    The pattern to search for.
+ *
+ * @throws Exception\InvalidPatternException If $pattern is invalid.
+ * @throws Exception\RuntimeException In case of an unexpected error.
+ *
+ * @psalm-pure
+ */
+function replace(string $haystack, string $pattern, string $replacement): string
+{
+    $result = Internal\call_preg(
+        'preg_replace',
+        static fn() => preg_replace($pattern, $replacement, $haystack),
+    );
+
+    // @codeCoverageIgnoreStart
+    try {
+        /**
+         * @psalm-suppress ImpureFunctionCall - see #130
+         * @psalm-suppress ImpureMethodCall -see #130
+         */
+        return Type\string()->assert($result);
+    } catch (Type\Exception\AssertException $e) {
+        throw new Exception\RuntimeException('Unexpected error', 0, $e);
+    }
+    // @codeCoverageIgnoreEnd
+}

--- a/src/Psl/Regex/replace_every.php
+++ b/src/Psl/Regex/replace_every.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Regex;
+
+use Psl\Type;
+use Psl\Vec;
+
+use function preg_replace;
+
+/**
+ * Returns the '$haystack' string with all occurrences of the keys of
+ * '$replacements' ( patterns ) replaced by the corresponding values.
+ *
+ * @param array<non-empty-string, string>   $replacements   A dict where the keys are regular expression patterns,
+ *                                                          and the values are the replacements.
+ *
+ * @throws Exception\InvalidPatternException If $pattern is invalid.
+ * @throws Exception\RuntimeException In case of an unexpected error.
+ *
+ * @psalm-pure
+ */
+function replace_every(string $haystack, array $replacements): string
+{
+    /**
+     * @psalm-suppress InvalidArgument - callable is not "pure", because keys() and values()
+     *      are conditionally pure, in this context, we know they are.
+     */
+    $result = Internal\call_preg(
+        'preg_replace',
+        static fn() => preg_replace(Vec\keys($replacements), Vec\values($replacements), $haystack),
+    );
+
+    // @codeCoverageIgnoreStart
+    try {
+        /**
+         * @psalm-suppress ImpureFunctionCall - see #130
+         * @psalm-suppress ImpureMethodCall -see #130
+         */
+        return Type\string()->assert($result);
+    } catch (Type\Exception\AssertException $e) {
+        throw new Exception\RuntimeException('Unexpected error', 0, $e);
+    }
+    // @codeCoverageIgnoreEnd
+}

--- a/src/Psl/Regex/split.php
+++ b/src/Psl/Regex/split.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Regex;
+
+use Psl;
+use Psl\Type;
+
+use function preg_split;
+
+use const PREG_SPLIT_NO_EMPTY;
+
+/**
+ * Split $subject by $pattern.
+ *
+ * @param non-empty-string  $pattern    The pattern to split $subject by.
+ * @param null|int          $limit      If specified, then only substrings up to limit are
+ *                                      returned with the rest of the string being placed in the last substring.
+ *
+ * @return list<string>
+ *
+ * @throws Exception\InvalidPatternException            If $pattern is invalid.
+ * @throws Exception\RuntimeException                   In case of an unexpected error.
+ * @throws Psl\Exception\InvariantViolationException    If $limit is negative, or equal to 0.
+ *
+ * @psalm-pure
+ */
+function split(string $subject, string $pattern, ?int $limit = null): array
+{
+    Psl\invariant($limit === null || $limit > 0, '$limit must be a positive integer.');
+    $result = Internal\call_preg(
+        'preg_split',
+        static fn() => preg_split($pattern, $subject, $limit ?? -1, PREG_SPLIT_NO_EMPTY),
+    );
+
+    // @codeCoverageIgnoreStart
+    try {
+        /**
+         * @psalm-suppress ImpureFunctionCall - see #130
+         * @psalm-suppress ImpureMethodCall -see #130
+         */
+        return Type\vec(Type\string())->assert($result);
+    } catch (Type\Exception\AssertException $e) {
+        throw new Exception\RuntimeException('Unexpected error', 0, $e);
+    }
+    // @codeCoverageIgnoreEnd
+}

--- a/src/Psl/Result/Failure.php
+++ b/src/Psl/Result/Failure.php
@@ -18,6 +18,8 @@ final class Failure implements ResultInterface
 {
     /**
      * @psalm-var Te
+     *
+     * @readonly
      */
     private Exception $exception;
 
@@ -33,6 +35,8 @@ final class Failure implements ResultInterface
      * Since this is a failed result wrapper, this always throws the exception thrown during the operation.
      *
      * @throws Exception
+     *
+     * @psalm-mutation-free
      */
     public function getResult(): void
     {
@@ -43,6 +47,8 @@ final class Failure implements ResultInterface
      * Since this is a failed result wrapper, this always returns the exception thrown during the operation.
      *
      * @psalm-return Te - The exception thrown during the operation.
+     *
+     * @psalm-mutation-free
      */
     public function getException(): Exception
     {
@@ -51,6 +57,8 @@ final class Failure implements ResultInterface
 
     /**
      * Since this is a failed result wrapper, this always returns `false`.
+     *
+     * @psalm-mutation-free
      */
     public function isSucceeded(): bool
     {
@@ -59,6 +67,8 @@ final class Failure implements ResultInterface
 
     /**
      * Since this is a failed result wrapper, this always returns `true`.
+     *
+     * @psalm-mutation-free
      */
     public function isFailed(): bool
     {

--- a/src/Psl/Result/ResultInterface.php
+++ b/src/Psl/Result/ResultInterface.php
@@ -25,6 +25,8 @@ interface ResultInterface
      * - if the operation failed: throw the exception inciting failure.
      *
      * @psalm-return T - The result of the operation upon success
+     *
+     * @psalm-mutation-free
      */
     public function getResult();
 
@@ -35,6 +37,8 @@ interface ResultInterface
      * - if the operation failed: returns the exception indicating failure.
      *
      * @throws Psl\Exception\InvariantViolationException - When the operation succeeded
+     *
+     * @psalm-mutation-free
      */
     public function getException(): Exception;
 
@@ -44,6 +48,8 @@ interface ResultInterface
      * if `isSucceeded()` returns `true`, `isFailed()` returns false.
      *
      * @return bool - `true` if the operation succeeded; `false` otherwise
+     *
+     * @psalm-mutation-free
      */
     public function isSucceeded(): bool;
 
@@ -53,6 +59,8 @@ interface ResultInterface
      * if `isFailed()` returns `true`, `isSucceeded()` returns false.
      *
      * @return bool - `true` if the operation failed; `false` otherwise
+     *
+     * @psalm-mutation-free
      */
     public function isFailed(): bool;
 

--- a/src/Psl/Result/Success.php
+++ b/src/Psl/Result/Success.php
@@ -18,6 +18,8 @@ final class Success implements ResultInterface
 {
     /**
      * @psalm-var T
+     *
+     * @readonly
      */
     private $value;
 
@@ -33,6 +35,8 @@ final class Success implements ResultInterface
      * Since this is a successful result wrapper, this always returns the actual result of the operation.
      *
      * @psalm-return T
+     *
+     * @psalm-mutation-free
      */
     public function getResult()
     {
@@ -48,6 +52,8 @@ final class Success implements ResultInterface
      * @psalm-return no-return
      *
      * @codeCoverageIgnore
+     *
+     * @psalm-mutation-free
      */
     public function getException(): Exception
     {
@@ -58,6 +64,8 @@ final class Success implements ResultInterface
      * Since this is a successful result wrapper, this always returns `true`.
      *
      * @return true
+     *
+     * @psalm-mutation-free
      */
     public function isSucceeded(): bool
     {
@@ -68,6 +76,8 @@ final class Success implements ResultInterface
      * Since this is a successful result wrapper, this always returns `false`.
      *
      * @return false
+     *
+     * @psalm-mutation-free
      */
     public function isFailed(): bool
     {

--- a/tests/Psl/Regex/MatchesTest.php
+++ b/tests/Psl/Regex/MatchesTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Regex;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Regex;
+
+final class MatchesTest extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function testMatches(bool $expected, string $subject, string $pattern, int $offset = 0): void
+    {
+        static::assertSame($expected, Regex\matches($subject, $pattern, $offset));
+    }
+
+    public function provideData(): iterable
+    {
+        yield [true, 'PHP is the web scripting language of choice.', '/php/i'];
+        yield [true, 'PHP is the web scripting language of choice.', '/\bweb\b/i'];
+        yield [true, 'PHP is the web scripting language of choice.', '/PHP/'];
+        yield [true, 'PHP is the web scripting language of choice.', '/\bweb\b/'];
+        yield [true, 'http://www.php.net/index.html', '@^(?:http://)?([^/]+)@i'];
+        yield [true, 'www.php.net', '/[^.]+\.[^.]+$/'];
+
+        yield [false, 'PHP is the web scripting language of choice.', '/php/'];
+        yield [false, 'PHP is the website scripting language of choice.', '/\bweb\b/i'];
+        yield [false, 'php is the web scripting language of choice.', '/PHP/'];
+        yield [false, 'hello', '/[^.]+\.[^.]+$/'];
+    }
+
+    public function testMatchesWithInvalidPattern(): void
+    {
+        $this->expectException(Regex\Exception\InvalidPatternException::class);
+        $this->expectExceptionMessage("No ending delimiter '/' found");
+
+        Regex\matches('hello', '/hello');
+    }
+}

--- a/tests/Psl/Regex/ReplaceEveryTest.php
+++ b/tests/Psl/Regex/ReplaceEveryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Regex;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Regex;
+
+final class ReplaceEveryTest extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function testReplaceEvery(string $expected, string $subject, array $replacements): void
+    {
+        static::assertSame($expected, Regex\replace_every($subject, $replacements));
+    }
+
+    public function provideData(): iterable
+    {
+        yield ['April1,2003', 'April 15, 2003', [
+            '/(\w+) (\d+), (\d+)/i' => '${1}1,$3'
+        ]];
+
+        yield ['The slow black bear jumps over the lazy dog.', 'The quick brown fox jumps over the lazy dog.', [
+            '/quick/' => 'slow',
+            '/brown/' => 'black',
+            '/fox/' => 'bear'
+        ]];
+
+        yield ['Hello, World!', 'Hello, World!', [
+            '/foo/' => 'bar'
+        ]];
+    }
+
+    public function testReplaceEveryWithInvalidPattern(): void
+    {
+        $this->expectException(Regex\Exception\InvalidPatternException::class);
+        $this->expectExceptionMessage("No ending delimiter '/' found");
+
+        Regex\replace_every('April 15, 2003', ['/(\w+) (\d+), (\d+)' => '${1}1,$3']);
+    }
+}

--- a/tests/Psl/Regex/ReplaceTest.php
+++ b/tests/Psl/Regex/ReplaceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Regex;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Regex;
+
+final class ReplaceTest extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function testReplace(string $expected, string $subject, string $pattern, string $replacement): void
+    {
+        static::assertSame($expected, Regex\replace($subject, $pattern, $replacement));
+    }
+
+    public function provideData(): iterable
+    {
+        yield ['April1,2003', 'April 15, 2003', '/(\w+) (\d+), (\d+)/i', '${1}1,$3'];
+
+        yield ['Hello, World!', 'Hello, World!', '/foo/', 'bar'];
+    }
+
+    public function testReplaceWithInvalidPattern(): void
+    {
+        $this->expectException(Regex\Exception\InvalidPatternException::class);
+        $this->expectExceptionMessage("No ending delimiter '/' found");
+
+        Regex\replace('April 15, 2003', '/(\w+) (\d+), (\d+)', '${1}1,$3');
+    }
+}

--- a/tests/Psl/Regex/SplitTest.php
+++ b/tests/Psl/Regex/SplitTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Regex;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Regex;
+
+final class SplitTest extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function testSplit(array $expected, string $subject, string $pattern, ?int $limit = null): void
+    {
+        static::assertSame($expected, Regex\split($subject, $pattern, $limit));
+    }
+
+    public function provideData(): iterable
+    {
+        yield [
+            ['hello'],
+            'hello',
+            "/[\s,]+/"
+        ];
+
+        yield [
+            ['php', 'standard', 'library'],
+            'php standard library',
+            "/[\s,]+/"
+        ];
+
+        yield [
+            ['p', 'h', 'p', ' ', 's', 't', 'a', 'n', 'd', 'a', 'r', 'd', ' ', 'l', 'i', 'b', 'r', 'a', 'r', 'y'],
+            'php standard library',
+            "//"
+        ];
+
+        yield [
+            ['p', 'h', 'p', ' ', 'standard library'],
+            'php standard library',
+            "//",
+            5
+        ];
+    }
+
+    public function testReplaceWithInvalidPattern(): void
+    {
+        $this->expectException(Regex\Exception\InvalidPatternException::class);
+        $this->expectExceptionMessage("No ending delimiter '/' found");
+
+        Regex\split('php standard library', '/');
+    }
+}


### PR DESCRIPTION
closes #29 

This PR doesn't provide a complete replacement for `preg_*` functions, as i don't think we can really type everything correctly.

therefor, here we only add functions that have a known return type, such as `replace`, `split`, and `matches`.

---

changelog:

Features:

- added `Psl\Regex\matches` function
- added `Psl\Regex\replace` function
- added `Psl\Regex\replace_every` function ( for consistency with `Psl\Str\replace_every`, `Psl\Str\Byte\replace_every`, .. etc )
- added `Psl\Regex\split` function