### PR TITLE
[Fun] tap()

### DIFF
--- a/docs/component/fun.md
+++ b/docs/component/fun.md
@@ -17,6 +17,7 @@
 - [lazy](./../../src/Psl/Fun/lazy.php#L16)
 - [pipe](./../../src/Psl/Fun/pipe.php#L34)
 - [rethrow](./../../src/Psl/Fun/rethrow.php#L17)
+- [tap](./../../src/Psl/Fun/tap.php#L54)
 - [when](./../../src/Psl/Fun/when.php#L33)
 
 

--- a/src/Psl/Fun/tap.php
+++ b/src/Psl/Fun/tap.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Fun;
+
+/**
+ * Runs the given function with the supplied object, then returns the object.
+ *
+ * Executes the function if a value is provided.
+ * Provides a curries version if no value was provided.
+ *
+ * Example:
+ *
+ *      $run = Fun\tap(
+ *          static function(int $i): void {
+ *              echo 'Result: '.$i.PHP_EOL;
+ *          }
+ *      );
+ *
+ *      $run(1)
+ *      Prints: Result: 1
+ *      => Int(1)
+ *
+ *      $run(2)
+ *      Prints: Result: 2
+ *      => Int(2)
+ *
+ *      $run(3)
+ *      Prints: Result: 3
+ *      => Int(3)
+ *
+ * More real life example:
+ *      Fun\pipe(
+ *          Fun\tap(
+ *              function (User $user) use ($eventDispatcher): void {
+ *                  $eventDispatcher->dispatch(
+ *                      new UserCreatedEvent($user->id)
+ *                  );
+ *              }
+ *          )
+ *       )($user);
+ *
+ *       => $user
+ *
+ * @template T
+ *
+ * @param (callable(T): void) $callback
+ *
+ * @return (callable(T): T)
+ *
+ * @pure
+ */
+function tap(callable $callback): callable
+{
+    return static function (mixed $value) use ($callback): mixed {
+        $callback($value);
+
+        return $value;
+    };
+}

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -146,6 +146,7 @@ final class Loader
         'Psl\Fun\lazy',
         'Psl\Fun\pipe',
         'Psl\Fun\rethrow',
+        'Psl\Fun\tap',
         'Psl\Fun\when',
         'Psl\Internal\boolean',
         'Psl\Internal\type',

--- a/tests/unit/Fun/TapTest.php
+++ b/tests/unit/Fun/TapTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Fun;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Fun;
+use Psl\Hash;
+use Psl\Ref;
+use Psl\Str;
+
+final class TapTest extends TestCase
+{
+    public function testItWorksAsACurriedFunctionThatCanBeUsedForPerformingSideEffects(): void
+    {
+        $log = new Ref('123');
+        $call = Fun\tap(
+            static function (string $x) use ($log): void {
+                $log->value .= $x;
+            }
+        );
+
+        static::assertSame('abc', $call('abc'));
+        static::assertSame('123abc', $log->value);
+
+        static::assertSame('def', $call('def'));
+        static::assertSame('123abcdef', $log->value);
+    }
+
+    public function testItCanBeCombinedInOtherFlowsForDebugging(): void
+    {
+        $log = new Ref('');
+        $result = Fun\pipe(
+            static fn (string $x) => Hash\hash($x, 'md5'),
+            Fun\tap(static function ($x) use ($log): void {
+                $log->value = $x;
+            }),
+            static fn (string $x): string => Str\truncate($x, 0, 1),
+        )('abc');
+
+        $md5 = Hash\hash('abc', 'md5');
+        $firstChar = Str\truncate($md5, 0, 1);
+
+        static::assertSame($firstChar, $result);
+        static::assertSame($md5, $log->value);
+    }
+}


### PR DESCRIPTION
This PR provides a `Fun\tap()` function.
It can be used to perform side effects in e.g. a pipeline whilst still keeping track of the original object.

```php
Fun\pipe(
    Fun\tap(
        function (User $user) use ($eventDispatcher): void {
            $eventDispatcher->dispatch(
                new UserCreatedEvent($user->id)
            );
        }
    )    
)($user);
```
```
=> $user
```

It can be handy for debugging intermediate pipeline stages this way:

```php
$log = new Ref('');
$result = Fun\pipe(
    static fn (string $x) => md5($x),
    Fun\tap(static function ($x) use ($log): void {
        $log->value = $x;
    }),
    static fn (string $x): string => Str\truncate($x, 0, 1),
)('abc');
```

Or for making broken architectures a bit more easy to integrate:

```php
$user = tap(
    static function (User $user): void {
        $user->name = 'taylor';
        $user->save();
    }
)(User::first());
```


The implementation is based on the one from [ramda](https://ramdajs.com/docs/#tap) without the value part.
You will get back a callable that takes a value as input and returns the input value as a result of that function. You can perform any action in between input and output.


Other languages / implementations

- Ramda : https://ramdajs.com/docs/#tap
- Ruby : https://medium.com/aviabird/ruby-tap-that-method-90c8a801fd6a
- Laravel : https://medium.com/@tanmaymishu/the-anatomy-of-laravels-tap-function-ea239c9846ab (This one has a higher order tap version - which I find very confusing)


