### PR TITLE
Call clearstatcache after writing to a file to reset file stat

### DIFF
--- a/src/Psl/Filesystem/Internal/write_file.php
+++ b/src/Psl/Filesystem/Internal/write_file.php
@@ -10,6 +10,7 @@ use Psl\Filesystem\Exception;
 use Psl\Internal;
 use Psl\Str;
 
+use function clearstatcache;
 use function file_put_contents;
 
 use const FILE_APPEND;
@@ -64,4 +65,6 @@ function write_file(string $file, string $content, bool $append): void
         ));
     }
     // @codeCoverageIgnoreEnd
+
+    clearstatcache();
 }

--- a/tests/unit/Filesystem/FileTest.php
+++ b/tests/unit/Filesystem/FileTest.php
@@ -95,6 +95,21 @@ final class FileTest extends AbstractFilesystemTest
         Filesystem\delete_file($file);
     }
 
+    public function testWriteFileClearsFileStat(): void
+    {
+        $file = Filesystem\create_temporary_file();
+
+        Filesystem\write_file($file, 'Hello');
+
+        static::assertSame(5, Filesystem\file_size($file));
+
+        Filesystem\append_file($file, ', World!');
+
+        static::assertSame(13, Filesystem\file_size($file));
+
+        Filesystem\delete_file($file);
+    }
+
     public function testWriteFileThrowsForDirectories(): void
     {
         $this->expectException(InvariantViolationException::class);


### PR DESCRIPTION
`write_file` internally calls `is_file` before writing to the file. This means the file stat is cached before the write operation.

If we do not clear the cache, many functions like `filesize` will report invalid data. 