### PR TITLE
Benchmarks and performance improvements

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,6 @@ jobs:
         php-version:
           - "8.0"
         operating-system:
-          - "macos-latest"
           - "ubuntu-latest"
 
     steps:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: "installing dependencies"
         run: |
-          make install-benchmark-dependencies
+          make install-benchmark-dependencies -j10 -O
 
       - name: "running benchmarks"
         run: make benchmarks

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,47 @@
+name: "benchmarks"
+
+on:
+  pull_request: ~
+  push: ~
+
+jobs:
+  unit-tests:
+    name: "unit tests"
+
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      matrix:
+        php-version:
+          - "8.0"
+        operating-system:
+          - "macos-latest"
+          - "ubuntu-latest"
+
+    steps:
+      - name: "checkout"
+        uses: "actions/checkout@v2"
+
+      - name: "installing PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php-version }}"
+          ini-values: memory_limit=-1
+          tools: composer:v2, cs2pr
+          extensions: bcmath, mbstring, intl, sodium, json
+
+      - name: "caching dependencies"
+        uses: "actions/cache@v2.1.6"
+        with:
+          path: |
+            ~/.composer/cache
+            vendor
+          key: "php-${{ matrix.php-version }}"
+          restore-keys: "php-${{ matrix.php-version }}"
+
+      - name: "installing dependencies"
+        run: |
+          make install-static-analysis-dependencies
+
+      - name: "running benchmarks"
+        run: make benchmarks

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   unit-tests:
-    name: "unit tests"
+    name: "benchmarks"
 
     runs-on: ${{ matrix.operating-system }}
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: "installing dependencies"
         run: |
-          make install-static-analysis-dependencies
+          make install-benchmark-dependencies
 
       - name: "running benchmarks"
         run: make benchmarks

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,6 +1,6 @@
 name: "code coverage"
 
-on: 
+on:
   pull_request: ~
   push: ~
 
@@ -24,8 +24,7 @@ jobs:
 
       - name: "installing dependencies"
         run: |
-          make install-root-dependencies
-          make install-unit-tests-dependencies
+          make install-unit-tests-dependencies -j10 -O
 
       - name: "sending code coverage to coveralls"
         env:

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -22,8 +22,7 @@ jobs:
 
       - name: "installing dependencies"
         run: |
-          make install-root-dependencies
-          make install-coding-standard-dependencies
+          make install-coding-standard-dependencies -j10 -O
 
       - name: "checking coding standards"
         run: make coding-standard-check

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: "installing dependencies"
         run: |
-          make install -j10 -O
+          make install-static-analysis-dependencies -j10 -O
 
       - name: "running security analysis ( psalm )"
         run: make security-analysis

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -22,8 +22,7 @@ jobs:
 
       - name: "installing dependencies"
         run: |
-          make install-root-dependencies
-          make install-static-analysis-dependencies
+          make install -j10 -O
 
       - name: "running security analysis ( psalm )"
         run: make security-analysis

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: "installing dependencies"
         run: |
-          make install -j10 -O
+          make install-static-analysis-dependencies -j10 -O
 
       - name: "running static analysis"
         run: make static-analysis

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,8 +24,7 @@ jobs:
 
       - name: "installing dependencies"
         run: |
-          make install-root-dependencies
-          make install-static-analysis-dependencies
+          make install -j10 -O
 
       - name: "running static analysis"
         run: make static-analysis

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: "installing dependencies"
         run: |
-          make install-unit-tests-dependencies -j10 -O
+          make install-unit-tests-dependencies -j10
 
       - name: "running unit tests"
         run: make unit-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,8 +41,7 @@ jobs:
 
       - name: "installing dependencies"
         run: |
-          make install-root-dependencies
-          make install-unit-tests-dependencies
+          make install-unit-tests-dependencies -j10 -O
 
       - name: "running unit tests"
         run: make unit-tests

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,17 @@ help:                                                                           
 install-root-dependencies:                                                      ## install dependencies for the library itself
 	composer update
 
-install-coding-standard-dependencies:                                           ## install dependencies for coding-standard checks tooling
+install-coding-standard-dependencies: install-root-dependencies                 ## install dependencies for coding-standard checks tooling
 	cd tools/php-cs-fixer && composer update --ignore-platform-req php
 	cd tools/php-codesniffer && composer update
 
-install-benchmark-dependencies:                                                 ## install dependencies for benchmark tooling
+install-benchmark-dependencies: install-root-dependencies                       ## install dependencies for benchmark tooling
 	cd tools/phpbench && composer install
 
-install-static-analysis-dependencies:                                           ## install dependencies for static analysis tooling
+install-static-analysis-dependencies: install-root-dependencies install-benchmark-dependencies ## install dependencies for static analysis tooling
 	cd tools/psalm && composer update
 
-install-unit-tests-dependencies:                                                ## install dependencies for the test suite
+install-unit-tests-dependencies: install-root-dependencies                       ## install dependencies for the test suite
 	cd tools/phpunit && composer update
 
 install: install-root-dependencies install-coding-standard-dependencies install-benchmark-dependencies install-static-analysis-dependencies install-unit-tests-dependencies ## install all dependencies for a development environment

--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,50 @@
-install-root-dependencies:
+help:                                                                           ## shows this help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_\-\.]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+install-root-dependencies:                                                      ## install dependencies for the library itself
 	composer update
 
-install-coding-standard-dependencies:
+install-coding-standard-dependencies:                                           ## install dependencies for coding-standard checks tooling
 	cd tools/php-cs-fixer && composer update --ignore-platform-req php
 	cd tools/php-codesniffer && composer update
 
-install-static-analysis-dependencies:
+install-benchmark-dependencies:                                                 ## install dependencies for benchmark tooling
+	cd tools/phpbench && composer install
+
+install-static-analysis-dependencies:                                           ## install dependencies for static analysis tooling
 	cd tools/psalm && composer update
 
-install-unit-tests-dependencies:
+install-unit-tests-dependencies:                                                ## install dependencies for the test suite
 	cd tools/phpunit && composer update
 
-install: install-root-dependencies install-coding-standard-dependencies install-static-analysis-dependencies install-unit-tests-dependencies
+install: install-root-dependencies install-coding-standard-dependencies install-benchmark-dependencies install-static-analysis-dependencies install-unit-tests-dependencies ## install all dependencies for a development environment
 
-coding-standard-fix:
+coding-standard-fix:                                                            ## apply automated coding standard fixes
 	./tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --config=tools/php-cs-fixer/.php_cs.dist.php
 	./tools/php-codesniffer/vendor/bin/phpcbf --basepath=. --standard=tools/php-codesniffer/.phpcs.xml
 
-coding-standard-check:
+coding-standard-check:                                                          ## check coding-standard compliance
 	./tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --config=tools/php-cs-fixer/.php_cs.dist.php --dry-run
 	./tools/php-codesniffer/vendor/bin/phpcs --basepath=. --standard=tools/php-codesniffer/.phpcs.xml
 
-static-analysis:
+benchmarks:                                                                     ## run benchmarks
+	./tools/phpbench/vendor/bin/phpbench run --config tools/phpbench/phpbench.json
+
+static-analysis:                                                                ## run static analysis checks
 	./tools/psalm/vendor/bin/psalm -c tools/psalm/psalm.xml --show-info=true --no-cache
 	./tools/psalm/vendor/bin/psalm -c tools/psalm/psalm.xml tests/static-analysis --no-cache
 
-type-coverage:
+type-coverage:                                                                  ## send static analysis type coverage metrics to https://shepherd.dev/
 	./tools/psalm/vendor/bin/psalm -c tools/psalm/psalm.xml --shepherd --stats
 
-security-analysis:
+security-analysis:                                                              ## run static analysis security checks
 	./tools/psalm/vendor/bin/psalm -c tools/psalm/psalm.xml --taint-analysis
 
-unit-tests:
+unit-tests:                                                                     ## run unit test suite
 	./tools/phpunit/vendor/bin/phpunit -c tools/phpunit/phpunit.xml.dist
 
-code-coverage: unit-tests
+code-coverage: unit-tests                                                       ## generate and upload test coverage metrics to https://coveralls.io/
 	composer global require php-coveralls/php-coveralls
 	php-coveralls -x tests/logs/clover.xml -o tests/logs/coveralls-upload.json -v
 
-check: coding-standard-check static-analysis security-analysis unit-tests
+check: coding-standard-check static-analysis security-analysis unit-tests       ## run quick checks for local development iterations

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,12 @@ coding-standard-check:                                                          
 benchmarks:                                                                     ## run benchmarks
 	./tools/phpbench/vendor/bin/phpbench run --config tools/phpbench/phpbench.json
 
+create-benchmark-reference:                                                     ## run benchmarks, mark current run as "reference"
+	./tools/phpbench/vendor/bin/phpbench run --config tools/phpbench/phpbench.json --tag=benchmark_reference
+
+compare-benchmark-to-reference:                                                 ## run benchmarks, compare result to the "reference" run
+	./tools/phpbench/vendor/bin/phpbench run --config tools/phpbench/phpbench.json --ref=benchmark_reference
+
 static-analysis:                                                                ## run static analysis checks
 	./tools/psalm/vendor/bin/psalm -c tools/psalm/psalm.xml --show-info=true --no-cache
 	./tools/psalm/vendor/bin/psalm -c tools/psalm/psalm.xml tests/static-analysis --no-cache

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "Psl\\Tests\\Benchmark\\": "tests/benchmark",
             "Psl\\Tests\\StaticAnalysis\\": "tests/static-analysis",
             "Psl\\Tests\\Unit\\": "tests/unit",
             "Psl\\Tests\\Fixture\\": "tests/fixture"

--- a/docs/component/collection.md
+++ b/docs/component/collection.md
@@ -25,7 +25,7 @@
 
 #### `Classes`
 
