### PR TITLE
feat(shell): refactor `Shell\execute` to use async streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 * refactored `Psl\IO` handles API.
 * introduced a new `Psl\File` component.
 * refactor `Psl\Filesystem\write_file`, `Psl\Filesystem\append_file`, and `Psl\Filesystem\read_file` to use `Psl\File` component.
+* refactor `Psl\Shell\execute` to use `Psl\IO\Stream` component.

--- a/docs/component/shell.md
+++ b/docs/component/shell.md
@@ -14,6 +14,6 @@
 
 - [escape_argument](./../../src/Psl/Shell/escape_argument.php#L17)
 - [escape_command](./../../src/Psl/Shell/escape_command.php#L14)
-- [execute](./../../src/Psl/Shell/execute.php#L37)
+- [execute](./../../src/Psl/Shell/execute.php#L40)
 
 

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -582,6 +582,7 @@ final class Loader
         'Psl\Shell\Exception\FailedExecutionException',
         'Psl\Shell\Exception\RuntimeException',
         'Psl\Shell\Exception\PossibleAttackException',
+        'Psl\Shell\Exception\TimeoutException',
         'Psl\Math\Exception\ArithmeticException',
         'Psl\Math\Exception\DivisionByZeroException',
         'Psl\Filesystem\Exception\RuntimeException',

--- a/src/Psl/Shell/Exception/TimeoutException.php
+++ b/src/Psl/Shell/Exception/TimeoutException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Shell\Exception;
+
+final class TimeoutException extends RuntimeException
+{
+}


### PR DESCRIPTION
Signed-off-by: azjezz <azjezz@protonmail.com>

---

This allows executing multiple shell commands concurrently, as follows:

```php
<?php

declare(strict_types=1);

use Psl\Async;
use Psl\Shell;

require 'vendor/autoload.php';

$time = time();

Async\concurrent([
    fn() => Shell\execute('sleep', ['2']),
    fn() => Shell\execute('sleep', ['2']),
    fn() => Shell\execute('sleep', ['2']),
]);

$duration = time() - $time;

print $duration; // 2
```