### PR TITLE
[Documentation] add documentation functions to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,10 @@ code-coverage: unit-tests                                                       
 	composer global require php-coveralls/php-coveralls
 	php-coveralls -x tests/logs/clover.xml -o tests/logs/coveralls-upload.json -v
 
-check: coding-standard-check static-analysis security-analysis unit-tests       ## run quick checks for local development iterations
+docs-generate:                                                                  ## regenerate docs
+	php docs/documenter.php
+
+docs-check:                                                                     ## checks if docs are up to date
+	php docs/documenter.php check
+
+check: coding-standard-check static-analysis security-analysis unit-tests docs-check  ## run quick checks for local development iterations


### PR DESCRIPTION
This PR adds functions to the makefile for generating the docs:

```
docs-generate                  regenerate docs
docs-check                     checks if docs are up to date
```

The docs-check now gets executed when running `make check` locally.
This will avoid github actions failure in advance until #206 is in place.