### PR TITLE
replace `@use` annotation by `@see`

### DIFF
--- a/docs/component/arr.md
+++ b/docs/component/arr.md
@@ -49,7 +49,7 @@
 - [slice](./../../src/Psl/Arr/slice.php#L35) ( deprecated )
 - [sort](./../../src/Psl/Arr/sort.php#L24) ( deprecated )
 - [sort_by](./../../src/Psl/Arr/sort_by.php#L27) ( deprecated )
-- [sort_by_key](./../../src/Psl/Arr/sort_by_key.php#L26) ( deprecated )
+- [sort_by_key](./../../src/Psl/Arr/sort_by_key.php#L25) ( deprecated )
 - [sort_with_keys](./../../src/Psl/Arr/sort_with_keys.php#L25) ( deprecated )
 - [sort_with_keys_by](./../../src/Psl/Arr/sort_with_keys_by.php#L29) ( deprecated )
 - [take](./../../src/Psl/Arr/take.php#L25) ( deprecated )

--- a/src/Psl/Arr/sort_by_key.php
+++ b/src/Psl/Arr/sort_by_key.php
@@ -21,7 +21,7 @@ use Psl\Dict;
  *
  * @deprecated use `Dict\sort_by_key`
  *
- * @use Dict\sort_by_key
+ * @see Dict\sort_by_key
  */
 function sort_by_key(array $array, ?callable $comparator = null): array
 {

--- a/src/Psl/Arr/sort_by_key.php
+++ b/src/Psl/Arr/sort_by_key.php
@@ -20,7 +20,6 @@ use Psl\Dict;
  * @return array<Tk, Tv>
  *
  * @deprecated use `Dict\sort_by_key`
- *
  * @see Dict\sort_by_key
  */
 function sort_by_key(array $array, ?callable $comparator = null): array


### PR DESCRIPTION
`@use` is used in psalm/phpstan for generic traits: https://psalm.dev/docs/annotating_code/templated_annotations/#template-inheritance