### PR TITLE
[Json] use TypeInterface

### DIFF
--- a/src/Psl/Json/typed.php
+++ b/src/Psl/Json/typed.php
@@ -6,20 +6,20 @@ namespace Psl\Json;
 
 use Psl\Type\Exception\AssertException;
 use Psl\Type\Exception\CoercionException;
-use Psl\Type\Type;
+use Psl\Type\TypeInterface;
 
 /**
  * Decode a json encoded string into a dynamic variable.
  *
  * @psalm-template T
  *
- * @psalm-param Type<T> $type
+ * @psalm-param TypeInterface<T> $type
  *
  * @psalm-return T
  *
  * @throws Exception\DecodeException If an error occurred.
  */
-function typed(string $json, Type $type)
+function typed(string $json, TypeInterface $type)
 {
     $value = decode($json);
 


### PR DESCRIPTION
Fixes:

- `Psl\Json\typed` now accepts any implementation of `Type\TypeInterface` ( previously, only implementation of `Type\Type` were allowed )