### PR TITLE
Filesystem - add argument values into InvariantViolationException message

### DIFF
--- a/docs/component/filesystem.md
+++ b/docs/component/filesystem.md
@@ -48,7 +48,7 @@
 - [is_readable](./../../src/Psl/Filesystem/is_readable.php#L20)
 - [is_symbolic_link](./../../src/Psl/Filesystem/is_symbolic_link.php#L19)
 - [is_writable](./../../src/Psl/Filesystem/is_writable.php#L20)
-- [read_directory](./../../src/Psl/Filesystem/read_directory.php#L20)
+- [read_directory](./../../src/Psl/Filesystem/read_directory.php#L19)
 - [read_file](./../../src/Psl/Filesystem/read_file.php#L24)
 - [read_symbolic_link](./../../src/Psl/Filesystem/read_symbolic_link.php#L21)
 - [write_file](./../../src/Psl/Filesystem/write_file.php#L18)

--- a/docs/component/filesystem.md
+++ b/docs/component/filesystem.md
@@ -48,7 +48,7 @@
 - [is_readable](./../../src/Psl/Filesystem/is_readable.php#L20)
 - [is_symbolic_link](./../../src/Psl/Filesystem/is_symbolic_link.php#L19)
 - [is_writable](./../../src/Psl/Filesystem/is_writable.php#L20)
-- [read_directory](./../../src/Psl/Filesystem/read_directory.php#L19)
+- [read_directory](./../../src/Psl/Filesystem/read_directory.php#L20)
 - [read_file](./../../src/Psl/Filesystem/read_file.php#L24)
 - [read_symbolic_link](./../../src/Psl/Filesystem/read_symbolic_link.php#L21)
 - [write_file](./../../src/Psl/Filesystem/write_file.php#L18)

--- a/src/Psl/Filesystem/Internal/write_file.php
+++ b/src/Psl/Filesystem/Internal/write_file.php
@@ -27,8 +27,8 @@ use const LOCK_EX;
 function write_file(string $file, string $content, bool $append): void
 {
     if (Filesystem\exists($file)) {
-        Psl\invariant(Filesystem\is_file($file), Str\format('File "%s" is not a file.', $file));
-        Psl\invariant(Filesystem\is_writable($file), Str\format('File "%s" is not writeable.', $file));
+        Psl\invariant(Filesystem\is_file($file), 'File "%s" is not a file.', $file);
+        Psl\invariant(Filesystem\is_writable($file), 'File "%s" is not writeable.', $file);
     } else {
         Filesystem\create_file($file);
     }

--- a/src/Psl/Filesystem/Internal/write_file.php
+++ b/src/Psl/Filesystem/Internal/write_file.php
@@ -27,8 +27,8 @@ use const LOCK_EX;
 function write_file(string $file, string $content, bool $append): void
 {
     if (Filesystem\exists($file)) {
-        Psl\invariant(Filesystem\is_file($file), '$file is not a file.');
-        Psl\invariant(Filesystem\is_writable($file), '$file is not writeable.');
+        Psl\invariant(Filesystem\is_file($file), Str\format('File "%s" is not a file.', $file));
+        Psl\invariant(Filesystem\is_writable($file), Str\format('File "%s" is not writeable.', $file));
     } else {
         Filesystem\create_file($file);
     }

--- a/src/Psl/Filesystem/change_group.php
+++ b/src/Psl/Filesystem/change_group.php
@@ -19,7 +19,7 @@ use function lchgrp;
  */
 function change_group(string $filename, int $group): void
 {
-    Psl\invariant(exists($filename), '$filename does not exist.');
+    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
 
     if (is_symbolic_link($filename)) {
         $fun = static fn(): bool => lchgrp($filename, $group);

--- a/src/Psl/Filesystem/change_group.php
+++ b/src/Psl/Filesystem/change_group.php
@@ -19,7 +19,7 @@ use function lchgrp;
  */
 function change_group(string $filename, int $group): void
 {
-    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
+    Psl\invariant(exists($filename), 'File "%s" does not exist.', $filename);
 
     if (is_symbolic_link($filename)) {
         $fun = static fn(): bool => lchgrp($filename, $group);

--- a/src/Psl/Filesystem/change_owner.php
+++ b/src/Psl/Filesystem/change_owner.php
@@ -19,7 +19,7 @@ use function lchown;
  */
 function change_owner(string $filename, int $user): void
 {
-    Psl\invariant(exists($filename), '$filename does not exist.');
+    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
     if (is_symbolic_link($filename)) {
         $fun = static fn(): bool => lchown($filename, $user);
     } else {

--- a/src/Psl/Filesystem/change_owner.php
+++ b/src/Psl/Filesystem/change_owner.php
@@ -19,7 +19,7 @@ use function lchown;
  */
 function change_owner(string $filename, int $user): void
 {
-    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
+    Psl\invariant(exists($filename), 'File "%s" does not exist.', $filename);
     if (is_symbolic_link($filename)) {
         $fun = static fn(): bool => lchown($filename, $user);
     } else {

--- a/src/Psl/Filesystem/change_permissions.php
+++ b/src/Psl/Filesystem/change_permissions.php
@@ -18,7 +18,7 @@ use function chmod;
  */
 function change_permissions(string $filename, int $permissions): void
 {
-    Psl\invariant(exists($filename), '$filename does not exist.');
+    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
 
     [$success, $error] = Internal\box(static fn(): bool => chmod($filename, $permissions));
     // @codeCoverageIgnoreStart

--- a/src/Psl/Filesystem/change_permissions.php
+++ b/src/Psl/Filesystem/change_permissions.php
@@ -18,7 +18,7 @@ use function chmod;
  */
 function change_permissions(string $filename, int $permissions): void
 {
-    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
+    Psl\invariant(exists($filename), 'File "%s" does not exist.', $filename);
 
     [$success, $error] = Internal\box(static fn(): bool => chmod($filename, $permissions));
     // @codeCoverageIgnoreStart

--- a/src/Psl/Filesystem/copy.php
+++ b/src/Psl/Filesystem/copy.php
@@ -20,7 +20,7 @@ use function stream_copy_to_stream;
  */
 function copy(string $source, string $destination, bool $overwrite = false): void
 {
-    Psl\invariant(is_file($source) && is_readable($source), '$source does not exist or is not readable.');
+    Psl\invariant(is_file($source) && is_readable($source), Str\format('Source "%s" does not exist or is not readable.', $source));
 
     if (!$overwrite && is_file($destination)) {
         return;

--- a/src/Psl/Filesystem/copy.php
+++ b/src/Psl/Filesystem/copy.php
@@ -20,7 +20,7 @@ use function stream_copy_to_stream;
  */
 function copy(string $source, string $destination, bool $overwrite = false): void
 {
-    Psl\invariant(is_file($source) && is_readable($source), Str\format('Source "%s" does not exist or is not readable.', $source));
+    Psl\invariant(is_file($source) && is_readable($source), 'Source "%s" does not exist or is not readable.', $source);
 
     if (!$overwrite && is_file($destination)) {
         return;

--- a/src/Psl/Filesystem/create_hard_link.php
+++ b/src/Psl/Filesystem/create_hard_link.php
@@ -20,8 +20,8 @@ use function link;
  */
 function create_hard_link(string $source, string $destination): void
 {
-    Psl\invariant(exists($source), '$source file does not exist.');
-    Psl\invariant(is_file($source), '$source is not a file.');
+    Psl\invariant(exists($source), Str\format('Source file "%s" does not exist.', $source));
+    Psl\invariant(is_file($source), Str\format('Source "%s" is not a file.', $source));
 
     $destination_directory = get_directory($destination);
     if (!is_directory($destination_directory)) {

--- a/src/Psl/Filesystem/create_hard_link.php
+++ b/src/Psl/Filesystem/create_hard_link.php
@@ -20,8 +20,8 @@ use function link;
  */
 function create_hard_link(string $source, string $destination): void
 {
-    Psl\invariant(exists($source), Str\format('Source file "%s" does not exist.', $source));
-    Psl\invariant(is_file($source), Str\format('Source "%s" is not a file.', $source));
+    Psl\invariant(exists($source), 'Source file "%s" does not exist.', $source);
+    Psl\invariant(is_file($source), 'Source "%s" is not a file.', $source);
 
     $destination_directory = get_directory($destination);
     if (!is_directory($destination_directory)) {

--- a/src/Psl/Filesystem/create_temporary_file.php
+++ b/src/Psl/Filesystem/create_temporary_file.php
@@ -26,8 +26,8 @@ use Psl\Str;
 function create_temporary_file(?string $directory = null, ?string $prefix = null): string
 {
     if (null !== $directory) {
-        Psl\invariant(is_directory($directory), Str\format('Directory "%s" is not a directory.', $directory));
-        Psl\invariant(is_writable($directory), Str\format('Directory "%s" is not writable.', $directory));
+        Psl\invariant(is_directory($directory), 'Directory "%s" is not a directory.', $directory);
+        Psl\invariant(is_writable($directory), 'Directory "%s" is not writable.', $directory);
     } else {
         $directory = Env\temp_dir();
     }

--- a/src/Psl/Filesystem/create_temporary_file.php
+++ b/src/Psl/Filesystem/create_temporary_file.php
@@ -26,8 +26,8 @@ use Psl\Str;
 function create_temporary_file(?string $directory = null, ?string $prefix = null): string
 {
     if (null !== $directory) {
-        Psl\invariant(is_directory($directory), '$directory is not a directory.');
-        Psl\invariant(is_writable($directory), '$directory is not writable.');
+        Psl\invariant(is_directory($directory), Str\format('Directory "%s" is not a directory.', $directory));
+        Psl\invariant(is_writable($directory), Str\format('Directory "%s" is not writable.', $directory));
     } else {
         $directory = Env\temp_dir();
     }

--- a/src/Psl/Filesystem/delete_directory.php
+++ b/src/Psl/Filesystem/delete_directory.php
@@ -22,7 +22,7 @@ use function rmdir;
  */
 function delete_directory(string $directory, bool $recursive = false): void
 {
-    Psl\invariant(is_directory($directory), '$directory does not exists.');
+    Psl\invariant(is_directory($directory), Str\format('Directory "%s" does not exist.', $directory));
 
     if ($recursive && !is_symbolic_link($directory)) {
         [$symbolic_nodes, $nodes] = Vec\partition(

--- a/src/Psl/Filesystem/delete_directory.php
+++ b/src/Psl/Filesystem/delete_directory.php
@@ -22,7 +22,7 @@ use function rmdir;
  */
 function delete_directory(string $directory, bool $recursive = false): void
 {
-    Psl\invariant(is_directory($directory), Str\format('Directory "%s" does not exist.', $directory));
+    Psl\invariant(is_directory($directory), 'Directory "%s" does not exist.', $directory);
 
     if ($recursive && !is_symbolic_link($directory)) {
         [$symbolic_nodes, $nodes] = Vec\partition(

--- a/src/Psl/Filesystem/delete_file.php
+++ b/src/Psl/Filesystem/delete_file.php
@@ -19,7 +19,7 @@ use function unlink;
  */
 function delete_file(string $filename): void
 {
-    Psl\invariant(is_file($filename), Str\format('File "%s" does not exist.', $filename));
+    Psl\invariant(is_file($filename), 'File "%s" does not exist.', $filename);
 
     [$result, $error_message] = Internal\box(static fn() => unlink($filename));
     // @codeCoverageIgnoreStart

--- a/src/Psl/Filesystem/delete_file.php
+++ b/src/Psl/Filesystem/delete_file.php
@@ -19,7 +19,7 @@ use function unlink;
  */
 function delete_file(string $filename): void
 {
-    Psl\invariant(is_file($filename), '$filename does not exists.');
+    Psl\invariant(is_file($filename), Str\format('File "%s" does not exist.', $filename));
 
     [$result, $error_message] = Internal\box(static fn() => unlink($filename));
     // @codeCoverageIgnoreStart

--- a/src/Psl/Filesystem/file_size.php
+++ b/src/Psl/Filesystem/file_size.php
@@ -16,7 +16,7 @@ use Psl\Str;
  */
 function file_size(string $filename): int
 {
-    Psl\invariant(is_file($filename) && is_readable($filename), Str\format('File "%s" does not exist.', $filename));
+    Psl\invariant(is_file($filename) && is_readable($filename), 'File "%s" does not exist.', $filename);
 
     // @codeCoverageIgnoreStart
     [$size, $message] = Internal\box(static fn() => filesize($filename));

--- a/src/Psl/Filesystem/file_size.php
+++ b/src/Psl/Filesystem/file_size.php
@@ -16,7 +16,7 @@ use Psl\Str;
  */
 function file_size(string $filename): int
 {
-    Psl\invariant(is_file($filename) && is_readable($filename), '$filename does not exist.');
+    Psl\invariant(is_file($filename) && is_readable($filename), Str\format('File "%s" does not exist.', $filename));
 
     // @codeCoverageIgnoreStart
     [$size, $message] = Internal\box(static fn() => filesize($filename));

--- a/src/Psl/Filesystem/get_access_time.php
+++ b/src/Psl/Filesystem/get_access_time.php
@@ -17,7 +17,7 @@ use function fileatime;
  */
 function get_access_time(string $filename): int
 {
-    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
+    Psl\invariant(exists($filename), 'File "%s" does not exist.', $filename);
 
     [$result, $message] = Psl\Internal\box(
         /**

--- a/src/Psl/Filesystem/get_access_time.php
+++ b/src/Psl/Filesystem/get_access_time.php
@@ -17,7 +17,7 @@ use function fileatime;
  */
 function get_access_time(string $filename): int
 {
-    Psl\invariant(exists($filename), '$filename does not exists.');
+    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
 
     [$result, $message] = Psl\Internal\box(
         /**

--- a/src/Psl/Filesystem/get_change_time.php
+++ b/src/Psl/Filesystem/get_change_time.php
@@ -18,7 +18,7 @@ use function filectime;
  */
 function get_change_time(string $filename): int
 {
-    Psl\invariant(exists($filename), '$filename does not exists.');
+    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
 
     [$result, $message] = Psl\Internal\box(
         /**

--- a/src/Psl/Filesystem/get_change_time.php
+++ b/src/Psl/Filesystem/get_change_time.php
@@ -18,7 +18,7 @@ use function filectime;
  */
 function get_change_time(string $filename): int
 {
-    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
+    Psl\invariant(exists($filename), 'File "%s" does not exist.', $filename);
 
     [$result, $message] = Psl\Internal\box(
         /**

--- a/src/Psl/Filesystem/get_group.php
+++ b/src/Psl/Filesystem/get_group.php
@@ -17,7 +17,7 @@ use function filegroup;
  */
 function get_group(string $filename): int
 {
-    Psl\invariant(exists($filename), '$filename does not exists.');
+    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
 
     [$result, $message] = Psl\Internal\box(
         /**

--- a/src/Psl/Filesystem/get_group.php
+++ b/src/Psl/Filesystem/get_group.php
@@ -17,7 +17,7 @@ use function filegroup;
  */
 function get_group(string $filename): int
 {
-    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
+    Psl\invariant(exists($filename), 'File "%s" does not exist.', $filename);
 
     [$result, $message] = Psl\Internal\box(
         /**

--- a/src/Psl/Filesystem/get_inode.php
+++ b/src/Psl/Filesystem/get_inode.php
@@ -17,7 +17,7 @@ use function fileinode;
  */
 function get_inode(string $filename): int
 {
-    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
+    Psl\invariant(exists($filename), 'File "%s" does not exist.', $filename);
 
     [$result, $message] = Psl\Internal\box(
         /**

--- a/src/Psl/Filesystem/get_inode.php
+++ b/src/Psl/Filesystem/get_inode.php
@@ -17,7 +17,7 @@ use function fileinode;
  */
 function get_inode(string $filename): int
 {
-    Psl\invariant(exists($filename), '$filename does not exists.');
+    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
 
     [$result, $message] = Psl\Internal\box(
         /**

--- a/src/Psl/Filesystem/get_modification_time.php
+++ b/src/Psl/Filesystem/get_modification_time.php
@@ -18,7 +18,7 @@ use function filemtime;
  */
 function get_modification_time(string $filename): int
 {
-    Psl\invariant(exists($filename), '$filename does not exists.');
+    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
 
     [$result, $message] = Internal\box(
         /**

--- a/src/Psl/Filesystem/get_modification_time.php
+++ b/src/Psl/Filesystem/get_modification_time.php
@@ -18,7 +18,7 @@ use function filemtime;
  */
 function get_modification_time(string $filename): int
 {
-    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
+    Psl\invariant(exists($filename), 'File "%s" does not exist.', $filename);
 
     [$result, $message] = Internal\box(
         /**

--- a/src/Psl/Filesystem/get_owner.php
+++ b/src/Psl/Filesystem/get_owner.php
@@ -17,7 +17,7 @@ use function fileowner;
  */
 function get_owner(string $filename): int
 {
-    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
+    Psl\invariant(exists($filename), 'File "%s" does not exist.', $filename);
 
     [$result, $message] = Psl\Internal\box(
         /**

--- a/src/Psl/Filesystem/get_owner.php
+++ b/src/Psl/Filesystem/get_owner.php
@@ -17,7 +17,7 @@ use function fileowner;
  */
 function get_owner(string $filename): int
 {
-    Psl\invariant(exists($filename), '$filename does not exists.');
+    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
 
     [$result, $message] = Psl\Internal\box(
         /**

--- a/src/Psl/Filesystem/get_permissions.php
+++ b/src/Psl/Filesystem/get_permissions.php
@@ -17,7 +17,7 @@ use function fileperms;
  */
 function get_permissions(string $filename): int
 {
-    Psl\invariant(exists($filename), '$filename does not exists.');
+    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
 
     [$result, $message] = Psl\Internal\box(
         /**

--- a/src/Psl/Filesystem/get_permissions.php
+++ b/src/Psl/Filesystem/get_permissions.php
@@ -17,7 +17,7 @@ use function fileperms;
  */
 function get_permissions(string $filename): int
 {
-    Psl\invariant(exists($filename), Str\format('File "%s" does not exist.', $filename));
+    Psl\invariant(exists($filename), 'File "%s" does not exist.', $filename);
 
     [$result, $message] = Psl\Internal\box(
         /**

--- a/src/Psl/Filesystem/read_directory.php
+++ b/src/Psl/Filesystem/read_directory.php
@@ -6,6 +6,7 @@ namespace Psl\Filesystem;
 
 use FilesystemIterator;
 use Psl;
+use Psl\Str;
 use Psl\Vec;
 
 /**
@@ -18,9 +19,9 @@ use Psl\Vec;
  */
 function read_directory(string $directory): array
 {
-    Psl\invariant(exists($directory), '$directory does not exists.');
-    Psl\invariant(is_directory($directory), '$directory is not a directory.');
-    Psl\invariant(is_readable($directory), '$directory is not readable.');
+    Psl\invariant(exists($directory), Str\format('Directory "%s" does not exist.', $directory));
+    Psl\invariant(is_directory($directory), Str\format('Directory "%s" is not a directory.', $directory));
+    Psl\invariant(is_readable($directory), Str\format('Directory "%s" is not readable.', $directory));
 
     /** @var list<string> */
     return Vec\values(new FilesystemIterator(

--- a/src/Psl/Filesystem/read_directory.php
+++ b/src/Psl/Filesystem/read_directory.php
@@ -19,9 +19,9 @@ use Psl\Vec;
  */
 function read_directory(string $directory): array
 {
-    Psl\invariant(exists($directory), Str\format('Directory "%s" does not exist.', $directory));
-    Psl\invariant(is_directory($directory), Str\format('Directory "%s" is not a directory.', $directory));
-    Psl\invariant(is_readable($directory), Str\format('Directory "%s" is not readable.', $directory));
+    Psl\invariant(exists($directory), 'Directory "%s" does not exist.', $directory);
+    Psl\invariant(is_directory($directory), 'Directory "%s" is not a directory.', $directory);
+    Psl\invariant(is_readable($directory), 'Directory "%s" is not readable.', $directory);
 
     /** @var list<string> */
     return Vec\values(new FilesystemIterator(

--- a/src/Psl/Filesystem/read_directory.php
+++ b/src/Psl/Filesystem/read_directory.php
@@ -6,7 +6,6 @@ namespace Psl\Filesystem;
 
 use FilesystemIterator;
 use Psl;
-use Psl\Str;
 use Psl\Vec;
 
 /**

--- a/src/Psl/Filesystem/read_file.php
+++ b/src/Psl/Filesystem/read_file.php
@@ -23,9 +23,9 @@ use function file_get_contents;
  */
 function read_file(string $file, int $offset = 0, ?int $length = null): string
 {
-    Psl\invariant(exists($file), '$file does not exist.');
-    Psl\invariant(is_file($file), '$file is not a file.');
-    Psl\invariant(is_readable($file), '$file is not readable.');
+    Psl\invariant(exists($file), Str\format('File "%s" does not exist.', $file));
+    Psl\invariant(is_file($file), Str\format('File "%s" is not a file.', $file));
+    Psl\invariant(is_readable($file), Str\format('File "%s" is not readable.', $file));
 
     if (null === $length) {
         [$content, $error] = Internal\box(

--- a/src/Psl/Filesystem/read_file.php
+++ b/src/Psl/Filesystem/read_file.php
@@ -23,9 +23,9 @@ use function file_get_contents;
  */
 function read_file(string $file, int $offset = 0, ?int $length = null): string
 {
-    Psl\invariant(exists($file), Str\format('File "%s" does not exist.', $file));
-    Psl\invariant(is_file($file), Str\format('File "%s" is not a file.', $file));
-    Psl\invariant(is_readable($file), Str\format('File "%s" is not readable.', $file));
+    Psl\invariant(exists($file), 'File "%s" does not exist.', $file);
+    Psl\invariant(is_file($file), 'File "%s" is not a file.', $file);
+    Psl\invariant(is_readable($file), 'File "%s" is not readable.', $file);
 
     if (null === $length) {
         [$content, $error] = Internal\box(

--- a/src/Psl/Filesystem/read_symbolic_link.php
+++ b/src/Psl/Filesystem/read_symbolic_link.php
@@ -20,8 +20,8 @@ use function readlink;
  */
 function read_symbolic_link(string $symbolic_link): string
 {
-    Psl\invariant(exists($symbolic_link), Str\format('Symbolic link "%s" does not exist.', $symbolic_link));
-    Psl\invariant(is_symbolic_link($symbolic_link), Str\format('Symbolic link "%s" is not a symbolic link.', $symbolic_link));
+    Psl\invariant(exists($symbolic_link), 'Symbolic link "%s" does not exist.', $symbolic_link);
+    Psl\invariant(is_symbolic_link($symbolic_link), 'Symbolic link "%s" is not a symbolic link.', $symbolic_link);
 
     [$result, $message] = Internal\box(
         /**

--- a/src/Psl/Filesystem/read_symbolic_link.php
+++ b/src/Psl/Filesystem/read_symbolic_link.php
@@ -20,8 +20,8 @@ use function readlink;
  */
 function read_symbolic_link(string $symbolic_link): string
 {
-    Psl\invariant(exists($symbolic_link), '$symbolic_link does not exists.');
-    Psl\invariant(is_symbolic_link($symbolic_link), '$symbolic_link is not a symbolic link.');
+    Psl\invariant(exists($symbolic_link), Str\format('Symbolic link "%s" does not exist.', $symbolic_link));
+    Psl\invariant(is_symbolic_link($symbolic_link), Str\format('Symbolic link "%s" is not a symbolic link.', $symbolic_link));
 
     [$result, $message] = Internal\box(
         /**

--- a/tests/unit/Filesystem/FileTest.php
+++ b/tests/unit/Filesystem/FileTest.php
@@ -42,7 +42,7 @@ final class FileTest extends AbstractFilesystemTest
     public function testTemporaryFileThrowsForNonExistingDirectory(): void
     {
         $this->expectException(InvariantViolationException::class);
-        $this->expectExceptionMessage('$directory is not a directory.');
+        $this->expectExceptionMessage('"' . __FILE__ . '" is not a directory.');
 
         Filesystem\create_temporary_file(__FILE__);
     }
@@ -98,7 +98,7 @@ final class FileTest extends AbstractFilesystemTest
     public function testWriteFileThrowsForDirectories(): void
     {
         $this->expectException(InvariantViolationException::class);
-        $this->expectExceptionMessage('$file is not a file.');
+        $this->expectExceptionMessage('File "' . $this->directory . '" is not a file.');
 
         Filesystem\write_file($this->directory, 'hello');
     }
@@ -110,7 +110,7 @@ final class FileTest extends AbstractFilesystemTest
         Filesystem\change_permissions($file, 0111);
 
         $this->expectException(InvariantViolationException::class);
-        $this->expectExceptionMessage('$file is not writeable.');
+        $this->expectExceptionMessage('File "' . $file . '" is not writeable.');
 
         Filesystem\write_file($file, 'hello');
     }

--- a/tests/unit/Filesystem/ReadDirectoryTest.php
+++ b/tests/unit/Filesystem/ReadDirectoryTest.php
@@ -36,7 +36,7 @@ final class ReadDirectoryTest extends AbstractFilesystemTest
     public function testReadDirectoryThrowsIfDirectoryDoesNotExist(): void
     {
         $this->expectException(InvariantViolationException::class);
-        $this->expectExceptionMessage('$directory does not exists.');
+        $this->expectExceptionMessage('Directory "' . Env\temp_dir() . '/foo-bar-baz' . '" does not exist.');
 
         Filesystem\read_directory(Env\temp_dir() . '/foo-bar-baz');
     }
@@ -50,7 +50,7 @@ final class ReadDirectoryTest extends AbstractFilesystemTest
         Filesystem\create_file($filename);
 
         $this->expectException(InvariantViolationException::class);
-        $this->expectExceptionMessage('$directory is not a directory.');
+        $this->expectExceptionMessage('Directory "' . $filename . '" is not a directory.');
 
         Filesystem\read_directory($filename);
     }
@@ -60,7 +60,7 @@ final class ReadDirectoryTest extends AbstractFilesystemTest
         Filesystem\change_permissions($this->directory, 0077);
 
         $this->expectException(InvariantViolationException::class);
-        $this->expectExceptionMessage('$directory is not readable.');
+        $this->expectExceptionMessage('Directory "' . $this->directory . '" is not readable.');
 
         try {
             Filesystem\read_directory($this->directory);


### PR DESCRIPTION
I mentioned in #204 that thrown `InvariantViolationException` messages should contain argument values. It's easier to debug and fix code.

I updated everything I have found. Unit tests just updated. No additional unit tests added.