### PR TITLE
Feature/variadic union type improvemence

### DIFF
--- a/src/Psl/Type/literal_scalar.php
+++ b/src/Psl/Type/literal_scalar.php
@@ -18,7 +18,7 @@ use Psl;
 function literal_scalar($value): TypeInterface
 {
     /** @psalm-suppress MissingThrowsDocblock */
-    union(union(string(), bool()), num())->assert($value);
+    union(string(), bool(), num())->assert($value);
 
     return new Internal\LiteralScalarType($value);
 }

--- a/src/Psl/Type/union.php
+++ b/src/Psl/Type/union.php
@@ -7,19 +7,26 @@ namespace Psl\Type;
 use Psl;
 
 /**
- * @template Tl
- * @template Tr
+ * @template T
  *
- * @param TypeInterface<Tl> $first
- * @param TypeInterface<Tr> $second
+ * @param TypeInterface<T> $first
+ * @param TypeInterface<T> $second
+ * @param TypeInterface<T> ...$rest
  *
- * @throws Psl\Exception\InvariantViolationException If $first, or $second is optional.
+ * @throws Psl\Exception\InvariantViolationException If $first, $second or one of $rest is optional.
  *
- * @return TypeInterface<Tl|Tr>
+ * @return TypeInterface<T>
  */
 function union(
     TypeInterface $first,
-    TypeInterface $second
+    TypeInterface $second,
+    TypeInterface ...$rest
 ): TypeInterface {
-    return new Internal\UnionType($first, $second);
+    $accumulated_type = new Internal\UnionType($first, $second);
+
+    foreach ($rest as $type) {
+        $accumulated_type = new Internal\UnionType($accumulated_type, $type);
+    }
+
+    return $accumulated_type;
 }

--- a/src/Psl/Type/union.php
+++ b/src/Psl/Type/union.php
@@ -10,16 +10,16 @@ use Psl;
  * @template Tl
  * @template Tr
  *
- * @param TypeInterface<Tl> $left_type
- * @param TypeInterface<Tr> $right_type
+ * @param TypeInterface<Tl> $first
+ * @param TypeInterface<Tr> $second
  *
- * @throws Psl\Exception\InvariantViolationException If $left_type, or $right_type is optional.
+ * @throws Psl\Exception\InvariantViolationException If $first, or $second is optional.
  *
  * @return TypeInterface<Tl|Tr>
  */
 function union(
-    TypeInterface $left_type,
-    TypeInterface $right_type
+    TypeInterface $first,
+    TypeInterface $second
 ): TypeInterface {
-    return new Internal\UnionType($left_type, $right_type);
+    return new Internal\UnionType($first, $second);
 }

--- a/tests/static-analysis/Type/union.php
+++ b/tests/static-analysis/Type/union.php
@@ -6,11 +6,11 @@ use Psl\Type;
 
 /**
  * @psalm-suppress UnusedParam
+ *
  * @param 'PENDING'|'PROCESSING'|'COMPLETED'|'ERROR' $state
  */
 function takes_valid_state(string $state): void
 {
-
 }
 
 function test(): void

--- a/tests/static-analysis/Type/union.php
+++ b/tests/static-analysis/Type/union.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Psl\Type;
+
+/**
+ * @psalm-suppress UnusedParam
+ * @param 'PENDING'|'PROCESSING'|'COMPLETED'|'ERROR' $state
+ */
+function takes_valid_state(string $state): void
+{
+
+}
+
+function test(): void
+{
+    /** @psalm-suppress MissingThrowsDocblock */
+    $old_school_codec = Type\union(
+        Type\literal_scalar('PENDING'),
+        Type\union(
+            Type\literal_scalar('PROCESSING'),
+            Type\union(
+                Type\literal_scalar('COMPLETED'),
+                Type\literal_scalar('ERROR'),
+            )
+        )
+    );
+
+    /** @psalm-suppress MissingThrowsDocblock */
+    $new_codec = Type\union(
+        Type\literal_scalar('PENDING'),
+        Type\literal_scalar('PROCESSING'),
+        Type\literal_scalar('COMPLETED'),
+        Type\literal_scalar('ERROR'),
+    );
+
+    /** @psalm-suppress MissingThrowsDocblock */
+    takes_valid_state($old_school_codec->assert('any'));
+
+    /** @psalm-suppress MissingThrowsDocblock */
+    takes_valid_state($new_codec->assert('any'));
+}

--- a/tests/unit/Type/UnionTypeTest.php
+++ b/tests/unit/Type/UnionTypeTest.php
@@ -39,7 +39,7 @@ final class UnionTypeTest extends TypeTest
     {
         yield [Type\union(Type\bool(), Type\string()), 'bool|string'];
         yield [Type\union(Type\bool(), Type\float()), 'bool|float'];
-        yield [Type\union(Type\bool(), Type\union(Type\float(), Type\int())), 'bool|float|int'];
+        yield [Type\union(Type\bool(), Type\float(), Type\int()), 'bool|float|int'];
         yield [Type\union(Type\bool(), Type\num()), 'bool|num'];
         yield [Type\union(Type\bool(), Type\array_key()), 'bool|array-key'];
         yield [
@@ -58,9 +58,20 @@ final class UnionTypeTest extends TypeTest
                     Type\object(IndexAccessInterface::class),
                     Type\object(CollectionInterface::class)
                 ),
-                Type\bool()
+                Type\bool(),
+                Type\non_empty_string()
             ),
-            '(Psl\Collection\IndexAccessInterface&Psl\Collection\CollectionInterface)|bool'
+            '((Psl\Collection\IndexAccessInterface&Psl\Collection\CollectionInterface)|bool)|non-empty-string'
+        ];
+        yield [
+            Type\union(
+                Type\null(),
+                Type\vec(Type\positive_int()),
+                Type\literal_scalar('php'),
+                Type\literal_scalar('still'),
+                Type\literal_scalar('alive'),
+            ),
+            'null|list<positive-int>|"php"|"still"|"alive"'
         ];
     }
 }


### PR DESCRIPTION
#183 

### Changelog
- function `Psl\Type\union` now takes variadic third parameter
- function `Psl\Type\union` arguments `$left_type` and `$right_type` were renamed to `$first` and `$second`
    This is a **breaking change**, because if somebody uses PHP8+ and does 
    `union(left_type: $left, right_type: $right)` - this would trigger runtime `Error`.
    
### Future scope
- I think we should use `@no-named-arguments` [psalm's annotation](https://psalm.dev/docs/annotating_code/supported_annotations/#no-named-arguments)
    I haven't used this in my PR, cause I think it should be discussed and (if accepted) added atomically for all possible functions and methods
- As @azjezz mentioned in #183, we should also make variadic function `Psl\Type\intersection`