-- [Map](./../../src/Psl/Collection/Map.php#L20)
+- [Map](./../../src/Psl/Collection/Map.php#L18)
 - [MutableMap](./../../src/Psl/Collection/MutableMap.php#L18)
 - [MutableVector](./../../src/Psl/Collection/MutableVector.php#L17)
 - [Vector](./../../src/Psl/Collection/Vector.php#L17)

--- a/src/Psl/Collection/AccessibleCollectionInterface.php
+++ b/src/Psl/Collection/AccessibleCollectionInterface.php
@@ -50,7 +50,7 @@ interface AccessibleCollectionInterface extends CollectionInterface, IndexAccess
      *                                 `AccessibleCollectionInterface` values.
      *
      * @return AccessibleCollectionInterface<Tk, Tv> A `AccessibleCollectionInterface` containing the values
-     *                                           after a user-specified condition is applied.
+     *                                               after a user-specified condition is applied.
      */
     public function filter(callable $fn): AccessibleCollectionInterface;
 
@@ -69,8 +69,8 @@ interface AccessibleCollectionInterface extends CollectionInterface, IndexAccess
      *                                     `AccessibleCollectionInterface` keys and values.
      *
      * @return AccessibleCollectionInterface<Tk, Tv> A `AccessibleCollectionInterface` containing the values
-     *                                           after a user-specified condition is applied to the keys and values
-     *                                           of the current `AccessibleCollectionInterface`.
+     *                                               after a user-specified condition is applied to the keys and values
+     *                                               of the current `AccessibleCollectionInterface`.
      */
     public function filterWithKey(callable $fn): AccessibleCollectionInterface;
 
@@ -90,7 +90,7 @@ interface AccessibleCollectionInterface extends CollectionInterface, IndexAccess
      *                               `AccessibleCollectionInterface` values.
      *
      * @return AccessibleCollectionInterface<Tk, Tu> A `AccessibleCollectionInterface` containing key/value
-     *                                           pairs after a user-specified operation is applied.
+     *                                               pairs after a user-specified operation is applied.
      */
     public function map(callable $fn): AccessibleCollectionInterface;
 
@@ -111,8 +111,8 @@ interface AccessibleCollectionInterface extends CollectionInterface, IndexAccess
      *                                   `AccessibleCollectionInterface` keys and values.
      *
      * @return AccessibleCollectionInterface<Tk, Tu> A `AccessibleCollectionInterface` containing the values
-     *                                           after a user-specified operation on the current
-     *                                           `AccessibleCollectionInterface`'s keys and values is  applied.
+     *                                               after a user-specified operation on the current
+     *                                               `AccessibleCollectionInterface`'s keys and values is  applied.
      */
     public function mapWithKey(callable $fn): AccessibleCollectionInterface;
 
@@ -185,8 +185,8 @@ interface AccessibleCollectionInterface extends CollectionInterface, IndexAccess
      *                               elements of this `AccessibleCollectionInterface`.
      *
      * @return AccessibleCollectionInterface<Tk, array{0: Tv, 1: Tu}> The `AccessibleCollectionInterface` that
-     *                                           combines the values of the current `AccessibleCollectionInterface`
-     *                                           with the provided `iterable`.
+     *                                                                combines the values of the current `AccessibleCollectionInterface`
+     *                                                                with the provided `iterable`.
      *
      * @psalm-mutation-free
      */
@@ -205,8 +205,8 @@ interface AccessibleCollectionInterface extends CollectionInterface, IndexAccess
      *  `AccessibleCollectionInterface`.
      *
      * @return AccessibleCollectionInterface<Tk, Tv> A `AccessibleCollectionInterface` that is a proper
-     *                                           subset of the current `AccessibleCollectionInterface` up
-     *                                           to `n` elements.
+     *                                               subset of the current `AccessibleCollectionInterface` up
+     *                                               to `n` elements.
      *
      * @psalm-mutation-free
      */
@@ -224,8 +224,8 @@ interface AccessibleCollectionInterface extends CollectionInterface, IndexAccess
      *                                 condition.
      *
      * @return AccessibleCollectionInterface<Tk, Tv> A `AccessibleCollectionInterface` that is a proper subset
-     *                                           of the current `AccessibleCollectionInterface` up until
-     *                                           the callback returns `false`.
+     *                                               of the current `AccessibleCollectionInterface` up until
+     *                                               the callback returns `false`.
      */
     public function takeWhile(callable $fn): AccessibleCollectionInterface;
 
@@ -242,8 +242,8 @@ interface AccessibleCollectionInterface extends CollectionInterface, IndexAccess
      *               first one in the returned `AccessibleCollectionInterface`.
      *
      * @return AccessibleCollectionInterface<Tk, Tv> A `AccessibleCollectionInterface` that is a proper subset
-     *                                           of the current `AccessibleCollectionInterface` containing values
-     *                                           after the specified `n`-th element.
+     *                                               of the current `AccessibleCollectionInterface` containing values
+     *                                               after the specified `n`-th element.
      *
      * @psalm-mutation-free
      */
@@ -261,8 +261,8 @@ interface AccessibleCollectionInterface extends CollectionInterface, IndexAccess
      *                                 returned `AccessibleCollectionInterface`.
      *
      * @return AccessibleCollectionInterface<Tk, Tv> A `AccessibleCollectionInterface` that is a proper subset
-     *                                           of the current `AccessibleCollectionInterface` starting after
-     *                                           the callback returns `true`.
+     *                                               of the current `AccessibleCollectionInterface` starting after
+     *                                               the callback returns `true`.
      */
     public function dropWhile(callable $fn): AccessibleCollectionInterface;
 
@@ -282,8 +282,8 @@ interface AccessibleCollectionInterface extends CollectionInterface, IndexAccess
      * @param int $length The length of the returned `AccessibleCollectionInterface`
      *
      * @return AccessibleCollectionInterface<Tk, Tv> A `AccessibleCollectionInterface` that is a proper subset
-     *                                           of the current `AccessibleCollectionInterface` starting at `$start`
-     *                                           up to but not including the element `$start + $length`.
+     *                                               of the current `AccessibleCollectionInterface` starting at `$start`
+     *                                               up to but not including the element `$start + $length`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/AccessibleCollectionInterface.php
+++ b/src/Psl/Collection/AccessibleCollectionInterface.php
@@ -185,8 +185,9 @@ interface AccessibleCollectionInterface extends CollectionInterface, IndexAccess
      *                               elements of this `AccessibleCollectionInterface`.
      *
      * @return AccessibleCollectionInterface<Tk, array{0: Tv, 1: Tu}> The `AccessibleCollectionInterface` that
-     *                                                                combines the values of the current `AccessibleCollectionInterface`
-     *                                                                with the provided `iterable`.
+     *                                                                combines the values of the current
+     *                                                                `AccessibleCollectionInterface` with
+     *                                                                the provided `iterable`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/CollectionInterface.php
+++ b/src/Psl/Collection/CollectionInterface.php
@@ -66,7 +66,7 @@ interface CollectionInterface extends Countable, IteratorAggregate, JsonSerializ
      *                                 `CollectionInterface` values.
      *
      * @return CollectionInterface<Tk, Tv> A CollectionInterface containing the values after a user-specified
-     *                                 condition is applied.
+     *                                     condition is applied.
      */
     public function filter(callable $fn): CollectionInterface;
 
@@ -85,7 +85,7 @@ interface CollectionInterface extends Countable, IteratorAggregate, JsonSerializ
      *                                     `CollectionInterface` keys and values.
      *
      * @return CollectionInterface<Tk, Tv> A `CollectionInterface` containing the values after a user-specified
-     *                                 condition is applied to the keys and values of the current `CollectionInterface`.
+     *                                     condition is applied to the keys and values of the current `CollectionInterface`.
      */
     public function filterWithKey(callable $fn): CollectionInterface;
 
@@ -105,7 +105,7 @@ interface CollectionInterface extends Countable, IteratorAggregate, JsonSerializ
      *                               `CollectionInterface` values.
      *
      * @return CollectionInterface<Tk, Tu> A `CollectionInterface` containing key/value pairs after
-     *                                 a user-specified operation is applied.
+     *                                     a user-specified operation is applied.
      */
     public function map(callable $fn): CollectionInterface;
 
@@ -126,7 +126,7 @@ interface CollectionInterface extends Countable, IteratorAggregate, JsonSerializ
      *                                   `CollectionInterface` keys and values.
      *
      * @return CollectionInterface<Tk, Tu> A `CollectionInterface` containing the values after a user-specified
-     *                                 operation on the current `CollectionInterface`'s keys and values is applied.
+     *                                     operation on the current `CollectionInterface`'s keys and values is applied.
      */
     public function mapWithKey(callable $fn): CollectionInterface;
 
@@ -145,7 +145,7 @@ interface CollectionInterface extends Countable, IteratorAggregate, JsonSerializ
      *                               elements of this `CollectionInterface`.
      *
      * @return CollectionInterface<Tk, array{0: Tv, 1: Tu}> The `CollectionInterface` that combines
-     *                                 the values of the current `CollectionInterface` with the provided `iterable`.
+     *                                                      the values of the current `CollectionInterface` with the provided `iterable`.
      *
      * @psalm-mutation-free
      */
@@ -164,7 +164,7 @@ interface CollectionInterface extends Countable, IteratorAggregate, JsonSerializ
      *               `CollectionInterface`.
      *
      * @return CollectionInterface<Tk, Tv> A `CollectionInterface` that is a proper subset of the current
-     *                                 `CollectionInterface` up to `n` elements.
+     *                                     `CollectionInterface` up to `n` elements.
      *
      * @psalm-mutation-free
      */
@@ -182,7 +182,7 @@ interface CollectionInterface extends Countable, IteratorAggregate, JsonSerializ
      *                                 condition.
      *
      * @return CollectionInterface<Tk, Tv> A `CollectionInterface` that is a proper subset of the current
-     *                                 `CollectionInterface` up until the callback returns `false`.
+     *                                     `CollectionInterface` up until the callback returns `false`.
      */
     public function takeWhile(callable $fn): CollectionInterface;
 
@@ -199,7 +199,7 @@ interface CollectionInterface extends Countable, IteratorAggregate, JsonSerializ
      *               first one in the returned `CollectionInterface`.
      *
      * @return CollectionInterface<Tk, Tv> A `CollectionInterface` that is a proper subset of the current
-     *                                 `CollectionInterface` containing values after the specified `n`-th element.
+     *                                     `CollectionInterface` containing values after the specified `n`-th element.
      *
      * @psalm-mutation-free
      */
@@ -217,7 +217,7 @@ interface CollectionInterface extends Countable, IteratorAggregate, JsonSerializ
      *                                 returned `CollectionInterface`.
      *
      * @return CollectionInterface<Tk, Tv> A `CollectionInterface` that is a proper subset of the current
-     *                                 `CollectionInterface` starting after the callback returns `true`.
+     *                                     `CollectionInterface` starting after the callback returns `true`.
      */
     public function dropWhile(callable $fn): CollectionInterface;
 
@@ -237,8 +237,8 @@ interface CollectionInterface extends Countable, IteratorAggregate, JsonSerializ
      * @param int $length The length of the returned `CollectionInterface`.
      *
      * @return CollectionInterface<Tk, Tv> A `CollectionInterface` that is a proper subset of the current
-     *                                 `CollectionInterface` starting at `$start` up to but not including
-     *                                 the element `$start + $length`.
+     *                                     `CollectionInterface` starting at `$start` up to but not including
+     *                                     the element `$start + $length`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/CollectionInterface.php
+++ b/src/Psl/Collection/CollectionInterface.php
@@ -85,7 +85,8 @@ interface CollectionInterface extends Countable, IteratorAggregate, JsonSerializ
      *                                     `CollectionInterface` keys and values.
      *
      * @return CollectionInterface<Tk, Tv> A `CollectionInterface` containing the values after a user-specified
-     *                                     condition is applied to the keys and values of the current `CollectionInterface`.
+     *                                     condition is applied to the keys and values of the
+     *                                     current `CollectionInterface`.
      */
     public function filterWithKey(callable $fn): CollectionInterface;
 
@@ -145,7 +146,8 @@ interface CollectionInterface extends Countable, IteratorAggregate, JsonSerializ
      *                               elements of this `CollectionInterface`.
      *
      * @return CollectionInterface<Tk, array{0: Tv, 1: Tu}> The `CollectionInterface` that combines
-     *                                                      the values of the current `CollectionInterface` with the provided `iterable`.
+     *                                                      the values of the current `CollectionInterface` with
+     *                                                      the provided `iterable`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/Map.php
+++ b/src/Psl/Collection/Map.php
@@ -9,7 +9,6 @@ use Psl\Dict;
 use Psl\Iter;
 use Psl\Vec;
 
-use function count;
 
 /**
  * @template Tk of array-key
@@ -272,7 +271,7 @@ final class Map implements MapInterface
      *                                 `Map` values.
      *
      * @return Map<Tk, Tv> A Map containing the values after a user-specified condition
-     *                 is applied.
+     *                     is applied.
      */
     public function filter(callable $fn): Map
     {
@@ -294,7 +293,7 @@ final class Map implements MapInterface
      *                                     `Map` keys and values.
      *
      * @return Map<Tk, Tv> A `Map` containing the values after a user-specified
-     *                 condition is applied to the keys and values of the current `Map`.
+     *                     condition is applied to the keys and values of the current `Map`.
      */
     public function filterWithKey(callable $fn): Map
     {
@@ -317,7 +316,7 @@ final class Map implements MapInterface
      *                               `Map` values.
      *
      * @return Map<Tk, Tu> A `Map` containing key/value pairs after a user-specified
-     *                 operation is applied.
+     *                     operation is applied.
      */
     public function map(callable $fn): Map
     {
@@ -341,7 +340,7 @@ final class Map implements MapInterface
      *                                   `Map` keys and values.
      *
      * @return Map<Tk, Tu> A `Map` containing the values after a user-specified
-     *                 operation on the current `Map`'s keys and values is applied.
+     *                     operation on the current `Map`'s keys and values is applied.
      */
     public function mapWithKey(callable $fn): Map
     {
@@ -363,7 +362,7 @@ final class Map implements MapInterface
      *                               elements of this `Map`.
      *
      * @return Map<Tk, array{0: Tv, 1: Tu}> The `Map` that combines the values of the current
-     *                 `Map` with the provided `iterable`.
+     *                                      `Map` with the provided `iterable`.
      *
      * @psalm-mutation-free
      */
@@ -412,7 +411,7 @@ final class Map implements MapInterface
      * @throws Psl\Exception\InvariantViolationException If $n is negative.
      *
      * @return Map<Tk, Tv> A `Map` that is a proper subset of the current
-     *                 `Map` up to `n` elements.
+     *                     `Map` up to `n` elements.
      *
      * @psalm-mutation-free
      */
@@ -433,7 +432,7 @@ final class Map implements MapInterface
      *                                 condition.
      *
      * @return Map<Tk, Tv> A `Map` that is a proper subset of the current
-     *                 `Map` up until the callback returns `false`.
+     *                     `Map` up until the callback returns `false`.
      */
     public function takeWhile(callable $fn): Map
     {
@@ -455,7 +454,7 @@ final class Map implements MapInterface
      * @throws Psl\Exception\InvariantViolationException If $n is negative.
      *
      * @return Map<Tk, Tv> A `Map` that is a proper subset of the current
-     *                 `Map` containing values after the specified `n`-th element.
+     *                     `Map` containing values after the specified `n`-th element.
      *
      * @psalm-mutation-free
      */
@@ -476,7 +475,7 @@ final class Map implements MapInterface
      *                                 returned `Map`.
      *
      * @return Map<Tk, Tv> A `Map` that is a proper subset of the current
-     *                 `Map` starting after the callback returns `true`.
+     *                     `Map` starting after the callback returns `true`.
      */
     public function dropWhile(callable $fn): Map
     {
@@ -499,8 +498,8 @@ final class Map implements MapInterface
      *
      * @throws Psl\Exception\InvariantViolationException If $start or $length are negative.
      *
-     * @return Map<Tk, Tv>  A `Map` that is a proper subset of the current
-     *                 `Map` starting at `$start` up to but not including the element `$start + $length`.
+     * @return Map<Tk, Tv> A `Map` that is a proper subset of the current
+     *                     `Map` starting at `$start` up to but not including the element `$start + $length`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/Map.php
+++ b/src/Psl/Collection/Map.php
@@ -9,7 +9,6 @@ use Psl\Dict;
 use Psl\Iter;
 use Psl\Vec;
 
-
 /**
  * @template Tk of array-key
  * @template Tv

--- a/src/Psl/Collection/MapInterface.php
+++ b/src/Psl/Collection/MapInterface.php
@@ -45,7 +45,7 @@ interface MapInterface extends AccessibleCollectionInterface
      *                                 `MapInterface` values.
      *
      * @return MapInterface<Tk, Tv> A MapInterface containing the values after a user-specified condition
-     *                          is applied.
+     *                              is applied.
      */
     public function filter(callable $fn): MapInterface;
 
@@ -64,7 +64,7 @@ interface MapInterface extends AccessibleCollectionInterface
      *                                     `MapInterface` keys and values.
      *
      * @return MapInterface<Tk, Tv> A `MapInterface` containing the values after a user-specified
-     *                          condition is applied to the keys and values of the current `MapInterface`.
+     *                              condition is applied to the keys and values of the current `MapInterface`.
      */
     public function filterWithKey(callable $fn): MapInterface;
 
@@ -84,7 +84,7 @@ interface MapInterface extends AccessibleCollectionInterface
      *                               `MapInterface` values.
      *
      * @return MapInterface<Tk, Tu> A `MapInterface` containing key/value pairs after a user-specified
-     *                          operation is applied.
+     *                              operation is applied.
      */
     public function map(callable $fn): MapInterface;
 
@@ -105,7 +105,7 @@ interface MapInterface extends AccessibleCollectionInterface
      *                                   `MapInterface` keys and values.
      *
      * @return MapInterface<Tk, Tu> A `MapInterface` containing the values after a user-specified
-     *                          operation on the current `MapInterface`'s keys and values is applied.
+     *                              operation on the current `MapInterface`'s keys and values is applied.
      */
     public function mapWithKey(callable $fn): MapInterface;
 
@@ -178,7 +178,7 @@ interface MapInterface extends AccessibleCollectionInterface
      *                               elements of this `MapInterface`.
      *
      * @return MapInterface<Tk, array{0: Tv, 1: Tu}> - The `MapInterface` that combines the values of the current
-     *                          `MapInterface` with the provided `iterable`.
+     *                                               `MapInterface` with the provided `iterable`.
      *
      * @psalm-mutation-free
      */
@@ -197,7 +197,7 @@ interface MapInterface extends AccessibleCollectionInterface
      *               `MapInterface`.
      *
      * @return MapInterface<Tk, Tv> A `MapInterface` that is a proper subset of the current
-     *                          `MapInterface` up to `n` elements.
+     *                              `MapInterface` up to `n` elements.
      *
      * @psalm-mutation-free
      */
@@ -215,7 +215,7 @@ interface MapInterface extends AccessibleCollectionInterface
      *                                 condition.
      *
      * @return MapInterface<Tk, Tv> A `MapInterface` that is a proper subset of the current
-     *                          `MapInterface` up until the callback returns `false`.
+     *                              `MapInterface` up until the callback returns `false`.
      */
     public function takeWhile(callable $fn): MapInterface;
 
@@ -232,7 +232,7 @@ interface MapInterface extends AccessibleCollectionInterface
      *               first one in the returned `MapInterface`.
      *
      * @return MapInterface<Tk, Tv> - A `MapInterface` that is a proper subset of the current
-     *                          `MapInterface` containing values after the specified `n`-th element.
+     *                              `MapInterface` containing values after the specified `n`-th element.
      *
      * @psalm-mutation-free
      */
@@ -250,7 +250,7 @@ interface MapInterface extends AccessibleCollectionInterface
      *                                 returned `MapInterface`.
      *
      * @return MapInterface<Tk, Tv> A `MapInterface` that is a proper subset of the current
-     *                          `MapInterface` starting after the callback returns `true`.
+     *                              `MapInterface` starting after the callback returns `true`.
      */
     public function dropWhile(callable $fn): MapInterface;
 
@@ -270,8 +270,8 @@ interface MapInterface extends AccessibleCollectionInterface
      * @param int $length The length of the returned `MapInterface`
      *
      * @return MapInterface<Tk, Tv> - A `MapInterface` that is a proper subset of the current
-     *                          `MapInterface` starting at `$start` up to but not including
-     *                          the element `$start + $length`.
+     *                              `MapInterface` starting at `$start` up to but not including
+     *                              the element `$start + $length`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/MutableAccessibleCollectionInterface.php
+++ b/src/Psl/Collection/MutableAccessibleCollectionInterface.php
@@ -196,8 +196,8 @@ interface MutableAccessibleCollectionInterface extends
      *
      * @return MutableAccessibleCollectionInterface<Tk, array{0: Tv, 1: Tu}> The `MutableAccessibleCollectionInterface`
      *                                                                       that combines the values of the current
-     *                                                                       `MutableAccessibleCollectionInterface` with the provided
-     *                                                                       `iterable`.
+     *                                                                       `MutableAccessibleCollectionInterface` with
+     *                                                                       the provided `iterable`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/MutableAccessibleCollectionInterface.php
+++ b/src/Psl/Collection/MutableAccessibleCollectionInterface.php
@@ -56,7 +56,7 @@ interface MutableAccessibleCollectionInterface extends
      *                                 `MutableAccessibleCollectionInterface` values.
      *
      * @return MutableAccessibleCollectionInterface<Tk, Tv> A `MutableAccessibleCollectionInterface` containing
-     *                                                  the values after a user-specified condition is applied.
+     *                                                      the values after a user-specified condition is applied.
      */
     public function filter(callable $fn): MutableAccessibleCollectionInterface;
 
@@ -75,9 +75,9 @@ interface MutableAccessibleCollectionInterface extends
      *                                     `MutableAccessibleCollectionInterface` keys and values.
      *
      * @return MutableAccessibleCollectionInterface<Tk, Tv> A `MutableAccessibleCollectionInterface` containing
-     *                                                  the values after a user-specified condition is applied
-     *                                                  to the keys and values of the current
-     *                                                  `MutableAccessibleCollectionInterface`.
+     *                                                      the values after a user-specified condition is applied
+     *                                                      to the keys and values of the current
+     *                                                      `MutableAccessibleCollectionInterface`.
      */
     public function filterWithKey(callable $fn): MutableAccessibleCollectionInterface;
 
@@ -97,7 +97,7 @@ interface MutableAccessibleCollectionInterface extends
      *                               `MutableAccessibleCollectionInterface` values.
      *
      * @return MutableAccessibleCollectionInterface<Tk, Tu> A `MutableAccessibleCollectionInterface` containing
-     *                                                  key/value pairs after a user-specified operation is applied.
+     *                                                      key/value pairs after a user-specified operation is applied.
      */
     public function map(callable $fn): MutableAccessibleCollectionInterface;
 
@@ -118,9 +118,9 @@ interface MutableAccessibleCollectionInterface extends
      *                                   `MutableAccessibleCollectionInterface` keys and values.
      *
      * @return MutableAccessibleCollectionInterface<Tk, Tu> A `MutableAccessibleCollectionInterface` containing
-     *                                                  the values after a user-specified operation on the current
-     *                                                  `MutableAccessibleCollectionInterface`'s keys and values is
-     *                                                  applied.
+     *                                                      the values after a user-specified operation on the current
+     *                                                      `MutableAccessibleCollectionInterface`'s keys and values is
+     *                                                      applied.
      */
     public function mapWithKey(callable $fn): MutableAccessibleCollectionInterface;
 
@@ -195,9 +195,9 @@ interface MutableAccessibleCollectionInterface extends
      *                               elements of this `MutableAccessibleCollectionInterface`.
      *
      * @return MutableAccessibleCollectionInterface<Tk, array{0: Tv, 1: Tu}> The `MutableAccessibleCollectionInterface`
-     *                                                  that combines the values of the current
-     *                                                  `MutableAccessibleCollectionInterface` with the provided
-     *                                                  `iterable`.
+     *                                                                       that combines the values of the current
+     *                                                                       `MutableAccessibleCollectionInterface` with the provided
+     *                                                                       `iterable`.
      *
      * @psalm-mutation-free
      */
@@ -215,8 +215,8 @@ interface MutableAccessibleCollectionInterface extends
      * @param int $n The last element that will be included in the returned `MutableAccessibleCollectionInterface`.
      *
      * @return MutableAccessibleCollectionInterface<Tk, Tv> A `MutableAccessibleCollectionInterface` that is a proper
-     *                                                  subset of the current `MutableAccessibleCollectionInterface`
-     *                                                  up to `n` elements.
+     *                                                      subset of the current `MutableAccessibleCollectionInterface`
+     *                                                      up to `n` elements.
      *
      * @psalm-mutation-free
      */
@@ -234,8 +234,8 @@ interface MutableAccessibleCollectionInterface extends
      *                                 condition.
      *
      * @return MutableAccessibleCollectionInterface<Tk, Tv> A `MutableAccessibleCollectionInterface` that is a proper
-     *                                                  subset of the current `MutableAccessibleCollectionInterface`
-     *                                                  up until the callback returns `false`.
+     *                                                      subset of the current `MutableAccessibleCollectionInterface`
+     *                                                      up until the callback returns `false`.
      */
     public function takeWhile(callable $fn): MutableAccessibleCollectionInterface;
 
@@ -252,8 +252,8 @@ interface MutableAccessibleCollectionInterface extends
      *               first one in the returned `MutableAccessibleCollectionInterface`.
      *
      * @return MutableAccessibleCollectionInterface<Tk, Tv> A `MutableAccessibleCollectionInterface` that is a proper
-     *                                                  subset of the current `MutableAccessibleCollectionInterface`
-     *                                                  containing values after the specified `n`-th element.
+     *                                                      subset of the current `MutableAccessibleCollectionInterface`
+     *                                                      containing values after the specified `n`-th element.
      *
      * @psalm-mutation-free
      */
@@ -271,8 +271,8 @@ interface MutableAccessibleCollectionInterface extends
      *                                 returned `MutableAccessibleCollectionInterface`.
      *
      * @return MutableAccessibleCollectionInterface<Tk, Tv> A `MutableAccessibleCollectionInterface` that is a proper
-     *                                                  subset of the current `MutableAccessibleCollectionInterface`
-     *                                                  starting after the callback returns `true`.
+     *                                                      subset of the current `MutableAccessibleCollectionInterface`
+     *                                                      starting after the callback returns `true`.
      */
     public function dropWhile(callable $fn): MutableAccessibleCollectionInterface;
 
@@ -291,9 +291,9 @@ interface MutableAccessibleCollectionInterface extends
      * @param int $length The length of the returned `MutableAccessibleCollectionInterface`
      *
      * @return MutableAccessibleCollectionInterface<Tk, Tv> A `MutableAccessibleCollectionInterface` that is a proper
-     *                                                  subset of the current `MutableAccessibleCollectionInterface`
-     *                                                  starting at `$start` up to but not including the element
-     *                                                  `$start + $length`.
+     *                                                      subset of the current `MutableAccessibleCollectionInterface`
+     *                                                      starting at `$start` up to but not including the element
+     *                                                      `$start + $length`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/MutableCollectionInterface.php
+++ b/src/Psl/Collection/MutableCollectionInterface.php
@@ -114,7 +114,8 @@ interface MutableCollectionInterface extends CollectionInterface
      *                               elements of this `MutableCollectionInterface`.
      *
      * @return MutableCollectionInterface<Tk, array{0: Tv, 1: Tu}> The `MutableCollectionInterface` that
-     *                                                             combines the values of the current `MutableCollectionInterface` with
+     *                                                             combines the values of the
+     *                                                             current `MutableCollectionInterface` with
      *                                                             the provided `iterable`.
      *
      * @psalm-mutation-free
@@ -188,7 +189,8 @@ interface MutableCollectionInterface extends CollectionInterface
      *                                 returned `MutableCollectionInterface`.
      *
      * @return MutableCollectionInterface<Tk, Tv> A `MutableCollectionInterface` that is a proper subset of the current
-     *                                            `MutableCollectionInterface` starting after the callback returns `true`.
+     *                                            `MutableCollectionInterface` starting after the callback
+     *                                            returns `true`.
      */
     public function dropWhile(callable $fn): MutableCollectionInterface;
 
@@ -214,7 +216,7 @@ interface MutableCollectionInterface extends CollectionInterface
      * @psalm-mutation-free
      */
     public function slice(int $start, int $length): MutableCollectionInterface;
-    
+
     /**
      * Removes all items from the collection.
      *

--- a/src/Psl/Collection/MutableCollectionInterface.php
+++ b/src/Psl/Collection/MutableCollectionInterface.php
@@ -33,7 +33,7 @@ interface MutableCollectionInterface extends CollectionInterface
      *                                 `MutableCollectionInterface` values.
      *
      * @return MutableCollectionInterface<Tk, Tv> A `MutableCollectionInterface` containing the values
-     *                                        after a user-specified condition is applied.
+     *                                            after a user-specified condition is applied.
      */
     public function filter(callable $fn): MutableCollectionInterface;
 
@@ -52,8 +52,8 @@ interface MutableCollectionInterface extends CollectionInterface
      *                                     `MutableCollectionInterface` keys and values.
      *
      * @return MutableCollectionInterface<Tk, Tv> A `MutableCollectionInterface` containing the values after
-     *                                        a user-specified condition is applied to the keys and values of
-     *                                        the current `MutableCollectionInterface`.
+     *                                            a user-specified condition is applied to the keys and values of
+     *                                            the current `MutableCollectionInterface`.
      */
     public function filterWithKey(callable $fn): MutableCollectionInterface;
 
@@ -73,7 +73,7 @@ interface MutableCollectionInterface extends CollectionInterface
      *                               `MutableCollectionInterface` values.
      *
      * @return MutableCollectionInterface<Tk, Tu> A `MutableCollectionInterface` containing key/value pairs
-     *                                        after a user-specified operation is applied.
+     *                                            after a user-specified operation is applied.
      */
     public function map(callable $fn): MutableCollectionInterface;
 
@@ -94,8 +94,8 @@ interface MutableCollectionInterface extends CollectionInterface
      *                                   `MutableCollectionInterface` keys and values.
      *
      * @return MutableCollectionInterface<Tk, Tu> A `MutableCollectionInterface` containing the values
-     *                                        after a user-specified operation on the current
-     *                                        `MutableCollectionInterface`'s keys and values is applied.
+     *                                            after a user-specified operation on the current
+     *                                            `MutableCollectionInterface`'s keys and values is applied.
      */
     public function mapWithKey(callable $fn): MutableCollectionInterface;
 
@@ -114,8 +114,8 @@ interface MutableCollectionInterface extends CollectionInterface
      *                               elements of this `MutableCollectionInterface`.
      *
      * @return MutableCollectionInterface<Tk, array{0: Tv, 1: Tu}> The `MutableCollectionInterface` that
-     *                                        combines the values of the current `MutableCollectionInterface` with
-     *                                        the provided `iterable`.
+     *                                                             combines the values of the current `MutableCollectionInterface` with
+     *                                                             the provided `iterable`.
      *
      * @psalm-mutation-free
      */
@@ -133,7 +133,7 @@ interface MutableCollectionInterface extends CollectionInterface
      * @param int $n The last element that will be included in the returned `MutableCollectionInterface`.
      *
      * @return MutableCollectionInterface<Tk, Tv> A `MutableCollectionInterface` that is a proper
-     *                                        subset of the current `MutableCollectionInterface` up to `n` elements.
+     *                                            subset of the current `MutableCollectionInterface` up to `n` elements.
      *
      * @psalm-mutation-free
      */
@@ -151,8 +151,8 @@ interface MutableCollectionInterface extends CollectionInterface
      *                                 condition.
      *
      * @return MutableCollectionInterface<Tk, Tv> A `MutableCollectionInterface` that is a proper
-     *                                        subset of the current `MutableCollectionInterface` up until
-     *                                        the callback returns `false`.
+     *                                            subset of the current `MutableCollectionInterface` up until
+     *                                            the callback returns `false`.
      */
     public function takeWhile(callable $fn): MutableCollectionInterface;
 
@@ -169,8 +169,8 @@ interface MutableCollectionInterface extends CollectionInterface
      *               first one in the returned `MutableCollectionInterface`.
      *
      * @return MutableCollectionInterface<Tk, Tv> A `MutableCollectionInterface` that is a proper
-     *                                        subset of the current `MutableCollectionInterface` containing values
-     *                                        after the specified `n`-th element.
+     *                                            subset of the current `MutableCollectionInterface` containing values
+     *                                            after the specified `n`-th element.
      *
      * @psalm-mutation-free
      */
@@ -188,7 +188,7 @@ interface MutableCollectionInterface extends CollectionInterface
      *                                 returned `MutableCollectionInterface`.
      *
      * @return MutableCollectionInterface<Tk, Tv> A `MutableCollectionInterface` that is a proper subset of the current
-     *                                        `MutableCollectionInterface` starting after the callback returns `true`.
+     *                                            `MutableCollectionInterface` starting after the callback returns `true`.
      */
     public function dropWhile(callable $fn): MutableCollectionInterface;
 
@@ -208,8 +208,8 @@ interface MutableCollectionInterface extends CollectionInterface
      * @param int $length The length of the returned `MutableCollectionInterface`.
      *
      * @return MutableCollectionInterface<Tk, Tv> A `MutableCollectionInterface` that is a proper
-     *                                        subset of the current `MutableCollectionInterface` starting
-     *                                        at `$start` up to but not including the element `$start + $length`.
+     *                                            subset of the current `MutableCollectionInterface` starting
+     *                                            at `$start` up to but not including the element `$start + $length`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/MutableMap.php
+++ b/src/Psl/Collection/MutableMap.php
@@ -495,7 +495,8 @@ final class MutableMap implements MutableMapInterface
      * @throws Psl\Exception\InvariantViolationException If $start or $len are negative.
      *
      * @return MutableMap<Tk, Tv> A `MutableMap` that is a proper subset of the current
-     *                            `MutableMap` starting at `$start` up to but not including the element `$start + $length`.
+     *                            `MutableMap` starting at `$start` up to but not including the
+     *                            element `$start + $length`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/MutableMap.php
+++ b/src/Psl/Collection/MutableMap.php
@@ -268,7 +268,7 @@ final class MutableMap implements MutableMapInterface
      *                                 `MutableMap` values.
      *
      * @return MutableMap<Tk, Tv> A MutableMap containing the values after a user-specified condition
-     *                        is applied.
+     *                            is applied.
      */
     public function filter(callable $fn): MutableMap
     {
@@ -290,7 +290,7 @@ final class MutableMap implements MutableMapInterface
      *                                     `MutableMap` keys and values.
      *
      * @return MutableMap<Tk, Tv> A `MutableMap` containing the values after a user-specified
-     *                        condition is applied to the keys and values of the current `MutableMap`.
+     *                            condition is applied to the keys and values of the current `MutableMap`.
      */
     public function filterWithKey(callable $fn): MutableMap
     {
@@ -313,7 +313,7 @@ final class MutableMap implements MutableMapInterface
      *                               `MutableMap` values.
      *
      * @return MutableMap<Tk, Tu> A `MutableMap` containing key/value pairs after a user-specified
-     *                        operation is applied.
+     *                            operation is applied.
      */
     public function map(callable $fn): MutableMap
     {
@@ -337,7 +337,7 @@ final class MutableMap implements MutableMapInterface
      *                                   `MutableMap` keys and values.
      *
      * @return MutableMap<Tk, Tu> A `MutableMap` containing the values after a user-specified
-     *                        operation on the current `MutableMap`'s keys and values is applied.
+     *                            operation on the current `MutableMap`'s keys and values is applied.
      */
     public function mapWithKey(callable $fn): MutableMap
     {
@@ -359,7 +359,7 @@ final class MutableMap implements MutableMapInterface
      *                               elements of this `MutableMap`.
      *
      * @return MutableMap<Tk, array{0: Tv, 1: Tu}> A `MutableMap` that combines the values of the current
-     *                        `MutableMap` with the provided `iterable`.
+     *                                             `MutableMap` with the provided `iterable`.
      *
      * @psalm-mutation-free
      */
@@ -405,7 +405,7 @@ final class MutableMap implements MutableMapInterface
      * @throws Psl\Exception\InvariantViolationException If $n is negative.
      *
      * @return MutableMap<Tk, Tv> A `MutableMap` that is a proper subset of the current
-     *                        `MutableMap` up to `n` elements.
+     *                            `MutableMap` up to `n` elements.
      *
      * @psalm-mutation-free
      */
@@ -426,7 +426,7 @@ final class MutableMap implements MutableMapInterface
      *                                 condition.
      *
      * @return MutableMap<Tk, Tv> A `MutableMap` that is a proper subset of the current
-     *                        `MutableMap` up until the callback returns `false`.
+     *                            `MutableMap` up until the callback returns `false`.
      */
     public function takeWhile(callable $fn): MutableMap
     {
@@ -448,7 +448,7 @@ final class MutableMap implements MutableMapInterface
      * @throws Psl\Exception\InvariantViolationException If $n is negative.
      *
      * @return MutableMap<Tk, Tv> A `MutableMap` that is a proper subset of the current
-     *                        `MutableMap` containing values after the specified `n`-th element.
+     *                            `MutableMap` containing values after the specified `n`-th element.
      *
      * @psalm-mutation-free
      */
@@ -470,7 +470,7 @@ final class MutableMap implements MutableMapInterface
      *                                 returned `MutableMap`.
      *
      * @return MutableMap<Tk, Tv> A `MutableMap` that is a proper subset of the current
-     *                        `MutableMap` starting after the callback returns `true`.
+     *                            `MutableMap` starting after the callback returns `true`.
      */
     public function dropWhile(callable $fn): MutableMap
     {
@@ -495,7 +495,7 @@ final class MutableMap implements MutableMapInterface
      * @throws Psl\Exception\InvariantViolationException If $start or $len are negative.
      *
      * @return MutableMap<Tk, Tv> A `MutableMap` that is a proper subset of the current
-     *                        `MutableMap` starting at `$start` up to but not including the element `$start + $length`.
+     *                            `MutableMap` starting at `$start` up to but not including the element `$start + $length`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/MutableMapInterface.php
+++ b/src/Psl/Collection/MutableMapInterface.php
@@ -46,7 +46,7 @@ interface MutableMapInterface extends MapInterface, MutableAccessibleCollectionI
      *                                 `MutableMapInterface` values.
      *
      * @return MutableMapInterface<Tk, Tv> - a MutableMapInterface containing the values after a user-specified
-     *                                 condition is applied.
+     *                                     condition is applied.
      */
     public function filter(callable $fn): MutableMapInterface;
 
@@ -65,7 +65,7 @@ interface MutableMapInterface extends MapInterface, MutableAccessibleCollectionI
      *                                     the current `MutableMapInterface` keys and values.
      *
      * @return MutableMapInterface<Tk, Tv> - a `MutableMapInterface` containing the values after a user-specified
-     *                                 condition is applied to the keys and values of the current `MutableMapInterface`.
+     *                                     condition is applied to the keys and values of the current `MutableMapInterface`.
      */
     public function filterWithKey(callable $fn): MutableMapInterface;
 
@@ -85,7 +85,7 @@ interface MutableMapInterface extends MapInterface, MutableAccessibleCollectionI
      *                               `MutableMapInterface` values.
      *
      * @return MutableMapInterface<Tk, Tu> - a `MutableMapInterface` containing key/value pairs after
-     *                                 a user-specified operation is applied.
+     *                                     a user-specified operation is applied.
      */
     public function map(callable $fn): MutableMapInterface;
 
@@ -106,7 +106,7 @@ interface MutableMapInterface extends MapInterface, MutableAccessibleCollectionI
      *                                   `MutableMapInterface` keys and values.
      *
      * @return MutableMapInterface<Tk, Tu> A `MutableMapInterface` containing the values after a user-specified
-     *                                 operation on the current `MutableMapInterface`'s keys and values is applied.
+     *                                     operation on the current `MutableMapInterface`'s keys and values is applied.
      */
     public function mapWithKey(callable $fn): MutableMapInterface;
 
@@ -179,7 +179,7 @@ interface MutableMapInterface extends MapInterface, MutableAccessibleCollectionI
      *                               elements of this `MutableMapInterface`.
      *
      * @return MutableMapInterface<Tk, array{0: Tv, 1: Tu}> - The `MutableMapInterface` that combines
-     *                                 the values of the current `MutableMapInterface` with the provided `iterable`.
+     *                                                      the values of the current `MutableMapInterface` with the provided `iterable`.
      *
      * @psalm-mutation-free
      */
@@ -197,7 +197,7 @@ interface MutableMapInterface extends MapInterface, MutableAccessibleCollectionI
      * @param int $n The last element that will be included in the returned `MutableMapInterface`.
      *
      * @return MutableMapInterface<Tk, Tv> A `MutableMapInterface` that is a proper subset of the current
-     *                                 `MutableMapInterface` up to `n` elements.
+     *                                     `MutableMapInterface` up to `n` elements.
      *
      * @psalm-mutation-free
      */
@@ -214,7 +214,7 @@ interface MutableMapInterface extends MapInterface, MutableAccessibleCollectionI
      * @param (callable(Tv): bool) $fn The callback that is used to determine the stopping condition.
      *
      * @return MutableMapInterface<Tk, Tv> A `MutableMapInterface` that is a proper subset of the current
-     *                                 `MutableMapInterface` up until the callback returns `false`.
+     *                                     `MutableMapInterface` up until the callback returns `false`.
      */
     public function takeWhile(callable $fn): MutableMapInterface;
 
@@ -231,7 +231,7 @@ interface MutableMapInterface extends MapInterface, MutableAccessibleCollectionI
      *               the returned `MutableMapInterface`.
      *
      * @return MutableMapInterface<Tk, Tv> A `MutableMapInterface` that is a proper subset of the current
-     *                                 `MutableMapInterface` containing values after the specified `n`-th element.
+     *                                     `MutableMapInterface` containing values after the specified `n`-th element.
      *
      * @psalm-mutation-free
      */
@@ -249,7 +249,7 @@ interface MutableMapInterface extends MapInterface, MutableAccessibleCollectionI
      *                                 returned `MutableMapInterface`.
      *
      * @return MutableMapInterface<Tk, Tv> A `MutableMapInterface` that is a proper subset of the current
-     *                                 `MutableMapInterface` starting after the callback returns `true`.
+     *                                     `MutableMapInterface` starting after the callback returns `true`.
      */
     public function dropWhile(callable $fn): MutableMapInterface;
 
@@ -269,8 +269,8 @@ interface MutableMapInterface extends MapInterface, MutableAccessibleCollectionI
      * @param int $length The length of the returned `MutableMapInterface`.
      *
      * @return MutableMapInterface<Tk, Tv> - A `MutableMapInterface` that is a proper subset of the current
-     *                                 `MutableMapInterface` starting at `$start` up to but not including
-     *                                 the element `$start + $length`.
+     *                                     `MutableMapInterface` starting at `$start` up to but not including
+     *                                     the element `$start + $length`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/MutableMapInterface.php
+++ b/src/Psl/Collection/MutableMapInterface.php
@@ -65,7 +65,8 @@ interface MutableMapInterface extends MapInterface, MutableAccessibleCollectionI
      *                                     the current `MutableMapInterface` keys and values.
      *
      * @return MutableMapInterface<Tk, Tv> - a `MutableMapInterface` containing the values after a user-specified
-     *                                     condition is applied to the keys and values of the current `MutableMapInterface`.
+     *                                     condition is applied to the keys and values of the
+     *                                     current `MutableMapInterface`.
      */
     public function filterWithKey(callable $fn): MutableMapInterface;
 
@@ -179,7 +180,8 @@ interface MutableMapInterface extends MapInterface, MutableAccessibleCollectionI
      *                               elements of this `MutableMapInterface`.
      *
      * @return MutableMapInterface<Tk, array{0: Tv, 1: Tu}> - The `MutableMapInterface` that combines
-     *                                                      the values of the current `MutableMapInterface` with the provided `iterable`.
+     *                                                      the values of the current `MutableMapInterface` with
+     *                                                      the provided `iterable`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/MutableVector.php
+++ b/src/Psl/Collection/MutableVector.php
@@ -482,7 +482,7 @@ final class MutableVector implements MutableVectorInterface
      *                               elements of this `MutableVector`.
      *
      * @return MutableVector<array{0: T, 1: Tu}> The `MutableVector` that combines the values of the current
-     *                                `MutableVector` with the provided `iterable`.
+     *                                           `MutableVector` with the provided `iterable`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/MutableVectorInterface.php
+++ b/src/Psl/Collection/MutableVectorInterface.php
@@ -189,8 +189,8 @@ interface MutableVectorInterface extends MutableAccessibleCollectionInterface, V
      *                               elements of this `MutableVectorInterface`.
      *
      * @return MutableVectorInterface<array{0: T, 1: Tu}> - The `MutableVectorInterface` that combines the
-     *                                         values of the current `MutableVectorInterface` with the provided
-     *                                         `iterable`.
+     *                                                    values of the current `MutableVectorInterface` with the provided
+     *                                                    `iterable`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/MutableVectorInterface.php
+++ b/src/Psl/Collection/MutableVectorInterface.php
@@ -189,8 +189,8 @@ interface MutableVectorInterface extends MutableAccessibleCollectionInterface, V
      *                               elements of this `MutableVectorInterface`.
      *
      * @return MutableVectorInterface<array{0: T, 1: Tu}> - The `MutableVectorInterface` that combines the
-     *                                                    values of the current `MutableVectorInterface` with the provided
-     *                                                    `iterable`.
+     *                                                    values of the current `MutableVectorInterface` with
+     *                                                    the provided `iterable`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/Vector.php
+++ b/src/Psl/Collection/Vector.php
@@ -364,7 +364,7 @@ final class Vector implements VectorInterface
      *                               elements of this `VectorInterface`.
      *
      * @return Vector<array{0: T, 1: Tu}> The `Vector` that combines the values of the current
-     *                         `Vector` with the provided `iterable`.
+     *                                    `Vector` with the provided `iterable`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Collection/VectorInterface.php
+++ b/src/Psl/Collection/VectorInterface.php
@@ -217,7 +217,7 @@ interface VectorInterface extends AccessibleCollectionInterface
      *                               elements of this `VectorInterface`.
      *
      * @return VectorInterface<array{0: T, 1: Tu}> The `VectorInterface` that combines the values
-     *                                  of the current `VectorInterface` with the provided `iterable`.
+     *                                             of the current `VectorInterface` with the provided `iterable`.
      *
      * @psalm-mutation-free
      */

--- a/src/Psl/Str/Byte/words.php
+++ b/src/Psl/Str/Byte/words.php
@@ -12,7 +12,7 @@ use function str_word_count;
  * @param string|null $characters_list A list of additional characters which will be considered as 'word'
  *
  * @return array<int, string> a dict, where the key is the numeric position of
- *                    the word inside the string and the value is the actual word itself
+ *                            the word inside the string and the value is the actual word itself
  *
  * @pure
  */

--- a/src/Psl/Type/Internal/ArrayKeyType.php
+++ b/src/Psl/Type/Internal/ArrayKeyType.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Psl\Type\Internal;
 
+use function is_int;
+use function is_string;
+
 /**
  * @extends UnionType<string, int>
  *
@@ -15,6 +18,31 @@ final class ArrayKeyType extends UnionType
     {
         /** @psalm-suppress MissingThrowsDocblock */
         parent::__construct(new StringType(), new IntType());
+    }
+
+    public function matches(mixed $value): bool
+    {
+        return is_string($value) || is_int($value);
+    }
+
+    public function assert(mixed $value): mixed
+    {
+        // happy path performance optimization:
+        if (is_string($value) || is_int($value)) {
+            return $value;
+        }
+
+        return parent::assert($value);
+    }
+
+    public function coerce(mixed $value): mixed
+    {
+        // happy path performance optimization:
+        if (is_string($value) || is_int($value)) {
+            return $value;
+        }
+
+        return parent::coerce($value);
     }
 
     public function toString(): string

--- a/src/Psl/Type/Internal/DictType.php
+++ b/src/Psl/Type/Internal/DictType.php
@@ -84,7 +84,7 @@ final class DictType extends Type\Type
             $trace->withFrame('dict<' . $this->key_type->toString() . ', _>')
         );
         $value_type = $this->value_type->withTrace(
-            $trace->withFrame('dict<_, ' . $this->value_type->toString() . ', _>')
+            $trace->withFrame('dict<_, ' . $this->value_type->toString() . '>')
         );
 
         $result = [];

--- a/src/Psl/Type/Internal/DictType.php
+++ b/src/Psl/Type/Internal/DictType.php
@@ -80,8 +80,12 @@ final class DictType extends Type\Type
         }
 
         $trace = $this->getTrace();
-        $key_type = $this->key_type->withTrace($trace->withFrame('dict<' . $this->key_type->toString() . ', _>'));
-        $value_type = $this->value_type->withTrace($trace->withFrame('dict<_, ' . $this->value_type->toString() . ', _>'));
+        $key_type = $this->key_type->withTrace(
+            $trace->withFrame('dict<' . $this->key_type->toString() . ', _>')
+        );
+        $value_type = $this->value_type->withTrace(
+            $trace->withFrame('dict<_, ' . $this->value_type->toString() . ', _>')
+        );
 
         $result = [];
 

--- a/src/Psl/Type/Internal/DictType.php
+++ b/src/Psl/Type/Internal/DictType.php
@@ -51,7 +51,7 @@ final class DictType extends Type\Type
 
         $trace = $this->getTrace();
         $key_type = $this->key_type->withTrace($trace->withFrame('dict<' . $this->key_type->toString() . ', _>'));
-        $value_type = $this->value_type->withTrace($trace->withFrame('dict<_, ' . $this->value_type->toString() . ', _>'));
+        $value_type = $this->value_type->withTrace($trace->withFrame('dict<_, ' . $this->value_type->toString() . '>'));
 
         $result = [];
 

--- a/src/Psl/Type/Internal/IntType.php
+++ b/src/Psl/Type/Internal/IntType.php
@@ -7,8 +7,8 @@ namespace Psl\Type\Internal;
 use Psl\Type;
 use Psl\Type\Exception\AssertException;
 use Psl\Type\Exception\CoercionException;
-
 use Stringable;
+
 use function is_float;
 use function is_int;
 use function is_string;

--- a/src/Psl/Type/Internal/IntType.php
+++ b/src/Psl/Type/Internal/IntType.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Psl\Type\Internal;
 
-use Psl\Str;
 use Psl\Type;
 use Psl\Type\Exception\AssertException;
 use Psl\Type\Exception\CoercionException;
 
+use Stringable;
 use function is_float;
 use function is_int;
-use function is_object;
 use function is_string;
+use function ltrim;
 
 /**
  * @extends Type\Type<int>
@@ -38,30 +38,29 @@ final class IntType extends Type\Type
             return $value;
         }
 
-        if (is_string($value) || (is_object($value) && method_exists($value, '__toString'))) {
+        if (is_float($value)) {
+            $integer_value = (int) $value;
+            if (((float) $integer_value) === $value) {
+                return $integer_value;
+            }
+        }
+
+        if (is_string($value) || $value instanceof Stringable) {
             $str = (string)$value;
-            $int = Str\to_int($str);
-            if (null !== $int) {
+            $int = (int)$str;
+            if ($str === (string) $int) {
                 return $int;
             }
 
-            $trimmed = Str\trim_left($str, '0');
-            $int     = Str\to_int($trimmed);
-            if (null !== $int) {
+            $trimmed = ltrim($str, '0');
+            $int     = (int) $trimmed;
+            if ($trimmed === (string) $int) {
                 return $int;
             }
 
             // Exceptional case "000" -(trim)-> "", but we want to return 0
             if ('' === $trimmed && '' !== $str) {
                 return 0;
-            }
-        }
-
-        if (is_float($value)) {
-            $integer_value = (int) $value;
-            $reconstructed = (float) $integer_value;
-            if ($reconstructed === $value) {
-                return $integer_value;
             }
         }
 

--- a/src/Psl/Type/Internal/NonEmptyStringType.php
+++ b/src/Psl/Type/Internal/NonEmptyStringType.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Psl\Type\Internal;
 
-use Psl\Str;
 use Psl\Type;
 use Psl\Type\Exception\AssertException;
 use Psl\Type\Exception\CoercionException;
+use Stringable;
 
 use function is_int;
-use function is_object;
 use function is_string;
 
 /**
@@ -25,7 +24,8 @@ final class NonEmptyStringType extends Type\Type
      */
     public function matches(mixed $value): bool
     {
-        return is_string($value) && !Str\is_empty($value);
+        return '' !== $value
+            && is_string($value);
     }
 
     /**
@@ -35,20 +35,17 @@ final class NonEmptyStringType extends Type\Type
      */
     public function coerce(mixed $value): string
     {
-        if (is_string($value) && !Str\is_empty($value)) {
+        if ('' !== $value && is_string($value)) {
             return $value;
         }
 
         if (is_int($value)) {
-            $str = (string) $value;
-            if (!Str\is_empty($str)) {
-                return $str;
-            }
+            return (string) $value;
         }
 
-        if (is_object($value) && method_exists($value, '__toString')) {
-            $str = (string)$value;
-            if (!Str\is_empty($str)) {
+        if ($value instanceof Stringable) {
+            $str = (string) $value;
+            if ('' !== $str) {
                 return $str;
             }
         }
@@ -65,7 +62,7 @@ final class NonEmptyStringType extends Type\Type
      */
     public function assert(mixed $value): string
     {
-        if (is_string($value) && !Str\is_empty($value)) {
+        if ('' !== $value && is_string($value)) {
             return $value;
         }
 

--- a/src/Psl/Type/Internal/NonEmptyStringType.php
+++ b/src/Psl/Type/Internal/NonEmptyStringType.php
@@ -36,7 +36,7 @@ final class NonEmptyStringType extends Type\Type
     public function coerce(mixed $value): string
     {
         if ('' !== $value && is_string($value)) {
-            /** @psalm-var non-empty-string $value */
+            /** @var non-empty-string $value */
             return $value;
         }
 
@@ -64,7 +64,7 @@ final class NonEmptyStringType extends Type\Type
     public function assert(mixed $value): string
     {
         if ('' !== $value && is_string($value)) {
-            /** @psalm-var non-empty-string $value */
+            /** @var non-empty-string $value */
             return $value;
         }
 

--- a/src/Psl/Type/Internal/NonEmptyStringType.php
+++ b/src/Psl/Type/Internal/NonEmptyStringType.php
@@ -36,6 +36,7 @@ final class NonEmptyStringType extends Type\Type
     public function coerce(mixed $value): string
     {
         if ('' !== $value && is_string($value)) {
+            /** @psalm-var non-empty-string $value */
             return $value;
         }
 
@@ -63,6 +64,7 @@ final class NonEmptyStringType extends Type\Type
     public function assert(mixed $value): string
     {
         if ('' !== $value && is_string($value)) {
+            /** @psalm-var non-empty-string $value */
             return $value;
         }
 

--- a/src/Psl/Type/Internal/ShapeType.php
+++ b/src/Psl/Type/Internal/ShapeType.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Psl\Type\Internal;
 
 use Psl\Iter;
-use Psl\Str;
 use Psl\Type;
 use Psl\Type\Exception\AssertException;
 use Psl\Type\Exception\CoercionException;
@@ -27,7 +26,9 @@ use function is_iterable;
  */
 final class ShapeType extends Type\Type
 {
-    /** @var array<Tk, Type\TypeInterface<Tv>> */
+    /**
+     * @var array<Tk, Type\TypeInterface<Tv>>
+     */
     private array $requiredElements;
 
     /**
@@ -83,7 +84,7 @@ final class ShapeType extends Type\Type
             $coerced[$key] = $additionalValue;
         }
 
-        /** @psalm-var array<Tk, Tv> $coerced type inference is broken by additional (unknown) fields */
+        /** @var array<Tk, Tv> $coerced type inference is broken by additional (unknown) fields */
         return $coerced;
     }
 

--- a/src/Psl/Type/Internal/ShapeType.php
+++ b/src/Psl/Type/Internal/ShapeType.php
@@ -47,14 +47,12 @@ final class ShapeType extends Type\Type
             return $this->coerceIterable($value);
         }
 
-        $requiredValues = \array_intersect_key($value, $this->requiredElements);
-
-        if (\array_keys($requiredValues) !== \array_keys($this->requiredElements)) {
+        if (\array_keys(\array_intersect_key($value, $this->requiredElements)) !== \array_keys($this->requiredElements)) {
             // Fallback to slow implementation - unhappy path
             return $this->coerceIterable($value);
         }
 
-        if (\array_keys($value) !== \array_keys($this->elements_types) && ! $this->allow_unknown_fields) {
+        if (! $this->allow_unknown_fields && \array_keys($value) !== \array_keys($this->elements_types)) {
             // Fallback to slow implementation - unhappy path
             return $this->coerceIterable($value);
         }
@@ -65,7 +63,7 @@ final class ShapeType extends Type\Type
             foreach (\array_intersect_key($this->elements_types, $value) as $key => $type) {
                 $coerced[$key] = $type->coerce($value[$key]);
             }
-        } catch (CoercionException $failed) {
+        } catch (CoercionException) {
             // Fallback to slow implementation - unhappy path. Prevents having to eagerly compute traces.
             $this->coerceIterable($value);
         }

--- a/src/Psl/Type/Internal/ShapeType.php
+++ b/src/Psl/Type/Internal/ShapeType.php
@@ -77,10 +77,13 @@ final class ShapeType extends Type\Type
             $this->coerceIterable($value);
         }
 
+        /** @var mixed $additionalValue */
         foreach (array_diff_key($value, $this->elements_types) as $key => $additionalValue) {
+            /** @psalm-suppress MixedAssignment type inference is broken by additional (unknown) fields */
             $coerced[$key] = $additionalValue;
         }
 
+        /** @psalm-var array<Tk, Tv> $coerced type inference is broken by additional (unknown) fields */
         return $coerced;
     }
 
@@ -223,7 +226,7 @@ final class ShapeType extends Type\Type
 
         return [
             $trace,
-            $type->withTrace($trace)
+            $type->withTrace($trace),
         ];
     }
 }

--- a/src/Psl/Type/Internal/ShapeType.php
+++ b/src/Psl/Type/Internal/ShapeType.php
@@ -18,7 +18,7 @@ use Psl\Type\Exception\CoercionException;
  */
 final class ShapeType extends Type\Type
 {
-    /** @var array<string, null> */
+    /** @var array<Tk, Type\TypeInterface<Tv>> */
     private array $requiredElements;
 
     /**

--- a/src/Psl/Type/Internal/ShapeType.php
+++ b/src/Psl/Type/Internal/ShapeType.php
@@ -59,19 +59,22 @@ final class ShapeType extends Type\Type
             return $this->coerceIterable($value);
         }
 
-        $validatedValues = \array_intersect_key($value, $this->elements_types);
-        $allValues = $value;
+        $coerced = [];
 
         try {
-            foreach ($validatedValues as $key => $validatedValue) {
-                $allValues[$key] = $this->elements_types[$key]->coerce($validatedValue);
+            foreach (\array_intersect_key($this->elements_types, $value) as $key => $type) {
+                $coerced[$key] = $type->coerce($value[$key]);
             }
         } catch (CoercionException $failed) {
             // Fallback to slow implementation - unhappy path. Prevents having to eagerly compute traces.
             $this->coerceIterable($value);
         }
 
-        return $allValues;
+        foreach (\array_diff_key($value, $this->elements_types) as $key => $additionalValue) {
+            $coerced[$key] = $additionalValue;
+        }
+
+        return $coerced;
     }
 
     /**

--- a/src/Psl/Type/Internal/ShapeType.php
+++ b/src/Psl/Type/Internal/ShapeType.php
@@ -60,17 +60,18 @@ final class ShapeType extends Type\Type
         }
 
         $validatedValues = \array_intersect_key($value, $this->elements_types);
+        $allValues = $value;
 
         try {
             foreach ($validatedValues as $key => $validatedValue) {
-                $validatedValues[$key] = $this->elements_types[$key]->coerce($validatedValue);
+                $allValues[$key] = $this->elements_types[$key]->coerce($validatedValue);
             }
         } catch (CoercionException $failed) {
             // Fallback to slow implementation - unhappy path. Prevents having to eagerly compute traces.
             $this->coerceIterable($value);
         }
 
-        return array_merge($value, $validatedValues);
+        return $allValues;
     }
 
     /**

--- a/src/Psl/Type/Internal/StringType.php
+++ b/src/Psl/Type/Internal/StringType.php
@@ -8,8 +8,8 @@ use Psl\Type;
 use Psl\Type\Exception\AssertException;
 use Psl\Type\Exception\CoercionException;
 
+use Stringable;
 use function is_int;
-use function is_object;
 use function is_string;
 
 /**
@@ -36,12 +36,8 @@ final class StringType extends Type\Type
             return $value;
         }
 
-        if (is_int($value)) {
-            return (string)$value;
-        }
-
-        if (is_object($value) && method_exists($value, '__toString')) {
-            return (string)$value;
+        if (is_int($value) || $value instanceof Stringable) {
+            return (string) $value;
         }
 
         throw CoercionException::withValue($value, $this->toString(), $this->getTrace());

--- a/src/Psl/Type/Internal/StringType.php
+++ b/src/Psl/Type/Internal/StringType.php
@@ -7,8 +7,8 @@ namespace Psl\Type\Internal;
 use Psl\Type;
 use Psl\Type\Exception\AssertException;
 use Psl\Type\Exception\CoercionException;
-
 use Stringable;
+
 use function is_int;
 use function is_string;
 

--- a/src/Psl/Type/Internal/VecType.php
+++ b/src/Psl/Type/Internal/VecType.php
@@ -41,10 +41,6 @@ final class VecType extends Type\Type
             return false;
         }
 
-        if ([] === $value) {
-            return true;
-        }
-
         $index = 0;
         foreach ($value as $k => $v) {
             if ($index !== $k) {

--- a/src/Psl/Type/Internal/VecType.php
+++ b/src/Psl/Type/Internal/VecType.php
@@ -10,6 +10,7 @@ use Psl\Type;
 use Psl\Type\Exception\AssertException;
 use Psl\Type\Exception\CoercionException;
 
+use function is_array;
 use function is_iterable;
 
 /**

--- a/src/Psl/Type/Type.php
+++ b/src/Psl/Type/Type.php
@@ -32,11 +32,8 @@ abstract class Type implements TypeInterface
 
     protected function getTrace(): TypeTrace
     {
-        if (null === $this->trace) {
-            $this->trace = new TypeTrace();
-        }
-
-        return $this->trace;
+        return $this->trace
+            ?? $this->trace = new TypeTrace();
     }
 
     /**

--- a/tests/benchmark/Type/ArrayKeyTypeBench.php
+++ b/tests/benchmark/Type/ArrayKeyTypeBench.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Type;
+
+use Psl\Tests\Benchmark\Type\Asset\ExplicitStringableObject;
+use Psl\Tests\Benchmark\Type\Asset\ImplicitStringableObject;
+use function Psl\Type\array_key;
+
+/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\ArrayKeyType> */
+final class ArrayKeyTypeBench extends GenericTypeBench
+{
+    /** {@inheritDoc} */
+    public function provideHappyPathCoercion(): array
+    {
+        return array_merge(
+            $this->strictlyValidDataSet(),
+            [
+                'instanceof Stringable (explicit)' => [
+                    'type'  => array_key(),
+                    'value' => new ImplicitStringableObject(),
+                ],
+                'instanceof Stringable (implicit)' => [
+                    'type'  => array_key(),
+                    'value' => new ExplicitStringableObject(),
+                ],
+            ]
+        );
+    }
+
+    /** {@inheritDoc} */
+    public function provideHappyPathAssertion(): array
+    {
+        return $this->strictlyValidDataSet();
+    }
+
+    /** {@inheritDoc} */
+    public function provideHappyPathMatches(): array
+    {
+        return $this->strictlyValidDataSet();
+    }
+
+    /** @return array<non-empty-string, array{type: \Psl\Type\Internal\DictType, value: array}> */
+    private function strictlyValidDataSet(): array
+    {
+        return [
+            'string' => [
+                'type'  => array_key(),
+                'value' => 'foo',
+            ],
+            'int'    => [
+                'type'  => array_key(),
+                'value' => 123,
+            ],
+        ];
+    }
+}

--- a/tests/benchmark/Type/ArrayKeyTypeBench.php
+++ b/tests/benchmark/Type/ArrayKeyTypeBench.php
@@ -8,7 +8,7 @@ use Psl\Tests\Benchmark\Type\Asset\ExplicitStringableObject;
 use Psl\Tests\Benchmark\Type\Asset\ImplicitStringableObject;
 use function Psl\Type\array_key;
 
-/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\ArrayKeyType> */
+/** @extends GenericTypeBench<\Psl\Type\TypeInterface<array-key>> */
 final class ArrayKeyTypeBench extends GenericTypeBench
 {
     /** {@inheritDoc} */
@@ -41,7 +41,7 @@ final class ArrayKeyTypeBench extends GenericTypeBench
         return $this->strictlyValidDataSet();
     }
 
-    /** @return array<non-empty-string, array{type: \Psl\Type\Internal\DictType, value: array}> */
+    /** @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<array-key>, value: array-key}> */
     private function strictlyValidDataSet(): array
     {
         return [

--- a/tests/benchmark/Type/ArrayKeyTypeBench.php
+++ b/tests/benchmark/Type/ArrayKeyTypeBench.php
@@ -6,6 +6,7 @@ namespace Psl\Tests\Benchmark\Type;
 
 use Psl\Tests\Benchmark\Type\Asset\ExplicitStringableObject;
 use Psl\Tests\Benchmark\Type\Asset\ImplicitStringableObject;
+
 use function Psl\Type\array_key;
 
 /** @extends GenericTypeBench<\Psl\Type\TypeInterface<array-key>> */

--- a/tests/benchmark/Type/ArrayKeyTypeBench.php
+++ b/tests/benchmark/Type/ArrayKeyTypeBench.php
@@ -11,7 +11,9 @@ use function Psl\Type\array_key;
 /** @extends GenericTypeBench<\Psl\Type\TypeInterface<array-key>> */
 final class ArrayKeyTypeBench extends GenericTypeBench
 {
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathCoercion(): array
     {
         return array_merge(
@@ -29,19 +31,25 @@ final class ArrayKeyTypeBench extends GenericTypeBench
         );
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathAssertion(): array
     {
         return $this->strictlyValidDataSet();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathMatches(): array
     {
         return $this->strictlyValidDataSet();
     }
 
-    /** @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<array-key>, value: array-key}> */
+    /**
+     * @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<array-key>, value: array-key}>
+     */
     private function strictlyValidDataSet(): array
     {
         return [

--- a/tests/benchmark/Type/Asset/ExplicitStringableObject.php
+++ b/tests/benchmark/Type/Asset/ExplicitStringableObject.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Type\Asset;
+
+use Stringable;
+
+final class ExplicitStringableObject implements Stringable
+{
+    public function __toString()
+    {
+        return '123';
+    }
+}

--- a/tests/benchmark/Type/Asset/ImplicitStringableObject.php
+++ b/tests/benchmark/Type/Asset/ImplicitStringableObject.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Type\Asset;
+
+final class ImplicitStringableObject
+{
+    public function __toString()
+    {
+        return '123';
+    }
+}

--- a/tests/benchmark/Type/DictTypeBench.php
+++ b/tests/benchmark/Type/DictTypeBench.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Type;
+
+use ArrayIterator;
+
+use function array_combine;
+use function array_fill;
+use function array_map;
+use function Psl\Type\array_key;
+use function Psl\Type\dict;
+use function Psl\Type\int;
+use function Psl\Type\mixed;
+use function Psl\Type\optional;
+use function Psl\Type\shape;
+use function Psl\Type\string;
+
+/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\DictType> */
+final class DictTypeBench extends GenericTypeBench
+{
+    /** {@inheritDoc} */
+    public function provideHappyPathCoercion(): array
+    {
+        $arraysAndIterables = [];
+
+        foreach ($this->arrayDataSet() as $key => $pair) {
+            $arraysAndIterables[$key . ' array'] = $pair;
+            $arraysAndIterables[$key . ' iterable'] = [
+                'type' => $pair['type'],
+                'value' => new ArrayIterator($pair['value'])
+            ];
+        }
+
+        return $arraysAndIterables;
+    }
+
+    /** {@inheritDoc} */
+    public function provideHappyPathAssertion(): array
+    {
+        $arraysAndIterables = [];
+
+        foreach ($this->arrayDataSet() as $key => $pair) {
+            $arraysAndIterables[$key . ' array'] = $pair;
+        }
+
+        return $arraysAndIterables;
+    }
+
+    /** {@inheritDoc} */
+    public function provideHappyPathMatches(): array
+    {
+        return $this->provideHappyPathAssertion();
+    }
+
+    /** @return array<non-empty-string, array{type: \Psl\Type\Internal\DictType, value: array}> */
+    private function arrayDataSet(): array
+    {
+        return [
+            'generic array, empty' => [
+                'type' => dict(array_key(), mixed()),
+                'value' => [],
+            ],
+            'generic array, non-empty' => [
+                'type' => dict(array_key(), mixed()),
+                'value' => ['foo' => 'bar'],
+            ],
+            'generic array, large' => [
+                'type' => dict(array_key(), mixed()),
+                'value' => array_fill(0, 100, null),
+            ],
+            'int array, empty' => [
+                'type' => dict(int(), mixed()),
+                'value' => [],
+            ],
+            'int array, non-empty' => [
+                'type' => dict(int(), mixed()),
+                'value' => [
+                    'foo',
+                    'bar',
+                    'baz',
+                ],
+            ],
+            'int array, large' => [
+                'type' => dict(int(), mixed()),
+                'value' => array_fill(0, 100, null),
+            ],
+            'map, empty' => [
+                'type' => dict(string(), mixed()),
+                'value' => [],
+            ],
+            'map, non-empty' => [
+                'type' => dict(string(), mixed()),
+                'value' => [
+                    'foo' => 'bar',
+                    'baz' => 'tab',
+                    'taz' => 'tar',
+                ],
+            ],
+            'map, large' => [
+                'type' => dict(string(), mixed()),
+                'value' => array_combine(
+                    array_map(static fn (int $key): string => 'key' . $key, range(0, 99)),
+                    array_fill(0, 100, null),
+                ),
+            ],
+        ];
+    }
+}

--- a/tests/benchmark/Type/DictTypeBench.php
+++ b/tests/benchmark/Type/DictTypeBench.php
@@ -17,7 +17,9 @@ use function Psl\Type\string;
 /** @extends GenericTypeBench<\Psl\Type\TypeInterface<array>> */
 final class DictTypeBench extends GenericTypeBench
 {
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathCoercion(): array
     {
         $arraysAndIterables = [];
@@ -33,7 +35,9 @@ final class DictTypeBench extends GenericTypeBench
         return $arraysAndIterables;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathAssertion(): array
     {
         $arraysAndIterables = [];
@@ -45,7 +49,9 @@ final class DictTypeBench extends GenericTypeBench
         return $arraysAndIterables;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathMatches(): array
     {
         return $this->provideHappyPathAssertion();

--- a/tests/benchmark/Type/DictTypeBench.php
+++ b/tests/benchmark/Type/DictTypeBench.php
@@ -14,7 +14,7 @@ use function Psl\Type\int;
 use function Psl\Type\mixed;
 use function Psl\Type\string;
 
-/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\DictType> */
+/** @extends GenericTypeBench<\Psl\Type\TypeInterface<array>> */
 final class DictTypeBench extends GenericTypeBench
 {
     /** {@inheritDoc} */
@@ -51,7 +51,11 @@ final class DictTypeBench extends GenericTypeBench
         return $this->provideHappyPathAssertion();
     }
 
-    /** @return array<non-empty-string, array{type: \Psl\Type\Internal\DictType, value: array}> */
+    /**
+     * @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<array>, value: array}>
+     *
+     * @psalm-suppress MissingThrowsDocblock this method should never throw
+     */
     private function arrayDataSet(): array
     {
         return [
@@ -98,7 +102,7 @@ final class DictTypeBench extends GenericTypeBench
             'map, large' => [
                 'type' => dict(string(), mixed()),
                 'value' => array_combine(
-                    array_map(static fn (int $key): string => 'key' . $key, range(0, 99)),
+                    array_map(static fn (int $key): string => 'key' . (string) $key, range(0, 99)),
                     array_fill(0, 100, null),
                 ),
             ],

--- a/tests/benchmark/Type/DictTypeBench.php
+++ b/tests/benchmark/Type/DictTypeBench.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psl\Tests\Benchmark\Type;
 
 use ArrayIterator;
+
 use function array_combine;
 use function array_fill;
 use function array_map;

--- a/tests/benchmark/Type/DictTypeBench.php
+++ b/tests/benchmark/Type/DictTypeBench.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Psl\Tests\Benchmark\Type;
 
 use ArrayIterator;
-
 use function array_combine;
 use function array_fill;
 use function array_map;
@@ -13,8 +12,6 @@ use function Psl\Type\array_key;
 use function Psl\Type\dict;
 use function Psl\Type\int;
 use function Psl\Type\mixed;
-use function Psl\Type\optional;
-use function Psl\Type\shape;
 use function Psl\Type\string;
 
 /** @psalm-extends GenericTypeBench<\Psl\Type\Internal\DictType> */

--- a/tests/benchmark/Type/GenericTypeBench.php
+++ b/tests/benchmark/Type/GenericTypeBench.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Benchmark\Type;
 
 use PhpBench\Attributes\ParamProviders;
 
-/** @psalm-template BenchmarkedType of \Psl\Type\TypeInterface */
+/** @template BenchmarkedType of \Psl\Type\TypeInterface */
 abstract class GenericTypeBench
 {
     /**
@@ -20,7 +20,9 @@ abstract class GenericTypeBench
         return $input['type']->coerce($input['value']);
     }
 
-    /** @return array<non-empty-string, array{type: BenchmarkedType, value: mixed}> */
+    /**
+     * @return array<non-empty-string, array{type: BenchmarkedType, value: mixed}>
+     */
     abstract public function provideHappyPathCoercion(): array;
 
     /**
@@ -34,7 +36,9 @@ abstract class GenericTypeBench
         $input['type']->assert($input['value']);
     }
 
-    /** @return array<non-empty-string, array{type: BenchmarkedType, value: mixed}> */
+    /**
+     * @return array<non-empty-string, array{type: BenchmarkedType, value: mixed}>
+     */
     abstract public function provideHappyPathAssertion(): array;
 
     /** @param array{type: BenchmarkedType, value: mixed} $input */
@@ -44,6 +48,8 @@ abstract class GenericTypeBench
         return $input['type']->matches($input['value']);
     }
 
-    /** @return array<non-empty-string, array{type: BenchmarkedType, value: mixed}> */
+    /**
+     * @return array<non-empty-string, array{type: BenchmarkedType, value: mixed}>
+     */
     abstract public function provideHappyPathMatches(): array;
 }

--- a/tests/benchmark/Type/GenericTypeBench.php
+++ b/tests/benchmark/Type/GenericTypeBench.php
@@ -5,37 +5,37 @@ declare(strict_types=1);
 namespace Psl\Tests\Benchmark\Type;
 
 use PhpBench\Attributes\ParamProviders;
-use Psl\Type\TypeInterface;
 
+/** @psalm-type BenchmarkedType of TypeInterface */
 abstract class GenericTypeBench
 {
-    /** @param array{type: TypeInterface, value: mixed} */
+    /** @param array{type: BenchmarkedType, value: mixed} */
     #[ParamProviders('provideHappyPathCoercion')]
     final public function benchCoerce(array $input): mixed
     {
         return $input['type']->coerce($input['value']);
     }
 
-    /** @return array<non-empty-string, array{type: TypeInterface, value: mixed}> */
+    /** @return array<non-empty-string, array{type: BenchmarkedType, value: mixed}> */
     abstract public function provideHappyPathCoercion(): array;
 
-    /** @param array{type: TypeInterface, value: mixed} */
+    /** @param array{type: BenchmarkedType, value: mixed} */
     #[ParamProviders('provideHappyPathAssertion')]
     final public function benchAssert(array $input): void
     {
         $input['type']->assert($input['value']);
     }
 
-    /** @return array<non-empty-string, array{type: TypeInterface, value: mixed}> */
+    /** @return array<non-empty-string, array{type: BenchmarkedType, value: mixed}> */
     abstract public function provideHappyPathAssertion(): array;
 
-    /** @param array{type: TypeInterface, value: mixed} */
+    /** @param array{type: BenchmarkedType, value: mixed} */
     #[ParamProviders('provideHappyPathMatches')]
     final public function benchMatch(array $input): bool
     {
         return $input['type']->matches($input['value']);
     }
 
-    /** @return array<non-empty-string, array{type: TypeInterface, value: mixed}> */
+    /** @return array<non-empty-string, array{type: BenchmarkedType, value: mixed}> */
     abstract public function provideHappyPathMatches(): array;
 }

--- a/tests/benchmark/Type/GenericTypeBench.php
+++ b/tests/benchmark/Type/GenericTypeBench.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Type;
+
+use PhpBench\Attributes\ParamProviders;
+use Psl\Type\TypeInterface;
+
+abstract class GenericTypeBench
+{
+    /** @param array{type: TypeInterface, value: mixed} */
+    #[ParamProviders('provideHappyPathCoercion')]
+    final public function benchCoerce(array $input): mixed
+    {
+        return $input['type']->coerce($input['value']);
+    }
+
+    /** @return array<non-empty-string, array{type: TypeInterface, value: mixed}> */
+    abstract public function provideHappyPathCoercion(): array;
+
+    /** @param array{type: TypeInterface, value: mixed} */
+    #[ParamProviders('provideHappyPathAssertion')]
+    final public function benchAssert(array $input): void
+    {
+        $input['type']->assert($input['value']);
+    }
+
+    /** @return array<non-empty-string, array{type: TypeInterface, value: mixed}> */
+    abstract public function provideHappyPathAssertion(): array;
+
+    /** @param array{type: TypeInterface, value: mixed} */
+    #[ParamProviders('provideHappyPathMatches')]
+    final public function benchMatch(array $input): bool
+    {
+        return $input['type']->matches($input['value']);
+    }
+
+    /** @return array<non-empty-string, array{type: TypeInterface, value: mixed}> */
+    abstract public function provideHappyPathMatches(): array;
+}

--- a/tests/benchmark/Type/GenericTypeBench.php
+++ b/tests/benchmark/Type/GenericTypeBench.php
@@ -6,10 +6,14 @@ namespace Psl\Tests\Benchmark\Type;
 
 use PhpBench\Attributes\ParamProviders;
 
-/** @psalm-type BenchmarkedType of TypeInterface */
+/** @psalm-template BenchmarkedType of \Psl\Type\TypeInterface */
 abstract class GenericTypeBench
 {
-    /** @param array{type: BenchmarkedType, value: mixed} */
+    /**
+     * @param array{type: BenchmarkedType, value: mixed} $input
+     *
+     * @throws \Psl\Type\Exception\CoercionException
+     */
     #[ParamProviders('provideHappyPathCoercion')]
     final public function benchCoerce(array $input): mixed
     {
@@ -19,7 +23,11 @@ abstract class GenericTypeBench
     /** @return array<non-empty-string, array{type: BenchmarkedType, value: mixed}> */
     abstract public function provideHappyPathCoercion(): array;
 
-    /** @param array{type: BenchmarkedType, value: mixed} */
+    /**
+     * @param array{type: BenchmarkedType, value: mixed} $input
+     *
+     * @throws \Psl\Type\Exception\AssertException
+     */
     #[ParamProviders('provideHappyPathAssertion')]
     final public function benchAssert(array $input): void
     {
@@ -29,7 +37,7 @@ abstract class GenericTypeBench
     /** @return array<non-empty-string, array{type: BenchmarkedType, value: mixed}> */
     abstract public function provideHappyPathAssertion(): array;
 
-    /** @param array{type: BenchmarkedType, value: mixed} */
+    /** @param array{type: BenchmarkedType, value: mixed} $input */
     #[ParamProviders('provideHappyPathMatches')]
     final public function benchMatch(array $input): bool
     {

--- a/tests/benchmark/Type/IntTypeBench.php
+++ b/tests/benchmark/Type/IntTypeBench.php
@@ -11,7 +11,9 @@ use function Psl\Type\int;
 /** @extends GenericTypeBench<\Psl\Type\TypeInterface<int>> */
 final class IntTypeBench extends GenericTypeBench
 {
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathCoercion(): array
     {
         return array_merge(
@@ -37,19 +39,25 @@ final class IntTypeBench extends GenericTypeBench
         );
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathAssertion(): array
     {
         return $this->strictlyValidDataSet();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathMatches(): array
     {
         return $this->strictlyValidDataSet();
     }
 
-    /** @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<int>, value: int}> */
+    /**
+     * @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<int>, value: int}>
+     */
     private function strictlyValidDataSet(): array
     {
         return [

--- a/tests/benchmark/Type/IntTypeBench.php
+++ b/tests/benchmark/Type/IntTypeBench.php
@@ -8,7 +8,7 @@ use Psl\Tests\Benchmark\Type\Asset\ExplicitStringableObject;
 use Psl\Tests\Benchmark\Type\Asset\ImplicitStringableObject;
 use function Psl\Type\int;
 
-/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\IntType> */
+/** @extends GenericTypeBench<\Psl\Type\TypeInterface<int>> */
 final class IntTypeBench extends GenericTypeBench
 {
     /** {@inheritDoc} */
@@ -49,7 +49,7 @@ final class IntTypeBench extends GenericTypeBench
         return $this->strictlyValidDataSet();
     }
 
-    /** @return array<non-empty-string, array{type: \Psl\Type\Internal\DictType, value: array}> */
+    /** @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<int>, value: int}> */
     private function strictlyValidDataSet(): array
     {
         return [

--- a/tests/benchmark/Type/IntTypeBench.php
+++ b/tests/benchmark/Type/IntTypeBench.php
@@ -21,6 +21,10 @@ final class IntTypeBench extends GenericTypeBench
                     'type'  => int(),
                     'value' => '123',
                 ],
+                'float' => [
+                    'type'  => int(),
+                    'value' => 123.0,
+                ],
                 'instanceof Stringable (explicit)' => [
                     'type'  => int(),
                     'value' => new ImplicitStringableObject(),

--- a/tests/benchmark/Type/IntTypeBench.php
+++ b/tests/benchmark/Type/IntTypeBench.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Type;
+
+use Psl\Tests\Benchmark\Type\Asset\ExplicitStringableObject;
+use Psl\Tests\Benchmark\Type\Asset\ImplicitStringableObject;
+use function Psl\Type\int;
+
+/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\IntType> */
+final class IntTypeBench extends GenericTypeBench
+{
+    /** {@inheritDoc} */
+    public function provideHappyPathCoercion(): array
+    {
+        return array_merge(
+            $this->strictlyValidDataSet(),
+            [
+                'string' => [
+                    'type'  => int(),
+                    'value' => '123',
+                ],
+                'instanceof Stringable (explicit)' => [
+                    'type'  => int(),
+                    'value' => new ImplicitStringableObject(),
+                ],
+                'instanceof Stringable (implicit)' => [
+                    'type'  => int(),
+                    'value' => new ExplicitStringableObject(),
+                ],
+            ]
+        );
+    }
+
+    /** {@inheritDoc} */
+    public function provideHappyPathAssertion(): array
+    {
+        return $this->strictlyValidDataSet();
+    }
+
+    /** {@inheritDoc} */
+    public function provideHappyPathMatches(): array
+    {
+        return $this->strictlyValidDataSet();
+    }
+
+    /** @return array<non-empty-string, array{type: \Psl\Type\Internal\DictType, value: array}> */
+    private function strictlyValidDataSet(): array
+    {
+        return [
+            'int'    => [
+                'type'  => int(),
+                'value' => 123,
+            ],
+        ];
+    }
+}

--- a/tests/benchmark/Type/IntTypeBench.php
+++ b/tests/benchmark/Type/IntTypeBench.php
@@ -6,6 +6,7 @@ namespace Psl\Tests\Benchmark\Type;
 
 use Psl\Tests\Benchmark\Type\Asset\ExplicitStringableObject;
 use Psl\Tests\Benchmark\Type\Asset\ImplicitStringableObject;
+
 use function Psl\Type\int;
 
 /** @extends GenericTypeBench<\Psl\Type\TypeInterface<int>> */

--- a/tests/benchmark/Type/NonEmptyStringTypeBench.php
+++ b/tests/benchmark/Type/NonEmptyStringTypeBench.php
@@ -6,9 +6,10 @@ namespace Psl\Tests\Benchmark\Type;
 
 use Psl\Tests\Benchmark\Type\Asset\ExplicitStringableObject;
 use Psl\Tests\Benchmark\Type\Asset\ImplicitStringableObject;
+use function Psl\Type\non_empty_string;
 use function Psl\Type\string;
 
-/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\NonEmptyStringType> */
+/** @extends GenericTypeBench<\Psl\Type\TypeInterface<non-empty-string>> */
 final class NonEmptyStringTypeBench extends GenericTypeBench
 {
     /** {@inheritDoc} */
@@ -18,15 +19,15 @@ final class NonEmptyStringTypeBench extends GenericTypeBench
             $this->strictlyValidDataSet(),
             [
                 'int'    => [
-                    'type'  => string(),
+                    'type'  => non_empty_string(),
                     'value' => 123,
                 ],
                 'instanceof Stringable (explicit)' => [
-                    'type'  => string(),
+                    'type'  => non_empty_string(),
                     'value' => new ImplicitStringableObject(),
                 ],
                 'instanceof Stringable (implicit)' => [
-                    'type'  => string(),
+                    'type'  => non_empty_string(),
                     'value' => new ExplicitStringableObject(),
                 ],
             ]
@@ -45,12 +46,12 @@ final class NonEmptyStringTypeBench extends GenericTypeBench
         return $this->strictlyValidDataSet();
     }
 
-    /** @return array<non-empty-string, array{type: \Psl\Type\Internal\DictType, value: array}> */
+    /** @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<non-empty-string>, value: non-empty-string}> */
     private function strictlyValidDataSet(): array
     {
         return [
             'string' => [
-                'type'  => string(),
+                'type'  => non_empty_string(),
                 'value' => 'foo',
             ],
         ];

--- a/tests/benchmark/Type/NonEmptyStringTypeBench.php
+++ b/tests/benchmark/Type/NonEmptyStringTypeBench.php
@@ -12,7 +12,9 @@ use function Psl\Type\string;
 /** @extends GenericTypeBench<\Psl\Type\TypeInterface<non-empty-string>> */
 final class NonEmptyStringTypeBench extends GenericTypeBench
 {
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathCoercion(): array
     {
         return array_merge(
@@ -34,19 +36,25 @@ final class NonEmptyStringTypeBench extends GenericTypeBench
         );
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathAssertion(): array
     {
         return $this->strictlyValidDataSet();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathMatches(): array
     {
         return $this->strictlyValidDataSet();
     }
 
-    /** @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<non-empty-string>, value: non-empty-string}> */
+    /**
+     * @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<non-empty-string>, value: non-empty-string}>
+     */
     private function strictlyValidDataSet(): array
     {
         return [

--- a/tests/benchmark/Type/NonEmptyStringTypeBench.php
+++ b/tests/benchmark/Type/NonEmptyStringTypeBench.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Type;
+
+use Psl\Tests\Benchmark\Type\Asset\ExplicitStringableObject;
+use Psl\Tests\Benchmark\Type\Asset\ImplicitStringableObject;
+use function Psl\Type\string;
+
+/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\NonEmptyStringType> */
+final class NonEmptyStringTypeBench extends GenericTypeBench
+{
+    /** {@inheritDoc} */
+    public function provideHappyPathCoercion(): array
+    {
+        return array_merge(
+            $this->strictlyValidDataSet(),
+            [
+                'int'    => [
+                    'type'  => string(),
+                    'value' => 123,
+                ],
+                'instanceof Stringable (explicit)' => [
+                    'type'  => string(),
+                    'value' => new ImplicitStringableObject(),
+                ],
+                'instanceof Stringable (implicit)' => [
+                    'type'  => string(),
+                    'value' => new ExplicitStringableObject(),
+                ],
+            ]
+        );
+    }
+
+    /** {@inheritDoc} */
+    public function provideHappyPathAssertion(): array
+    {
+        return $this->strictlyValidDataSet();
+    }
+
+    /** {@inheritDoc} */
+    public function provideHappyPathMatches(): array
+    {
+        return $this->strictlyValidDataSet();
+    }
+
+    /** @return array<non-empty-string, array{type: \Psl\Type\Internal\DictType, value: array}> */
+    private function strictlyValidDataSet(): array
+    {
+        return [
+            'string' => [
+                'type'  => string(),
+                'value' => 'foo',
+            ],
+        ];
+    }
+}

--- a/tests/benchmark/Type/NonEmptyStringTypeBench.php
+++ b/tests/benchmark/Type/NonEmptyStringTypeBench.php
@@ -6,6 +6,7 @@ namespace Psl\Tests\Benchmark\Type;
 
 use Psl\Tests\Benchmark\Type\Asset\ExplicitStringableObject;
 use Psl\Tests\Benchmark\Type\Asset\ImplicitStringableObject;
+
 use function Psl\Type\non_empty_string;
 use function Psl\Type\string;
 

--- a/tests/benchmark/Type/ShapeTypeBench.php
+++ b/tests/benchmark/Type/ShapeTypeBench.php
@@ -124,4 +124,64 @@ final class ShapeTypeBench
     {
         return $this->complexShapeWithOptionalValues->coerce($this->validStructureWithFurtherValuesIterable);
     }
+
+    public function benchEmptyShapeMatchAgainstEmptyArray(): bool
+    {
+        return $this->emptyShape->matches([]);
+    }
+
+    public function benchEmptyShapeMatchAgainstEmptyIterable(): bool
+    {
+        return $this->emptyShape->matches($this->emptyIterable);
+    }
+
+    public function benchEmptyShapeMatchAgainstNonEmptyArray(): bool
+    {
+        return $this->emptyShape->matches(self::NON_EMPTY_ARRAY);
+    }
+
+    public function benchEmptyShapeMatchAgainstNonEmptyIterable(): bool
+    {
+        return $this->emptyShape->matches($this->nonEmptyIterable);
+    }
+
+    public function benchComplexShapeMatchAgainstValidStructure(): bool
+    {
+        return $this->complexShapeWithOptionalValues->matches(self::VALID_STRUCTURE);
+    }
+
+    public function benchComplexShapeMatchAgainstValidStructureIterable(): bool
+    {
+        return $this->complexShapeWithOptionalValues->matches($this->validStructureIterable);
+    }
+
+    public function benchComplexShapeMatchAgainstValidStructureWithFurtherValues(): bool
+    {
+        return $this->complexShapeWithOptionalValues->matches(self::VALID_STRUCTURE_WITH_FURTHER_VALUES);
+    }
+
+    public function benchComplexShapeMatchAgainstValidStructureWithFurtherValuesIterable(): bool
+    {
+        return $this->complexShapeWithOptionalValues->matches($this->validStructureWithFurtherValuesIterable);
+    }
+
+    public function benchEmptyShapeAssertionAgainstEmptyArray(): void
+    {
+        $this->emptyShape->assert([]);
+    }
+
+    public function benchEmptyShapeAssertionAgainstNonEmptyArray(): void
+    {
+        $this->emptyShape->assert(self::NON_EMPTY_ARRAY);
+    }
+
+    public function benchComplexShapeAssertionAgainstValidStructure(): void
+    {
+        $this->complexShapeWithOptionalValues->assert(self::VALID_STRUCTURE);
+    }
+
+    public function benchComplexShapeAssertionAgainstValidStructureWithFurtherValues(): void
+    {
+        $this->complexShapeWithOptionalValues->assert(self::VALID_STRUCTURE_WITH_FURTHER_VALUES);
+    }
 }

--- a/tests/benchmark/Type/ShapeTypeBench.php
+++ b/tests/benchmark/Type/ShapeTypeBench.php
@@ -5,183 +5,148 @@ declare(strict_types=1);
 namespace Psl\Tests\Benchmark\Type;
 
 use ArrayIterator;
-use PhpBench\Attributes\BeforeMethods;
 
-use Psl\Type\Exception\CoercionException;
-use Psl\Type\TypeInterface;
 use function Psl\Type\mixed;
 use function Psl\Type\optional;
 use function Psl\Type\shape;
 
-#[BeforeMethods('__construct')]
-final class ShapeTypeBench
+final class ShapeTypeBench extends GenericTypeBench
 {
-    private const NON_EMPTY_ARRAY = ['foo' => 'bar'];
-    private const VALID_STRUCTURE = [
-        'foo' => null,
-        'bar' => null,
-        'baz' => null,
-    ];
-    private const VALID_STRUCTURE_WITH_FURTHER_VALUES = [
-        'foo' => null,
-        'bar' => null,
-        'baz' => null,
-        'tab' => null,
-        'taz' => null,
-        'tar' => null,
-        'waz' => null,
-        'war' => null,
-    ];
-
-    /**
-     * @var TypeInterface<array>
-     */
-    private TypeInterface $emptyShape;
-    /**
-     * @var TypeInterface<array>
-     */
-    private TypeInterface $complexShapeWithOptionalValues;
-    private iterable $emptyIterable;
-    private iterable $nonEmptyIterable;
-    private iterable $validStructureIterable;
-    private iterable $validStructureWithFurtherValuesIterable;
-
-    public function __construct()
+    /** {@inheritDoc} */
+    public function provideHappyPathCoercion(): array
     {
-        $this->emptyShape                     = shape([], true);
-        $this->complexShapeWithOptionalValues = shape([
-            'foo' => mixed(),
-            'bar' => mixed(),
-            'baz' => mixed(),
-            'tab' => optional(mixed()),
-        ], true);
-        $this->emptyIterable = new ArrayIterator([]);
-        $this->nonEmptyIterable = new ArrayIterator(self::NON_EMPTY_ARRAY);
-        $this->validStructureIterable = new ArrayIterator(self::VALID_STRUCTURE);
-        $this->validStructureWithFurtherValuesIterable = new ArrayIterator(self::VALID_STRUCTURE_WITH_FURTHER_VALUES);
+        return [
+            'empty shape, empty array value' => [
+                'type' => shape([], true),
+                'value' => [],
+            ],
+            'empty shape, empty iterable value' => [
+                'type' => shape([], true),
+                'value' => new ArrayIterator([]),
+            ],
+            'empty shape, non-empty array value' => [
+                'type' => shape([], true),
+                'value' => ['foo' => 'bar'],
+            ],
+            'empty shape, non-empty iterable value' => [
+                'type' => shape([], true),
+                'value' => new ArrayIterator(['foo' => 'bar']),
+            ],
+            'complex shape with optional values, minimum array value' => [
+                'type' => shape([
+                    'foo' => mixed(),
+                    'bar' => mixed(),
+                    'baz' => mixed(),
+                    'tab' => optional(mixed()),
+                ], true),
+                'value' => [
+                    'foo' => null,
+                    'bar' => null,
+                    'baz' => null,
+                ],
+            ],
+            'complex shape with optional values, minimum iterable value' => [
+                'type' => shape([
+                    'foo' => mixed(),
+                    'bar' => mixed(),
+                    'baz' => mixed(),
+                    'tab' => optional(mixed()),
+                ], true),
+                'value' => new ArrayIterator([
+                    'foo' => null,
+                    'bar' => null,
+                    'baz' => null,
+                ]),
+            ],
+            'complex shape with optional values, array value with further values' => [
+                'type' => shape([
+                    'foo' => mixed(),
+                    'bar' => mixed(),
+                    'baz' => mixed(),
+                    'tab' => optional(mixed()),
+                ], true),
+                'value' => [
+                    'foo' => null,
+                    'bar' => null,
+                    'baz' => null,
+                    'tab' => null,
+                    'taz' => null,
+                    'tar' => null,
+                    'waz' => null,
+                    'war' => null,
+                ],
+            ],
+            'complex shape with optional values, iterable value with further values' => [
+                'type' => shape([
+                    'foo' => mixed(),
+                    'bar' => mixed(),
+                    'baz' => mixed(),
+                    'tab' => optional(mixed()),
+                ], true),
+                'value' => new ArrayIterator([
+                    'foo' => null,
+                    'bar' => null,
+                    'baz' => null,
+                    'tab' => null,
+                    'taz' => null,
+                    'tar' => null,
+                    'waz' => null,
+                    'war' => null,
+                ]),
+            ],
+        ];
     }
 
-    /**
-     * @throws CoercionException
-     */
-    public function benchEmptyShapeCoercionAgainstEmptyArray(): array
+    /** {@inheritDoc} */
+    public function provideHappyPathAssertion(): array
     {
-        return $this->emptyShape->coerce([]);
+        return [
+            'empty shape, empty array value' => [
+                'type' => shape([], true),
+                'value' => [],
+            ],
+            'empty shape, non-empty array value' => [
+                'type' => shape([], true),
+                'value' => ['foo' => 'bar'],
+            ],
+            'complex shape with optional values, minimum array value' => [
+                'type' => shape([
+                    'foo' => mixed(),
+                    'bar' => mixed(),
+                    'baz' => mixed(),
+                    'tab' => optional(mixed()),
+                ], true),
+                'value' => [
+                    'foo' => null,
+                    'bar' => null,
+                    'baz' => null,
+                ],
+            ],
+            'complex shape with optional values, array value with further values' => [
+                'type' => shape([
+                    'foo' => mixed(),
+                    'bar' => mixed(),
+                    'baz' => mixed(),
+                    'tab' => optional(mixed()),
+                ], true),
+                'value' => [
+                    'foo' => null,
+                    'bar' => null,
+                    'baz' => null,
+                    'tab' => null,
+                    'taz' => null,
+                    'tar' => null,
+                    'waz' => null,
+                    'war' => null,
+                ],
+            ],
+        ];
     }
 
-    /**
-     * @throws CoercionException
-     */
-    public function benchEmptyShapeCoercionAgainstEmptyIterable(): array
+    /** {@inheritDoc} */
+    public function provideHappyPathMatches(): array
     {
-        return $this->emptyShape->coerce($this->emptyIterable);
-    }
-
-    /**
-     * @throws CoercionException
-     */
-    public function benchEmptyShapeCoercionAgainstNonEmptyArray(): array
-    {
-        return $this->emptyShape->coerce(self::NON_EMPTY_ARRAY);
-    }
-
-    /**
-     * @throws CoercionException
-     */
-    public function benchEmptyShapeCoercionAgainstNonEmptyIterable(): array
-    {
-        return $this->emptyShape->coerce($this->nonEmptyIterable);
-    }
-
-    /**
-     * @throws CoercionException
-     */
-    public function benchComplexShapeCoercionAgainstValidStructure(): array
-    {
-        return $this->complexShapeWithOptionalValues->coerce(self::VALID_STRUCTURE);
-    }
-
-    /**
-     * @throws CoercionException
-     */
-    public function benchComplexShapeCoercionAgainstValidStructureIterable(): array
-    {
-        return $this->complexShapeWithOptionalValues->coerce($this->validStructureIterable);
-    }
-
-    /**
-     * @throws CoercionException
-     */
-    public function benchComplexShapeCoercionAgainstValidStructureWithFurtherValues(): array
-    {
-        return $this->complexShapeWithOptionalValues->coerce(self::VALID_STRUCTURE_WITH_FURTHER_VALUES);
-    }
-
-    /**
-     * @throws CoercionException
-     */
-    public function benchComplexShapeCoercionAgainstValidStructureWithFurtherValuesIterable(): array
-    {
-        return $this->complexShapeWithOptionalValues->coerce($this->validStructureWithFurtherValuesIterable);
-    }
-
-    public function benchEmptyShapeMatchAgainstEmptyArray(): bool
-    {
-        return $this->emptyShape->matches([]);
-    }
-
-    public function benchEmptyShapeMatchAgainstEmptyIterable(): bool
-    {
-        return $this->emptyShape->matches($this->emptyIterable);
-    }
-
-    public function benchEmptyShapeMatchAgainstNonEmptyArray(): bool
-    {
-        return $this->emptyShape->matches(self::NON_EMPTY_ARRAY);
-    }
-
-    public function benchEmptyShapeMatchAgainstNonEmptyIterable(): bool
-    {
-        return $this->emptyShape->matches($this->nonEmptyIterable);
-    }
-
-    public function benchComplexShapeMatchAgainstValidStructure(): bool
-    {
-        return $this->complexShapeWithOptionalValues->matches(self::VALID_STRUCTURE);
-    }
-
-    public function benchComplexShapeMatchAgainstValidStructureIterable(): bool
-    {
-        return $this->complexShapeWithOptionalValues->matches($this->validStructureIterable);
-    }
-
-    public function benchComplexShapeMatchAgainstValidStructureWithFurtherValues(): bool
-    {
-        return $this->complexShapeWithOptionalValues->matches(self::VALID_STRUCTURE_WITH_FURTHER_VALUES);
-    }
-
-    public function benchComplexShapeMatchAgainstValidStructureWithFurtherValuesIterable(): bool
-    {
-        return $this->complexShapeWithOptionalValues->matches($this->validStructureWithFurtherValuesIterable);
-    }
-
-    public function benchEmptyShapeAssertionAgainstEmptyArray(): void
-    {
-        $this->emptyShape->assert([]);
-    }
-
-    public function benchEmptyShapeAssertionAgainstNonEmptyArray(): void
-    {
-        $this->emptyShape->assert(self::NON_EMPTY_ARRAY);
-    }
-
-    public function benchComplexShapeAssertionAgainstValidStructure(): void
-    {
-        $this->complexShapeWithOptionalValues->assert(self::VALID_STRUCTURE);
-    }
-
-    public function benchComplexShapeAssertionAgainstValidStructureWithFurtherValues(): void
-    {
-        $this->complexShapeWithOptionalValues->assert(self::VALID_STRUCTURE_WITH_FURTHER_VALUES);
+        // As of now, matches ~= coercion in terms of happy path
+        return $this->provideHappyPathCoercion();
     }
 }

--- a/tests/benchmark/Type/ShapeTypeBench.php
+++ b/tests/benchmark/Type/ShapeTypeBench.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\Tests\Benchmark\Type;
 
+use ArrayIterator;
 use PhpBench\Attributes\BeforeMethods;
 
 use Psl\Type\Exception\CoercionException;
@@ -15,6 +16,23 @@ use function Psl\Type\shape;
 #[BeforeMethods('__construct')]
 final class ShapeTypeBench
 {
+    private const NON_EMPTY_ARRAY = ['foo' => 'bar'];
+    private const VALID_STRUCTURE = [
+        'foo' => null,
+        'bar' => null,
+        'baz' => null,
+    ];
+    private const VALID_STRUCTURE_WITH_FURTHER_VALUES = [
+        'foo' => null,
+        'bar' => null,
+        'baz' => null,
+        'tab' => null,
+        'taz' => null,
+        'tar' => null,
+        'waz' => null,
+        'war' => null,
+    ];
+
     /**
      * @var TypeInterface<array>
      */
@@ -23,6 +41,10 @@ final class ShapeTypeBench
      * @var TypeInterface<array>
      */
     private TypeInterface $complexShapeWithOptionalValues;
+    private iterable $emptyIterable;
+    private iterable $nonEmptyIterable;
+    private iterable $validStructureIterable;
+    private iterable $validStructureWithFurtherValuesIterable;
 
     public function __construct()
     {
@@ -33,6 +55,10 @@ final class ShapeTypeBench
             'baz' => mixed(),
             'tab' => optional(mixed()),
         ], true);
+        $this->emptyIterable = new ArrayIterator([]);
+        $this->nonEmptyIterable = new ArrayIterator(self::NON_EMPTY_ARRAY);
+        $this->validStructureIterable = new ArrayIterator(self::VALID_STRUCTURE);
+        $this->validStructureWithFurtherValuesIterable = new ArrayIterator(self::VALID_STRUCTURE_WITH_FURTHER_VALUES);
     }
 
     /**
@@ -46,9 +72,25 @@ final class ShapeTypeBench
     /**
      * @throws CoercionException
      */
+    public function benchEmptyShapeCoercionAgainstEmptyIterable(): array
+    {
+        return $this->emptyShape->coerce($this->emptyIterable);
+    }
+
+    /**
+     * @throws CoercionException
+     */
     public function benchEmptyShapeCoercionAgainstNonEmptyArray(): array
     {
-        return $this->emptyShape->coerce(['foo' => 'bar']);
+        return $this->emptyShape->coerce(self::NON_EMPTY_ARRAY);
+    }
+
+    /**
+     * @throws CoercionException
+     */
+    public function benchEmptyShapeCoercionAgainstNonEmptyIterable(): array
+    {
+        return $this->emptyShape->coerce($this->nonEmptyIterable);
     }
 
     /**
@@ -56,11 +98,15 @@ final class ShapeTypeBench
      */
     public function benchComplexShapeCoercionAgainstValidStructure(): array
     {
-        return $this->complexShapeWithOptionalValues->coerce([
-            'foo' => null,
-            'bar' => null,
-            'baz' => null,
-        ]);
+        return $this->complexShapeWithOptionalValues->coerce(self::VALID_STRUCTURE);
+    }
+
+    /**
+     * @throws CoercionException
+     */
+    public function benchComplexShapeCoercionAgainstValidStructureIterable(): array
+    {
+        return $this->complexShapeWithOptionalValues->coerce($this->validStructureIterable);
     }
 
     /**
@@ -68,15 +114,14 @@ final class ShapeTypeBench
      */
     public function benchComplexShapeCoercionAgainstValidStructureWithFurtherValues(): array
     {
-        return $this->complexShapeWithOptionalValues->coerce([
-            'foo' => null,
-            'bar' => null,
-            'baz' => null,
-            'tab' => null,
-            'taz' => null,
-            'tar' => null,
-            'waz' => null,
-            'war' => null,
-        ]);
+        return $this->complexShapeWithOptionalValues->coerce(self::VALID_STRUCTURE_WITH_FURTHER_VALUES);
+    }
+
+    /**
+     * @throws CoercionException
+     */
+    public function benchComplexShapeCoercionAgainstValidStructureWithFurtherValuesIterable(): array
+    {
+        return $this->complexShapeWithOptionalValues->coerce($this->validStructureWithFurtherValuesIterable);
     }
 }

--- a/tests/benchmark/Type/ShapeTypeBench.php
+++ b/tests/benchmark/Type/ShapeTypeBench.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Type;
+
+use PhpBench\Attributes\BeforeMethods;
+
+use Psl\Type\Exception\CoercionException;
+use Psl\Type\TypeInterface;
+use function Psl\Type\mixed;
+use function Psl\Type\optional;
+use function Psl\Type\shape;
+
+#[BeforeMethods('__construct')]
+final class ShapeTypeBench
+{
+    /**
+     * @var TypeInterface<array>
+     */
+    private TypeInterface $emptyShape;
+    /**
+     * @var TypeInterface<array>
+     */
+    private TypeInterface $complexShapeWithOptionalValues;
+
+    public function __construct()
+    {
+        $this->emptyShape                     = shape([], true);
+        $this->complexShapeWithOptionalValues = shape([
+            'foo' => mixed(),
+            'bar' => mixed(),
+            'baz' => mixed(),
+            'tab' => optional(mixed()),
+        ], true);
+    }
+
+    /**
+     * @throws CoercionException
+     */
+    public function benchEmptyShapeCoercionAgainstEmptyArray(): array
+    {
+        return $this->emptyShape->coerce([]);
+    }
+
+    /**
+     * @throws CoercionException
+     */
+    public function benchEmptyShapeCoercionAgainstNonEmptyArray(): array
+    {
+        return $this->emptyShape->coerce(['foo' => 'bar']);
+    }
+
+    /**
+     * @throws CoercionException
+     */
+    public function benchComplexShapeCoercionAgainstValidStructure(): array
+    {
+        return $this->complexShapeWithOptionalValues->coerce([
+            'foo' => null,
+            'bar' => null,
+            'baz' => null,
+        ]);
+    }
+
+    /**
+     * @throws CoercionException
+     */
+    public function benchComplexShapeCoercionAgainstValidStructureWithFurtherValues(): array
+    {
+        return $this->complexShapeWithOptionalValues->coerce([
+            'foo' => null,
+            'bar' => null,
+            'baz' => null,
+            'tab' => null,
+            'taz' => null,
+            'tar' => null,
+            'waz' => null,
+            'war' => null,
+        ]);
+    }
+}

--- a/tests/benchmark/Type/ShapeTypeBench.php
+++ b/tests/benchmark/Type/ShapeTypeBench.php
@@ -10,6 +10,7 @@ use function Psl\Type\mixed;
 use function Psl\Type\optional;
 use function Psl\Type\shape;
 
+/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\ShapeType> */
 final class ShapeTypeBench extends GenericTypeBench
 {
     /** {@inheritDoc} */
@@ -147,6 +148,6 @@ final class ShapeTypeBench extends GenericTypeBench
     public function provideHappyPathMatches(): array
     {
         // As of now, matches ~= coercion in terms of happy path
-        return $this->provideHappyPathCoercion();
+        return $this->provideHappyPathAssertion();
     }
 }

--- a/tests/benchmark/Type/ShapeTypeBench.php
+++ b/tests/benchmark/Type/ShapeTypeBench.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psl\Tests\Benchmark\Type;
 
 use ArrayIterator;
+
 use function Psl\Type\mixed;
 use function Psl\Type\optional;
 use function Psl\Type\shape;

--- a/tests/benchmark/Type/ShapeTypeBench.php
+++ b/tests/benchmark/Type/ShapeTypeBench.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Psl\Tests\Benchmark\Type;
 
 use ArrayIterator;
-
 use function Psl\Type\mixed;
 use function Psl\Type\optional;
 use function Psl\Type\shape;

--- a/tests/benchmark/Type/ShapeTypeBench.php
+++ b/tests/benchmark/Type/ShapeTypeBench.php
@@ -12,7 +12,9 @@ use function Psl\Type\shape;
 /** @extends GenericTypeBench<\Psl\Type\TypeInterface<array>> */
 final class ShapeTypeBench extends GenericTypeBench
 {
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathCoercion(): array
     {
         return [
@@ -97,7 +99,9 @@ final class ShapeTypeBench extends GenericTypeBench
         ];
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathAssertion(): array
     {
         return [
@@ -143,7 +147,9 @@ final class ShapeTypeBench extends GenericTypeBench
         ];
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathMatches(): array
     {
         // As of now, matches ~= coercion in terms of happy path

--- a/tests/benchmark/Type/ShapeTypeBench.php
+++ b/tests/benchmark/Type/ShapeTypeBench.php
@@ -9,7 +9,7 @@ use function Psl\Type\mixed;
 use function Psl\Type\optional;
 use function Psl\Type\shape;
 
-/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\ShapeType> */
+/** @extends GenericTypeBench<\Psl\Type\TypeInterface<array>> */
 final class ShapeTypeBench extends GenericTypeBench
 {
     /** {@inheritDoc} */

--- a/tests/benchmark/Type/StringTypeBench.php
+++ b/tests/benchmark/Type/StringTypeBench.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Type;
+
+use Psl\Tests\Benchmark\Type\Asset\ExplicitStringableObject;
+use Psl\Tests\Benchmark\Type\Asset\ImplicitStringableObject;
+use function Psl\Type\string;
+
+/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\StringType> */
+final class StringTypeBench extends GenericTypeBench
+{
+    /** {@inheritDoc} */
+    public function provideHappyPathCoercion(): array
+    {
+        return array_merge(
+            $this->strictlyValidDataSet(),
+            [
+                'int'    => [
+                    'type'  => string(),
+                    'value' => 123,
+                ],
+                'instanceof Stringable (explicit)' => [
+                    'type'  => string(),
+                    'value' => new ImplicitStringableObject(),
+                ],
+                'instanceof Stringable (implicit)' => [
+                    'type'  => string(),
+                    'value' => new ExplicitStringableObject(),
+                ],
+            ]
+        );
+    }
+
+    /** {@inheritDoc} */
+    public function provideHappyPathAssertion(): array
+    {
+        return $this->strictlyValidDataSet();
+    }
+
+    /** {@inheritDoc} */
+    public function provideHappyPathMatches(): array
+    {
+        return $this->strictlyValidDataSet();
+    }
+
+    /** @return array<non-empty-string, array{type: \Psl\Type\Internal\DictType, value: array}> */
+    private function strictlyValidDataSet(): array
+    {
+        return [
+            'string' => [
+                'type'  => string(),
+                'value' => 'foo',
+            ],
+        ];
+    }
+}

--- a/tests/benchmark/Type/StringTypeBench.php
+++ b/tests/benchmark/Type/StringTypeBench.php
@@ -6,6 +6,7 @@ namespace Psl\Tests\Benchmark\Type;
 
 use Psl\Tests\Benchmark\Type\Asset\ExplicitStringableObject;
 use Psl\Tests\Benchmark\Type\Asset\ImplicitStringableObject;
+
 use function Psl\Type\string;
 
 /** @extends GenericTypeBench<\Psl\Type\TypeInterface<string>> */

--- a/tests/benchmark/Type/StringTypeBench.php
+++ b/tests/benchmark/Type/StringTypeBench.php
@@ -11,7 +11,9 @@ use function Psl\Type\string;
 /** @extends GenericTypeBench<\Psl\Type\TypeInterface<string>> */
 final class StringTypeBench extends GenericTypeBench
 {
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathCoercion(): array
     {
         return array_merge(
@@ -33,19 +35,25 @@ final class StringTypeBench extends GenericTypeBench
         );
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathAssertion(): array
     {
         return $this->strictlyValidDataSet();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathMatches(): array
     {
         return $this->strictlyValidDataSet();
     }
 
-    /** @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<string>, value: string}> */
+    /**
+     * @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<string>, value: string}>
+     */
     private function strictlyValidDataSet(): array
     {
         return [

--- a/tests/benchmark/Type/StringTypeBench.php
+++ b/tests/benchmark/Type/StringTypeBench.php
@@ -8,7 +8,7 @@ use Psl\Tests\Benchmark\Type\Asset\ExplicitStringableObject;
 use Psl\Tests\Benchmark\Type\Asset\ImplicitStringableObject;
 use function Psl\Type\string;
 
-/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\StringType> */
+/** @extends GenericTypeBench<\Psl\Type\TypeInterface<string>> */
 final class StringTypeBench extends GenericTypeBench
 {
     /** {@inheritDoc} */
@@ -45,7 +45,7 @@ final class StringTypeBench extends GenericTypeBench
         return $this->strictlyValidDataSet();
     }
 
-    /** @return array<non-empty-string, array{type: \Psl\Type\Internal\DictType, value: array}> */
+    /** @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<string>, value: string}> */
     private function strictlyValidDataSet(): array
     {
         return [

--- a/tests/benchmark/Type/VecTypeBench.php
+++ b/tests/benchmark/Type/VecTypeBench.php
@@ -13,7 +13,9 @@ use function range;
 /** @extends GenericTypeBench<\Psl\Type\TypeInterface<list<mixed>>> */
 final class VecTypeBench extends GenericTypeBench
 {
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathCoercion(): array
     {
         $arraysAndIterables = [];
@@ -29,7 +31,9 @@ final class VecTypeBench extends GenericTypeBench
         return $arraysAndIterables;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathAssertion(): array
     {
         $arraysAndIterables = [];
@@ -41,7 +45,9 @@ final class VecTypeBench extends GenericTypeBench
         return $arraysAndIterables;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public function provideHappyPathMatches(): array
     {
         return $this->provideHappyPathAssertion();

--- a/tests/benchmark/Type/VecTypeBench.php
+++ b/tests/benchmark/Type/VecTypeBench.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Type;
+
+use ArrayIterator;
+
+use function array_combine;
+use function array_fill;
+use function array_map;
+use function Psl\Type\array_key;
+use function Psl\Type\dict;
+use function Psl\Type\int;
+use function Psl\Type\mixed;
+use function Psl\Type\optional;
+use function Psl\Type\shape;
+use function Psl\Type\string;
+use function Psl\Type\vec;
+use function range;
+
+/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\VecType> */
+final class VecTypeBench extends GenericTypeBench
+{
+    /** {@inheritDoc} */
+    public function provideHappyPathCoercion(): array
+    {
+        $arraysAndIterables = [];
+
+        foreach ($this->arrayDataSet() as $key => $pair) {
+            $arraysAndIterables[$key . ' array'] = $pair;
+            $arraysAndIterables[$key . ' iterable'] = [
+                'type' => $pair['type'],
+                'value' => new ArrayIterator($pair['value'])
+            ];
+        }
+
+        return $arraysAndIterables;
+    }
+
+    /** {@inheritDoc} */
+    public function provideHappyPathAssertion(): array
+    {
+        $arraysAndIterables = [];
+
+        foreach ($this->arrayDataSet() as $key => $pair) {
+            $arraysAndIterables[$key . ' array'] = $pair;
+        }
+
+        return $arraysAndIterables;
+    }
+
+    /** {@inheritDoc} */
+    public function provideHappyPathMatches(): array
+    {
+        return $this->provideHappyPathAssertion();
+    }
+
+    /** @return array<non-empty-string, array{type: \Psl\Type\Internal\DictType, value: array}> */
+    private function arrayDataSet(): array
+    {
+        return [
+            'mixed, empty' => [
+                'type' => vec(mixed()),
+                'value' => [],
+            ],
+            'mixed, non-empty' => [
+                'type' => vec(mixed()),
+                'value' => [
+                    'foo',
+                    'bar',
+                    'baz',
+                ],
+            ],
+            'mixed, large' => [
+                'type' => vec(mixed()),
+                'value' => range(0, 100),
+            ],
+            'int, empty' => [
+                'type' => vec(int()),
+                'value' => [],
+            ],
+            'int, non-empty' => [
+                'type' => vec(int()),
+                'value' => [
+                    4,
+                    25,
+                    8,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/benchmark/Type/VecTypeBench.php
+++ b/tests/benchmark/Type/VecTypeBench.php
@@ -10,7 +10,7 @@ use function Psl\Type\mixed;
 use function Psl\Type\vec;
 use function range;
 
-/** @psalm-extends GenericTypeBench<\Psl\Type\Internal\VecType> */
+/** @extends GenericTypeBench<\Psl\Type\TypeInterface<list<mixed>>> */
 final class VecTypeBench extends GenericTypeBench
 {
     /** {@inheritDoc} */
@@ -47,7 +47,11 @@ final class VecTypeBench extends GenericTypeBench
         return $this->provideHappyPathAssertion();
     }
 
-    /** @return array<non-empty-string, array{type: \Psl\Type\Internal\DictType, value: array}> */
+    /**
+     * @return array<non-empty-string, array{type: \Psl\Type\TypeInterface<list<mixed>>, value: array}>
+     *
+     * @psalm-suppress MissingThrowsDocblock this block should never throw
+     */
     private function arrayDataSet(): array
     {
         return [

--- a/tests/benchmark/Type/VecTypeBench.php
+++ b/tests/benchmark/Type/VecTypeBench.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psl\Tests\Benchmark\Type;
 
 use ArrayIterator;
+
 use function Psl\Type\int;
 use function Psl\Type\mixed;
 use function Psl\Type\vec;

--- a/tests/benchmark/Type/VecTypeBench.php
+++ b/tests/benchmark/Type/VecTypeBench.php
@@ -5,17 +5,8 @@ declare(strict_types=1);
 namespace Psl\Tests\Benchmark\Type;
 
 use ArrayIterator;
-
-use function array_combine;
-use function array_fill;
-use function array_map;
-use function Psl\Type\array_key;
-use function Psl\Type\dict;
 use function Psl\Type\int;
 use function Psl\Type\mixed;
-use function Psl\Type\optional;
-use function Psl\Type\shape;
-use function Psl\Type\string;
 use function Psl\Type\vec;
 use function range;
 

--- a/tests/unit/Type/ShapeTypeTest.php
+++ b/tests/unit/Type/ShapeTypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\Tests\Unit\Type;
 
+use ArrayIterator;
 use Psl\Collection;
 use Psl\Iter;
 use Psl\Type;
@@ -42,7 +43,38 @@ final class ShapeTypeTest extends TypeTest
         ]);
     }
 
+    public function testWillConsiderUnknownIterableFieldsWhenCoercing(): void
+    {
+        static::assertEquals(
+            [
+                'defined_key' => 'value',
+                'additional_key' => 'value',
+            ],
+            Type\shape([
+                'defined_key' => Type\mixed(),
+            ], true)
+                ->coerce(new ArrayIterator([
+                    'defined_key' => 'value',
+                    'additional_key' => 'value',
+                ]))
+        );
+    }
+
     public function getValidCoercions(): iterable
+    {
+        foreach ($this->validCoercions() as $row) {
+            yield $row;
+            yield [
+                new ArrayIterator($row[0]),
+                $row[1]
+            ];
+        }
+    }
+
+    /**
+     * @return iterable<array{0: array, 1: T}>
+     */
+    private function validCoercions(): iterable
     {
         yield [
             ['name' => 'saif', 'articles' => new Collection\Vector([])],

--- a/tools/phpbench/composer.json
+++ b/tools/phpbench/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpbench/phpbench": "^1.1"
+    }
+}

--- a/tools/phpbench/composer.lock
+++ b/tools/phpbench/composer.lock
@@ -1,0 +1,1750 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "2ff1aa331348857b17757a3c61f25133",
+    "packages": [
+        {
+            "name": "doctrine/annotations",
+            "version": "1.13.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "5b668aef16090008790395c02c893b1ba13f7e08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/5b668aef16090008790395c02c893b1ba13f7e08",
+                "reference": "5b668aef16090008790395c02c893b1ba13f7e08",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "ext-tokenizer": "*",
+                "php": "^7.1 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^1.11 || ^2.0",
+                "doctrine/coding-standard": "^6.0 || ^8.1",
+                "phpstan/phpstan": "^0.12.20",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.1.5",
+                "symfony/cache": "^4.4 || ^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/1.13.2"
+            },
+            "time": "2021-08-05T19:00:23+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/e864bbf5904cb8f5bb334f99209b48018522f042",
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/1.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-25T17:44:05+00:00"
+        },
+        {
+            "name": "phpbench/container",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpbench/container.git",
+                "reference": "4af6c2619296e95b72409fd6244f000276277047"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpbench/container/zipball/4af6c2619296e95b72409fd6244f000276277047",
+                "reference": "4af6c2619296e95b72409fd6244f000276277047",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0|^2.0",
+                "symfony/options-resolver": "^4.2 || ^5.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "phpstan/phpstan": "^0.12.52",
+                "phpunit/phpunit": "^8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpBench\\DependencyInjection\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "Simple, configurable, service container.",
+            "support": {
+                "issues": "https://github.com/phpbench/container/issues",
+                "source": "https://github.com/phpbench/container/tree/2.2.0"
+            },
+            "time": "2021-07-14T20:56:29+00:00"
+        },
+        {
+            "name": "phpbench/dom",
+            "version": "0.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpbench/dom.git",
+                "reference": "d26e615c4d64da41d168ab1096e4f55d97f2344f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpbench/dom/zipball/d26e615c4d64da41d168ab1096e4f55d97f2344f",
+                "reference": "d26e615c4d64da41d168ab1096e4f55d97f2344f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^7.2||^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.18",
+                "phpstan/phpstan": "^0.12.83",
+                "phpunit/phpunit": "^8.0||^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpBench\\Dom\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "DOM wrapper to simplify working with the PHP DOM implementation",
+            "support": {
+                "issues": "https://github.com/phpbench/dom/issues",
+                "source": "https://github.com/phpbench/dom/tree/0.3.1"
+            },
+            "time": "2021-04-21T20:44:19+00:00"
+        },
+        {
+            "name": "phpbench/phpbench",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpbench/phpbench.git",
+                "reference": "e1ba6761baf776515b0e2aec8cfa2ba921926735"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/e1ba6761baf776515b0e2aec8cfa2ba921926735",
+                "reference": "e1ba6761baf776515b0e2aec8cfa2ba921926735",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.2.7",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "ext-tokenizer": "*",
+                "php": "^7.2 || ^8.0",
+                "phpbench/container": "^2.1",
+                "phpbench/dom": "~0.3.1",
+                "psr/log": "^1.1",
+                "seld/jsonlint": "^1.1",
+                "symfony/console": "^4.2 || ^5.0",
+                "symfony/filesystem": "^4.2 || ^5.0",
+                "symfony/finder": "^4.2 || ^5.0",
+                "symfony/options-resolver": "^4.2 || ^5.0",
+                "symfony/process": "^4.2 || ^5.0",
+                "webmozart/path-util": "^2.3"
+            },
+            "require-dev": {
+                "dantleech/invoke": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "jangregor/phpstan-prophecy": "^0.8.1",
+                "phpspec/prophecy": "^1.12",
+                "phpstan/phpstan": "^0.12.7",
+                "phpunit/phpunit": "^8.5.8 || ^9.0",
+                "symfony/error-handler": "^5.2",
+                "symfony/var-dumper": "^4.0 || ^5.0"
+            },
+            "suggest": {
+                "ext-xdebug": "For Xdebug profiling extension."
+            },
+            "bin": [
+                "bin/phpbench"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "lib/Report/Func/functions.php"
+                ],
+                "psr-4": {
+                    "PhpBench\\": "lib/",
+                    "PhpBench\\Extensions\\XDebug\\": "extensions/xdebug/lib/",
+                    "PhpBench\\Extensions\\Reports\\": "extensions/reports/lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "PHP Benchmarking Framework",
+            "support": {
+                "issues": "https://github.com/phpbench/phpbench/issues",
+                "source": "https://github.com/phpbench/phpbench/tree/1.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/dantleech",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-08-15T10:55:27+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
+            },
+            "time": "2021-03-05T17:36:06+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
+        },
+        {
+            "name": "seld/jsonlint",
+            "version": "1.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
+                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/jsonlint/issues",
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.8.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-11T09:19:24+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v5.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "8b1008344647462ae6ec57559da166c2bfa5e16a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/8b1008344647462ae6ec57559da166c2bfa5e16a",
+                "reference": "8b1008344647462ae6ec57559da166c2bfa5e16a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/string": "^5.1"
+            },
+            "conflict": {
+                "psr/log": ">=3",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/dotenv": "<5.1",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v5.3.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-08-25T20:02:16+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-23T23:28:01+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "343f4fe324383ca46792cae728a3b6e2f708fb32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/343f4fe324383ca46792cae728a3b6e2f708fb32",
+                "reference": "343f4fe324383ca46792cae728a3b6e2f708fb32",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v5.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-21T12:40:44+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v5.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "a10000ada1e600d109a6c7632e9ac42e8bf2fb93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/a10000ada1e600d109a6c7632e9ac42e8bf2fb93",
+                "reference": "a10000ada1e600d109a6c7632e9ac42e8bf2fb93",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v5.3.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-08-04T21:20:46+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v5.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "4b78e55b179003a42523a362cc0e8327f7a69b5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/4b78e55b179003a42523a362cc0e8327f7a69b5e",
+                "reference": "4b78e55b179003a42523a362cc0e8327f7a69b5e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-php73": "~1.0",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v5.3.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-08-04T21:20:46+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/16880ba9c5ebe3642d1995ab866db29270b36535",
+                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T12:26:48+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T12:26:48+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-28T13:41:28+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "38f26c7d6ed535217ea393e05634cb0b244a1967"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/38f26c7d6ed535217ea393e05634cb0b244a1967",
+                "reference": "38f26c7d6ed535217ea393e05634cb0b244a1967",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.3.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-08-04T21:20:46+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/container": "^1.1"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-01T10:43:52+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v5.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "8d224396e28d30f81969f083a58763b8b9ceb0a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/8d224396e28d30f81969f083a58763b8b9ceb0a5",
+                "reference": "8d224396e28d30f81969f083a58763b8b9ceb0a5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "~1.15"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.3.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-08-26T08:00:08+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+            },
+            "time": "2021-03-09T10:59:23+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "support": {
+                "issues": "https://github.com/webmozart/path-util/issues",
+                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
+            },
+            "time": "2015-12-17T08:42:14+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
+}

--- a/tools/phpbench/phpbench.json
+++ b/tools/phpbench/phpbench.json
@@ -1,5 +1,6 @@
 {
     "runner.bootstrap":       "../../vendor/autoload.php",
+    "runner.file_pattern":    "*Bench.php",
     "runner.iterations":      5,
     "runner.revs":            10,
     "runner.path":            "../../tests/benchmark",

--- a/tools/phpbench/phpbench.json
+++ b/tools/phpbench/phpbench.json
@@ -1,4 +1,6 @@
 {
+    "runner.annotations":     false,
+    "runner.attributes":      true,
     "runner.bootstrap":       "../../vendor/autoload.php",
     "runner.file_pattern":    "*Bench.php",
     "runner.iterations":      5,

--- a/tools/phpbench/phpbench.json
+++ b/tools/phpbench/phpbench.json
@@ -1,0 +1,13 @@
+{
+    "runner.bootstrap":       "../../vendor/autoload.php",
+    "runner.iterations":      5,
+    "runner.revs":            10,
+    "runner.path":            "../../tests/benchmark",
+    "runner.retry_threshold": 5,
+    "runner.warmup":          2,
+    "report.outputs":         {
+        "report": {
+            "extends": "aggregate"
+        }
+    }
+}

--- a/tools/psalm/psalm.xml
+++ b/tools/psalm/psalm.xml
@@ -2,6 +2,7 @@
 <psalm totallyTyped="true" forbidEcho="true" strictBinaryOperands="true" phpVersion="8.0" allowStringToStandInForClass="true" rememberPropertyAssignmentsAfterCall="false" checkForThrowsDocblock="true" checkForThrowsInGlobalScope="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://getpsalm.org/schema/config" xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd" errorBaseline="baseline.xml">
     <projectFiles>
         <directory name="../../src" />
+        <directory name="../../tests/benchmark" />
         <directory name="../../integration" />
         <ignoreFiles>
             <file name="../../src/bootstrap.php" />
@@ -9,6 +10,13 @@
             <file name="../../src/Psl/Internal/Loader.php" />
         </ignoreFiles>
     </projectFiles>
+
+    <extraFiles>
+        <!-- because of the structure of this project, it's not possible to
+            autoload phpbench attributes. Until that's fixed via a single `composer.lock`,
+            we can refer to the symbols provided by phpbench, manually -->
+        <directory name="../../tools/phpbench/vendor/phpbench/phpbench/lib/Attributes"/>
+    </extraFiles>
 
     <issueHandlers>
         <DuplicateFunction errorLevel="suppress" />


### PR DESCRIPTION
## Scope of work

This patch attempts to improve happy-path execution time for `Psl\Type` components, and specifically:

 * `Psl\Type\TypeInterface#coerce()`
 * `Psl\Type\TypeInterface#assert()`
 * `Psl\Type\TypeInterface#matches()`

## Results

Results as per 2021-09-08 (af6d3784a7f58aa7f24577caec95c2a160ac3412) are as follows: 

```
root@6d63f978332e:/app# ./tools/phpbench/vendor/bin/phpbench run --config tools/phpbench/phpbench.json --ref=benchmark_reference --iterations=15 --revs=8
PHPBench (1.1.0) running benchmarks...
with configuration file: /app/tools/phpbench/phpbench.json
with PHP version 8.0.10, xdebug ✔, opcache ✔
comparing [actual vs. benchmark_reference]

\Psl\Tests\Benchmark\Type\StringTypeBench

    benchCoerce # string....................R1 I5 - [Mo1.000μs vs. Mo1.000μs] 0.00% (±0.00%)
    benchCoerce # int.......................R1 I1 - [Mo1.125μs vs. Mo1.125μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (ex.R1 I8 - [Mo1.375μs vs. Mo1.875μs] -26.67% (±0.00%)
    benchCoerce # instanceof Stringable (im.R1 I7 - [Mo1.375μs vs. Mo1.875μs] -26.67% (±0.00%)
    benchAssert.............................R1 I5 - [Mo1.125μs vs. Mo1.125μs] 0.00% (±0.00%)
    benchMatch..............................R2 I14 - [Mo1.000μs vs. Mo1.000μs] 0.00% (±0.00%)

\Psl\Tests\Benchmark\Type\ShapeTypeBench

    benchCoerce # empty shape, empty array .R1 I1 - [Mo3.125μs vs. Mo17.202μs] -81.83% (±1.00%)
    benchCoerce # empty shape, empty iterab.R2 I7 - [Mo5.497μs vs. Mo17.548μs] -68.68% (±1.40%)
    benchCoerce # empty shape, non-empty ar.R1 I4 - [Mo3.502μs vs. Mo23.732μs] -85.24% (±2.32%)
    benchCoerce # empty shape, non-empty it.R1 I14 - [Mo7.004μs vs. Mo24.129μs] -70.97% (±1.27%)
    benchCoerce # complex shape with option.R1 I14 - [Mo5.625μs vs. Mo62.697μs] -91.03% (±1.21%)
    benchCoerce # complex shape with option.R1 I10 - [Mo29.472μs vs. Mo64.065μs] -54.00% (±0.86%)
    benchCoerce # complex shape with option.R1 I12 - [Mo8.672μs vs. Mo93.012μs] -90.68% (±1.57%)
    benchCoerce # complex shape with option.R1 I14 - [Mo39.567μs vs. Mo94.873μs] -58.30% (±0.94%)
    benchAssert # empty shape, empty array .R1 I0 - [Mo1.250μs vs. Mo15.543μs] -91.96% (±0.00%)
    benchAssert # empty shape, non-empty ar.R1 I7 - [Mo2.000μs vs. Mo18.186μs] -89.00% (±2.89%)
    benchAssert # complex shape with option.R1 I2 - [Mo22.480μs vs. Mo49.896μs] -54.95% (±1.44%)
    benchAssert # complex shape with option.R1 I2 - [Mo29.613μs vs. Mo63.770μs] -53.56% (±1.22%)
    benchMatch # empty shape, empty array v.R1 I3 - [Mo1.500μs vs. Mo15.995μs] -90.62% (±0.00%)
    benchMatch # empty shape, non-empty arr.R2 I7 - [Mo2.500μs vs. Mo18.625μs] -86.58% (±1.24%)
    benchMatch # complex shape with optiona.R1 I7 - [Mo22.995μs vs. Mo50.246μs] -54.24% (±0.97%)
    benchMatch # complex shape with optiona.R1 I3 - [Mo30.085μs vs. Mo64.037μs] -53.02% (±0.44%)

\Psl\Tests\Benchmark\Type\VecTypeBench

    benchCoerce # mixed, empty array........R1 I14 - [Mo3.753μs vs. Mo5.125μs] -26.77% (±2.02%)
    benchCoerce # mixed, empty iterable.....R1 I14 - [Mo4.116μs vs. Mo5.125μs] -19.69% (±2.44%)
    benchCoerce # mixed, non-empty array....R1 I14 - [Mo5.602μs vs. Mo6.749μs] -17.00% (±2.27%)
    benchCoerce # mixed, non-empty iterable.R1 I14 - [Mo5.750μs vs. Mo7.000μs] -17.85% (±0.96%)
    benchCoerce # mixed, large array........R1 I14 - [Mo48.082μs vs. Mo49.339μs] -2.55% (±1.26%)
    benchCoerce # mixed, large iterable.....R1 I14 - [Mo51.736μs vs. Mo52.998μs] -2.38% (±2.04%)
    benchCoerce # int, empty array..........R1 I10 - [Mo3.770μs vs. Mo5.125μs] -26.45% (±2.76%)
    benchCoerce # int, empty iterable.......R2 I8 - [Mo3.998μs vs. Mo5.191μs] -22.99% (±2.05%)
    benchCoerce # int, non-empty array......R2 I4 - [Mo5.620μs vs. Mo6.699μs] -16.10% (±1.89%)
    benchCoerce # int, non-empty iterable...R2 I14 - [Mo5.779μs vs. Mo7.000μs] -17.45% (±2.14%)
    benchAssert # mixed, empty array........R1 I10 - [Mo3.625μs vs. Mo5.125μs] -29.26% (±2.52%)
    benchAssert # mixed, non-empty array....R1 I14 - [Mo5.750μs vs. Mo7.245μs] -20.64% (±0.87%)
    benchAssert # mixed, large array........R1 I14 - [Mo64.692μs vs. Mo66.096μs] -2.12% (±1.18%)
    benchAssert # int, empty array..........R1 I14 - [Mo3.741μs vs. Mo5.125μs] -27.00% (±2.38%)
    benchAssert # int, non-empty array......R13 I14 - [Mo5.752μs vs. Mo7.269μs] -20.86% (±1.41%)
    benchMatch # mixed, empty array.........R1 I13 - [Mo1.125μs vs. Mo1.250μs] -10.00% (±0.00%)
    benchMatch # mixed, non-empty array.....R1 I4 - [Mo2.875μs vs. Mo3.125μs] -8.03% (±2.21%)
    benchMatch # mixed, large array.........R2 I6 - [Mo54.026μs vs. Mo53.978μs] +0.09% (±0.69%)
    benchMatch # int, empty array...........R1 I0 - [Mo1.125μs vs. Mo1.250μs] -10.00% (±0.00%)
    benchMatch # int, non-empty array.......R1 I4 - [Mo2.875μs vs. Mo3.125μs] -8.01% (±2.49%)

\Psl\Tests\Benchmark\Type\DictTypeBench

    benchCoerce # generic array, empty arra.R3 I7 - [Mo6.128μs vs. Mo8.708μs] -29.63% (±1.45%)
    benchCoerce # generic array, empty iter.R1 I1 - [Mo6.376μs vs. Mo8.850μs] -27.95% (±1.33%)
    benchCoerce # generic array, non-empty .R1 I2 - [Mo7.374μs vs. Mo10.614μs] -30.53% (±1.70%)
    benchCoerce # generic array, non-empty .R1 I14 - [Mo7.600μs vs. Mo10.875μs] -30.12% (±1.80%)
    benchCoerce # generic array, large arra.R1 I5 - [Mo99.035μs vs. Mo3.702ms] -97.33% (±2.06%)
    benchCoerce # generic array, large iter.R1 I5 - [Mo103.920μs vs. Mo3.086ms] -96.63% (±1.47%)
    benchCoerce # int array, empty array....R1 I3 - [Mo6.103μs vs. Mo8.436μs] -27.65% (±1.67%)
    benchCoerce # int array, empty iterable.R1 I10 - [Mo6.153μs vs. Mo8.760μs] -29.77% (±1.85%)
    benchCoerce # int array, non-empty arra.R1 I13 - [Mo9.011μs vs. Mo11.639μs] -22.58% (±1.40%)
    benchCoerce # int array, non-empty iter.R1 I6 - [Mo9.428μs vs. Mo12.013μs] -21.52% (±1.26%)
    benchCoerce # int array, large array....R2 I9 - [Mo100.810μs vs. Mo102.101μs] -1.26% (±2.02%)
    benchCoerce # int array, large iterable.R1 I4 - [Mo104.550μs vs. Mo107.096μs] -2.38% (±1.10%)
    benchCoerce # map, empty array..........R2 I8 - [Mo6.082μs vs. Mo8.475μs] -28.24% (±1.93%)
    benchCoerce # map, empty iterable.......R2 I13 - [Mo6.246μs vs. Mo8.604μs] -27.40% (±1.44%)
    benchCoerce # map, non-empty array......R1 I9 - [Mo9.001μs vs. Mo11.503μs] -21.75% (±0.82%)
    benchCoerce # map, non-empty iterable...R2 I13 - [Mo9.575μs vs. Mo11.875μs] -19.38% (±1.56%)
    benchCoerce # map, large array..........R2 I14 - [Mo102.754μs vs. Mo104.467μs] -1.64% (±2.33%)
    benchCoerce # map, large iterable.......R1 I2 - [Mo106.440μs vs. Mo109.807μs] -3.07% (±1.45%)
    benchAssert # generic array, empty arra.R1 I14 - [Mo5.750μs vs. Mo8.248μs] -30.29% (±0.54%)
    benchAssert # generic array, non-empty .R1 I14 - [Mo6.986μs vs. Mo9.750μs] -28.35% (±1.45%)
    benchAssert # generic array, large arra.R4 I10 - [Mo98.287μs vs. Mo3.511ms] -97.20% (±1.85%)
    benchAssert # int array, empty array....R3 I12 - [Mo5.750μs vs. Mo8.250μs] -30.31% (±1.10%)
    benchAssert # int array, non-empty arra.R3 I13 - [Mo8.737μs vs. Mo11.286μs] -22.59% (±1.64%)
    benchAssert # int array, large array....R2 I8 - [Mo98.272μs vs. Mo101.161μs] -2.86% (±1.21%)
    benchAssert # map, empty array..........R2 I14 - [Mo5.745μs vs. Mo8.250μs] -30.36% (±1.49%)
    benchAssert # map, non-empty array......R6 I11 - [Mo8.702μs vs. Mo11.181μs] -22.17% (±1.47%)
    benchAssert # map, large array..........R1 I7 - [Mo102.052μs vs. Mo104.321μs] -2.17% (±1.40%)
    benchMatch # generic array, empty array.R1 I14 - [Mo6.148μs vs. Mo8.651μs] -28.93% (±2.49%)
    benchMatch # generic array, non-empty a.R7 I13 - [Mo7.375μs vs. Mo10.256μs] -28.09% (±1.77%)
    benchMatch # generic array, large array.R1 I6 - [Mo100.021μs vs. Mo4.486ms] -97.77% (±1.98%)
    benchMatch # int array, empty array.....R1 I14 - [Mo6.227μs vs. Mo8.699μs] -28.41% (±2.21%)
    benchMatch # int array, non-empty array.R1 I14 - [Mo9.000μs vs. Mo11.664μs] -22.83% (±0.69%)
    benchMatch # int array, large array.....R1 I1 - [Mo98.781μs vs. Mo101.539μs] -2.72% (±1.67%)
    benchMatch # map, empty array...........R6 I14 - [Mo6.248μs vs. Mo8.625μs] -27.57% (±2.31%)
    benchMatch # map, non-empty array.......R6 I14 - [Mo9.017μs vs. Mo11.552μs] -21.95% (±1.28%)
    benchMatch # map, large array...........R6 I14 - [Mo102.852μs vs. Mo105.609μs] -2.61% (±1.44%)

\Psl\Tests\Benchmark\Type\ArrayKeyTypeBench

    benchCoerce # string....................R1 I0 - [Mo1.000μs vs. Mo1.750μs] -42.86% (±0.00%)
    benchCoerce # int.......................R1 I12 - [Mo1.000μs vs. Mo19.582μs] -94.89% (±0.00%)
    benchCoerce # instanceof Stringable (ex.R2 I7 - [Mo61.066μs vs. Mo53.186μs] +14.82% (±1.27%)
    benchCoerce # instanceof Stringable (im.R1 I4 - [Mo61.126μs vs. Mo52.867μs] +15.62% (±1.32%)
    benchAssert # string....................R1 I0 - [Mo1.125μs vs. Mo1.500μs] -25.00% (±0.00%)
    benchAssert # int.......................R2 I4 - [Mo1.125μs vs. Mo17.236μs] -93.47% (±0.00%)
    benchMatch # string.....................R1 I11 - [Mo1.000μs vs. Mo1.375μs] -27.27% (±0.00%)
    benchMatch # int........................R1 I10 - [Mo1.000μs vs. Mo1.875μs] -46.67% (±0.00%)

\Psl\Tests\Benchmark\Type\NonEmptyStringTypeBench

    benchCoerce # string....................R2 I8 - [Mo1.000μs vs. Mo1.375μs] -27.27% (±0.00%)
    benchCoerce # int.......................R2 I13 - [Mo1.125μs vs. Mo1.500μs] -25.00% (±0.00%)
    benchCoerce # instanceof Stringable (ex.R1 I5 - [Mo1.625μs vs. Mo2.500μs] -35.01% (±3.89%)
    benchCoerce # instanceof Stringable (im.R1 I11 - [Mo1.625μs vs. Mo2.500μs] -34.99% (±0.00%)
    benchAssert.............................R1 I7 - [Mo1.125μs vs. Mo1.375μs] -18.18% (±0.00%)
    benchMatch..............................R1 I7 - [Mo1.000μs vs. Mo1.250μs] -20.00% (±0.00%)

\Psl\Tests\Benchmark\Type\IntTypeBench

    benchCoerce # int.......................R1 I2 - [Mo1.000μs vs. Mo1.000μs] 0.00% (±0.00%)
    benchCoerce # string....................R3 I13 - [Mo1.250μs vs. Mo1.875μs] -33.32% (±0.00%)
    benchCoerce # float.....................R2 I5 - [Mo1.125μs vs. Mo1.250μs] -10.00% (±0.00%)
    benchCoerce # instanceof Stringable (ex.R5 I11 - [Mo1.750μs vs. Mo2.625μs] -33.35% (±3.69%)
    benchCoerce # instanceof Stringable (im.R2 I12 - [Mo1.750μs vs. Mo2.500μs] -30.01% (±0.00%)
    benchAssert.............................R1 I2 - [Mo1.125μs vs. Mo1.125μs] 0.00% (±0.00%)
    benchMatch..............................R1 I7 - [Mo0.875μs vs. Mo1.000μs] -12.50% (±0.00%)

Subjects: 21, Assertions: 0, Failures: 0, Errors: 0

```

## Dependencies

 * [ ] https://github.com/phpbench/phpbench/pull/918