### PR TITLE
improve metaphone errors

### DIFF
--- a/docs/component/str.md
+++ b/docs/component/str.md
@@ -46,7 +46,7 @@
 - [length](./../../src/Psl/Str/length.php#L30)
 - [levenshtein](./../../src/Psl/Str/levenshtein.php#L29)
 - [lowercase](./../../src/Psl/Str/lowercase.php#L35)
-- [metaphone](./../../src/Psl/Str/metaphone.php#L19)
+- [metaphone](./../../src/Psl/Str/metaphone.php#L23)
 - [ord](./../../src/Psl/Str/ord.php#L27)
 - [pad_left](./../../src/Psl/Str/pad_left.php#L36)
 - [pad_right](./../../src/Psl/Str/pad_right.php#L36)

--- a/src/Psl/Str/metaphone.php
+++ b/src/Psl/Str/metaphone.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Str;
 
+use Psl;
+
 use function metaphone as php_metaphone;
 
 /**
@@ -12,13 +14,15 @@ use function metaphone as php_metaphone;
  * @param int $phonemes This parameter restricts the returned metaphone key to phonemes characters in length.
  *                      the default value of 0 means no restriction.
  *
- * @return string|null the metaphone key as a string, or NULL on failure
+ * @throws Psl\Exception\InvariantViolationException If $phonemes is negative.
+ *
+ * @return string the metaphone key as a string
  *
  * @pure
  */
-function metaphone(string $string, int $phonemes = 0): ?string
+function metaphone(string $string, int $phonemes = 0): string
 {
-    $result = php_metaphone($string, $phonemes);
+    Psl\invariant($phonemes >= 0, 'Expected non-negative phonemes, got %d.', $phonemes);
 
-    return false === $result ? null : $result;
+    return php_metaphone($string, $phonemes);
 }

--- a/tests/Psl/Str/MetaphoneTest.php
+++ b/tests/Psl/Str/MetaphoneTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psl\Tests\Str;
 
 use PHPUnit\Framework\TestCase;
+use Psl;
 use Psl\Str;
 
 final class MetaphoneTest extends TestCase
@@ -26,5 +27,13 @@ final class MetaphoneTest extends TestCase
             ['', 'سيف'],
             ['', '1337'],
         ];
+    }
+
+    public function testThrowsIfPhonemeIsNegative(): void
+    {
+        $this->expectException(Psl\Exception\InvariantViolationException::class);
+        $this->expectExceptionMessage('Expected non-negative phonemes, got -1.');
+
+        Str\metaphone('foo', -1);
     }
 }


### PR DESCRIPTION
As of PHP 8, `metaphone` no longer returns `false` on error: https://github.com/php/php-src/commit/84be22f1f5db499001379f762869d00fc3bc6f55

Previously, the only way `false` could be returned is the `phonemes` parameter to be negative, which this PR handles.

I guess this could considered be a BC beak, as if a user is on PHP 7.4, and was passing in an invalid phoneme parameter, it will throw instead of returning `null` now.