### PR TITLE
Don't perform operations on possible numeric-string

### DIFF
--- a/src/Psl/Math/mean.php
+++ b/src/Psl/Math/mean.php
@@ -9,7 +9,7 @@ use Psl\Iter;
 /**
  * Return the arithmetic mean of the numbers in the given iterable.
  *
- * @param iterable<numeric> $numbers
+ * @param iterable<int|float> $numbers
  */
 function mean(iterable $numbers): ?float
 {
@@ -20,8 +20,8 @@ function mean(iterable $numbers): ?float
 
     $mean = 0.0;
     foreach ($numbers as $number) {
-        $mean += $number / $count;
+        $mean += (float)$number / $count;
     }
 
-    return (float) $mean;
+    return $mean;
 }

--- a/src/Psl/Math/sum_floats.php
+++ b/src/Psl/Math/sum_floats.php
@@ -7,7 +7,7 @@ namespace Psl\Math;
 /**
  * Returns the float sum of the values of the given iterable.
  *
- * @param list<numeric> $numbers
+ * @param list<int|float> $numbers
  *
  * @pure
  */
@@ -15,8 +15,8 @@ function sum_floats(array $numbers): float
 {
     $result = 0.0;
     foreach ($numbers as $number) {
-        $result += $number;
+        $result += (float)$number;
     }
 
-    return (float) $result;
+    return $result;
 }


### PR DESCRIPTION
This PR remove the possibility to perform operations on numeric-strings. This should prevent build failure in case this(https://github.com/vimeo/psalm/pull/6169) or this(https://github.com/vimeo/psalm/pull/6167) is merged in Psalm