### PR TITLE
feat(channel): introduce new channel component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@
 * introduced a new `Psl\Network` component.
 * introduced a new `Psl\TCP` component.
 * introduced a new `Psl\Unix` component.
+* introduced a new `Psl\Channel` component.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 
 - [Psl](./component/psl.md)
 - [Psl\Async](./component/async.md)
+- [Psl\Channel](./component/channel.md)
 - [Psl\Class](./component/class.md)
 - [Psl\Collection](./component/collection.md)
 - [Psl\DataStructure](./component/data-structure.md)

--- a/docs/component/channel.md
+++ b/docs/component/channel.md
@@ -1,0 +1,23 @@
+<!--
+    This markdown file was generated using `docs/documenter.php`.
+
+    Any edits to it will likely be lost.
+-->
+
+[*index](./../README.md)
+
+---
+
+### `Psl\Channel` Component
+
+#### `Functions`
+
+- [bounded](./../../src/Psl/Channel/bounded.php#L18)
+- [unbounded](./../../src/Psl/Channel/unbounded.php#L16)
+
+#### `Interfaces`
+
+- [ReceiverInterface](./../../src/Psl/Channel/ReceiverInterface.php#L12)
+- [SenderInterface](./../../src/Psl/Channel/SenderInterface.php#L12)
+
+

--- a/docs/component/data-structure.md
+++ b/docs/component/data-structure.md
@@ -18,8 +18,8 @@
 
 #### `Classes`
 
-- [PriorityQueue](./../../src/Psl/DataStructure/PriorityQueue.php#L18)
-- [Queue](./../../src/Psl/DataStructure/Queue.php#L19)
+- [PriorityQueue](./../../src/Psl/DataStructure/PriorityQueue.php#L20)
+- [Queue](./../../src/Psl/DataStructure/Queue.php#L21)
 - [Stack](./../../src/Psl/DataStructure/Stack.php#L19)
 
 

--- a/docs/documenter.php
+++ b/docs/documenter.php
@@ -184,6 +184,7 @@ function get_all_components(): array
     $components = [
         'Psl',
         'Psl\\Async',
+        'Psl\\Channel',
         'Psl\\Class',
         'Psl\\Collection',
         'Psl\\DataStructure',

--- a/examples/channel/main.php
+++ b/examples/channel/main.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Example\IO;
+
+use Psl\Async;
+use Psl\Channel;
+use Psl\IO;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+/**
+ * @var Channel\ReceiverInterface<string> $receiver
+ * @var Channel\SenderInterface<string> $sender
+ */
+[$receiver, $sender] = Channel\unbounded();
+
+Async\Scheduler::delay(1, static function () use ($sender) {
+    $sender->send('Hello, World!');
+});
+
+$message = $receiver->receive();
+
+IO\output_handle()->writeAll($message);

--- a/src/Psl/Channel/ChannelInterface.php
+++ b/src/Psl/Channel/ChannelInterface.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Channel;
+
+use Countable;
+
+/**
+ * @template T
+ */
+interface ChannelInterface extends Countable
+{
+    /**
+     * Returns the channel capacity if it’s bounded.
+     *
+     * @mutation-free
+     */
+    public function getCapacity(): ?int;
+
+    /**
+     * Closes the channel.
+     *
+     * The remaining messages can still be received.
+     */
+    public function close(): void;
+
+    /**
+     * Returns true if the channel is closed.
+     *
+     * @mutation-free
+     */
+    public function isClosed(): bool;
+
+    /**
+     * Returns the number of messages in the channel.
+     *
+     * @return positive-int|0
+     *
+     * @mutation-free
+     */
+    public function count(): int;
+
+    /**
+     * Returns true if the channel is full.
+     *
+     * Unbounded channels are never full.
+     *
+     * @mutation-free
+     */
+    public function isFull(): bool;
+
+    /**
+     * Returns true if the channel is empty.
+     *
+     * @mutation-free
+     */
+    public function isEmpty(): bool;
+}

--- a/src/Psl/Channel/Exception/ClosedChannelException.php
+++ b/src/Psl/Channel/Exception/ClosedChannelException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Channel\Exception;
+
+use Psl\Channel;
+use Psl\Exception\RuntimeException;
+
+/**
+ * This exception is thrown when attempting to send or receive a message on a closed channel.
+ *
+ * @see Channel\SenderInterface::send()
+ * @see Channel\SenderInterface::trySend()
+ * @see Channel\ReceiverInterface::receive()
+ * @see Channel\ReceiverInterface::tryReceive()
+ */
+final class ClosedChannelException extends RuntimeException implements ExceptionInterface
+{
+    public function __construct(string $message = 'Channel has been closed')
+    {
+        parent::__construct($message);
+    }
+
+    public static function forSending(): ClosedChannelException
+    {
+        return new self('Attempted to send a message to a closed channel.');
+    }
+
+    public static function forReceiving(): ClosedChannelException
+    {
+        return new self('Attempted to receive a message from a closed empty channel.');
+    }
+}

--- a/src/Psl/Channel/Exception/EmptyChannelException.php
+++ b/src/Psl/Channel/Exception/EmptyChannelException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Channel\Exception;
+
+use OutOfBoundsException;
+use Psl\Channel;
+
+/**
+ * This exception is throw when calling {@see Channel\ReceiverInterface::tryReceive()} on an empty channel.
+ */
+final class EmptyChannelException extends OutOfBoundsException implements ExceptionInterface
+{
+    public static function create(): EmptyChannelException
+    {
+        return new self('Attempted to receiver from an empty channel.');
+    }
+}

--- a/src/Psl/Channel/Exception/ExceptionInterface.php
+++ b/src/Psl/Channel/Exception/ExceptionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Channel\Exception;
+
+use Psl\Exception;
+
+interface ExceptionInterface extends Exception\ExceptionInterface
+{
+}

--- a/src/Psl/Channel/Exception/FullChannelException.php
+++ b/src/Psl/Channel/Exception/FullChannelException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Channel\Exception;
+
+use OutOfBoundsException;
+use Psl\Channel;
+use Psl\Str;
+
+/**
+ * This exception is throw when calling {@see Channel\SenderInterface::trySend()} on a full channel.
+ */
+final class FullChannelException extends OutOfBoundsException implements ExceptionInterface
+{
+    public static function ofCapacity(int $capacity): FullChannelException
+    {
+        return new self(Str\format('Channel has reached its full capacity of %d.', $capacity));
+    }
+}

--- a/src/Psl/Channel/Internal/ChannelState.php
+++ b/src/Psl/Channel/Internal/ChannelState.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Channel\Internal;
+
+use Psl\Channel\ChannelInterface;
+use Psl\Channel\Exception;
+use Psl\DataStructure\Queue;
+use Psl\DataStructure\QueueInterface;
+
+/**
+ * @template T
+ *
+ * @implements ChannelInterface<T>
+ *
+ * @internal
+ */
+final class ChannelState implements ChannelInterface
+{
+    /**
+     * @var QueueInterface<T>
+     */
+    private QueueInterface $messages;
+
+    private bool $closed = false;
+
+    public function __construct(
+        private ?int $capacity = null,
+    ) {
+        $this->messages = new Queue();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCapacity(): ?int
+    {
+        return $this->capacity;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function close(): void
+    {
+        $this->closed = true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isClosed(): bool
+    {
+        return $this->closed;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function count(): int
+    {
+        return $this->messages->count();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isFull(): bool
+    {
+        if (null === $this->capacity) {
+            return false;
+        }
+
+        return $this->capacity === $this->count();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isEmpty(): bool
+    {
+        return 0 === $this->messages->count();
+    }
+
+    /**
+     * @param T $message
+     *
+     * @throws Exception\ClosedChannelException If the channel is closed.
+     * @throws Exception\FullChannelException If the channel is full.
+     */
+    public function send(mixed $message): void
+    {
+        if ($this->closed) {
+            throw Exception\ClosedChannelException::forSending();
+        }
+
+        if (null === $this->capacity || $this->capacity > $this->count()) {
+            $this->messages->enqueue($message);
+
+            return;
+        }
+
+        throw Exception\FullChannelException::ofCapacity($this->capacity);
+    }
+
+    /**
+     * @throws Exception\ClosedChannelException If the channel is closed, and there's no more messages to receive.
+     * @throws Exception\EmptyChannelException If the channel is empty.
+     *
+     * @return T
+     */
+    public function receive(): mixed
+    {
+        $empty = 0 === $this->count();
+        $closed = $this->closed;
+        if ($closed && $empty) {
+            throw Exception\ClosedChannelException::forReceiving();
+        }
+
+        if ($empty) {
+            throw Exception\EmptyChannelException::create();
+        }
+
+        /** @psalm-suppress MissingThrowsDocblock */
+        return $this->messages->dequeue();
+    }
+}

--- a/src/Psl/Channel/Internal/Receiver.php
+++ b/src/Psl/Channel/Internal/Receiver.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Channel\Internal;
+
+use Psl\Async;
+use Psl\Channel\Exception;
+use Psl\Channel\ReceiverInterface;
+
+/**
+ * @template T
+ *
+ * @implements ReceiverInterface<T>
+ */
+final class Receiver implements ReceiverInterface
+{
+    /**
+     * @var null|Async\Deferred<T>
+     */
+    private ?Async\Deferred $deferred = null;
+
+    /**
+     * @param ChannelState<T> $state
+     */
+    public function __construct(
+        private ChannelState $state
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function receive(): mixed
+    {
+        // there's a pending operation? wait for it.
+        $this->deferred?->getAwaitable()->then(static fn() => null, static fn() => null)->ignore()->await();
+
+        if ($this->state->isEmpty()) {
+            $this->deferred = new Async\Deferred();
+
+            Async\Scheduler::repeat(0.0001, function (string $identifier): void {
+                if (null === $this->deferred) {
+                    Async\Scheduler::cancel($identifier);
+                }
+
+                if ($this->state->isClosed()) {
+                    /**
+                     * Channel has been closed from the receiving side.
+                     *
+                     * @psalm-suppress PossiblyNullReference
+                     */
+                    if (!$this->deferred->isComplete()) {
+                        /** @psalm-suppress PossiblyNullReference */
+                        $this->deferred->error(Exception\ClosedChannelException::forSending());
+                    }
+
+                    return;
+                }
+
+                if (!$this->state->isEmpty()) {
+                    /** @psalm-suppress PossiblyNullReference */
+                    $this->deferred->complete(null);
+                }
+            });
+
+            /** @psalm-suppress PossiblyNullReference */
+            $this->deferred->getAwaitable()->await();
+            $this->deferred = null;
+        }
+
+        /** @psalm-suppress MissingThrowsDocblock */
+        return $this->state->receive();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tryReceive(): mixed
+    {
+        return $this->state->receive();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCapacity(): ?int
+    {
+        return $this->state->getCapacity();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function close(): void
+    {
+        $this->deferred?->error(Exception\ClosedChannelException::forSending());
+
+        $this->state->close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isClosed(): bool
+    {
+        return $this->state->isClosed();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function count(): int
+    {
+        return $this->state->count();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isFull(): bool
+    {
+        return $this->state->isFull();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isEmpty(): bool
+    {
+        return $this->state->isEmpty();
+    }
+}

--- a/src/Psl/Channel/Internal/Sender.php
+++ b/src/Psl/Channel/Internal/Sender.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Channel\Internal;
+
+use Psl\Async;
+use Psl\Channel\Exception;
+use Psl\Channel\SenderInterface;
+
+/**
+ * @template T
+ *
+ * @implements SenderInterface<T>
+ */
+final class Sender implements SenderInterface
+{
+    /**
+     * @var null|Async\Deferred<T>
+     */
+    private ?Async\Deferred $deferred = null;
+
+    /**
+     * @param ChannelState<T> $state
+     */
+    public function __construct(
+        private ChannelState $state
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function send(mixed $message): void
+    {
+        // there's a pending operation? wait for it.
+        $this->deferred?->getAwaitable()->then(static fn() => null, static fn() => null)->ignore()->await();
+
+        if ($this->state->isFull()) {
+            $this->deferred = new Async\Deferred();
+
+            Async\Scheduler::repeat(0.0001, function (string $identifier): void {
+                if (null === $this->deferred) {
+                    Async\Scheduler::cancel($identifier);
+                }
+
+                if ($this->state->isClosed()) {
+                    /**
+                     * Channel has been closed from the receiving side.
+                     *
+                     * @psalm-suppress PossiblyNullReference
+                     */
+                    if (!$this->deferred->isComplete()) {
+                        /** @psalm-suppress PossiblyNullReference */
+                        $this->deferred->error(Exception\ClosedChannelException::forSending());
+                    }
+
+                    return;
+                }
+
+                if (!$this->state->isFull()) {
+                    /** @psalm-suppress PossiblyNullReference */
+                    $this->deferred->complete(null);
+                }
+            });
+
+            /** @psalm-suppress PossiblyNullReference */
+            $this->deferred->getAwaitable()->await();
+            $this->deferred = null;
+        }
+
+        /** @psalm-suppress MissingThrowsDocblock */
+        $this->state->send($message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function trySend(mixed $message): void
+    {
+        $this->state->send($message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCapacity(): ?int
+    {
+        return $this->state->getCapacity();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function close(): void
+    {
+        $this->deferred?->error(Exception\ClosedChannelException::forSending());
+
+        $this->state->close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isClosed(): bool
+    {
+        return $this->state->isClosed();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function count(): int
+    {
+        return $this->state->count();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isFull(): bool
+    {
+        return $this->state->isFull();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isEmpty(): bool
+    {
+        return $this->state->isEmpty();
+    }
+}

--- a/src/Psl/Channel/ReceiverInterface.php
+++ b/src/Psl/Channel/ReceiverInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Channel;
+
+/**
+ * @template T
+ *
+ * @extends ChannelInterface<T>
+ */
+interface ReceiverInterface extends ChannelInterface
+{
+    /**
+     * Receives a message from the channel.
+     *
+     * If the channel is empty, this method waits until there is a message.
+     *
+     * If the channel is closed, this method receives a message or throws if there are no more messages.
+     *
+     * @throws Exception\ClosedChannelException If the channel is closed, and there's no more messages to receive.
+     *
+     * @return T
+     */
+    public function receive(): mixed;
+
+    /**
+     * Receives a message from the channel immediately.
+     *
+     * If the channel is empty, this method will throw an exception.
+     *
+     * If the channel is closed, this method receives a message or throws if there are no more messages.
+     *
+     * @throws Exception\ClosedChannelException If the channel is closed, and there's no more messages to receive.
+     * @throws Exception\EmptyChannelException If the channel is empty.
+     *
+     * @return T
+     */
+    public function tryReceive(): mixed;
+}

--- a/src/Psl/Channel/SenderInterface.php
+++ b/src/Psl/Channel/SenderInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Channel;
+
+/**
+ * @template T
+ *
+ * @extends ChannelInterface<T>
+ */
+interface SenderInterface extends ChannelInterface
+{
+    /**
+     * Send a message to the channel.
+     *
+     * If the channel is full, this method waits until there is space for a message.
+     *
+     * If the channel is closed, this method throws.
+     *
+     * @param T $message
+     *
+     * @throws Exception\ClosedChannelException If the channel is closed.
+     */
+    public function send(mixed $message): void;
+
+    /**
+     * Receives a message from the channel immediately.
+     *
+     * If the channel is full, this method will throw an exception.
+     *
+     * If the channel is closed, this method throws.
+     *
+     * @param T $message
+     *
+     * @throws Exception\ClosedChannelException If the channel is closed.
+     * @throws Exception\FullChannelException If the channel is full.
+     */
+    public function trySend(mixed $message): void;
+}

--- a/src/Psl/Channel/bounded.php
+++ b/src/Psl/Channel/bounded.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Channel;
+
+/**
+ * Creates a bounded channel.
+ *
+ * The created channel has space to hold at most $capacity messages at a time.
+ *
+ * @template T
+ *
+ * @param positive-int $capacity
+ *
+ * @return array{0: ReceiverInterface<T>, 1: SenderInterface<T>}
+ */
+function bounded(int $capacity): array
+{
+    $channel = new Internal\ChannelState($capacity);
+
+    return [
+        new Internal\Receiver($channel),
+        new Internal\Sender($channel),
+    ];
+}

--- a/src/Psl/Channel/unbounded.php
+++ b/src/Psl/Channel/unbounded.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Channel;
+
+/**
+ * Creates an unbounded channel.
+ *
+ * The created channel can hold an unlimited number of messages.
+ *
+ * @template T
+ *
+ * @return array{0: ReceiverInterface<T>, 1: SenderInterface<T>}
+ */
+function unbounded(): array
+{
+    $channel = new Internal\ChannelState();
+
+    return [
+        new Internal\Receiver($channel),
+        new Internal\Sender($channel),
+    ];
+}

--- a/src/Psl/DataStructure/PriorityQueue.php
+++ b/src/Psl/DataStructure/PriorityQueue.php
@@ -10,6 +10,8 @@ use Psl\Iter;
 use Psl\Math;
 use Psl\Vec;
 
+use function count;
+
 /**
  * @template T
  *
@@ -128,14 +130,17 @@ final class PriorityQueue implements PriorityQueueInterface
 
     /**
      * Count the nodes in the queue.
+     *
+     * @return positive-int|0
      */
     public function count(): int
     {
         $count = 0;
         foreach ($this->queue as $_priority => $list) {
-            $count += Iter\count($list);
+            $count += count($list);
         }
 
+        /** @var positive-int|0 */
         return $count;
     }
 }

--- a/src/Psl/DataStructure/Queue.php
+++ b/src/Psl/DataStructure/Queue.php
@@ -9,6 +9,8 @@ use Psl\Dict;
 use Psl\Iter;
 use Psl\Vec;
 
+use function count;
+
 /**
  * A basic implementation of a queue data structure ( FIFO ).
  *
@@ -79,9 +81,11 @@ final class Queue implements QueueInterface
 
     /**
      * Count the nodes in the queue.
+     *
+     * @return positive-int|0
      */
     public function count(): int
     {
-        return Iter\count($this->queue);
+        return count($this->queue);
     }
 }

--- a/src/Psl/DataStructure/QueueInterface.php
+++ b/src/Psl/DataStructure/QueueInterface.php
@@ -50,6 +50,8 @@ interface QueueInterface extends Countable
 
     /**
      * Count the nodes in the queue.
+     *
+     * @return positive-int|0
      */
     public function count(): int;
 }

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -476,6 +476,8 @@ final class Loader
         'Psl\Network\Internal\server_listen',
         'Psl\TCP\connect',
         'Psl\Unix\connect',
+        'Psl\Channel\bounded',
+        'Psl\Channel\unbounded',
     ];
 
     public const INTERFACES = [
@@ -533,6 +535,9 @@ final class Loader
         'Psl\Network\ServerInterface',
         'Psl\TCP\SocketInterface',
         'Psl\Unix\SocketInterface',
+        'Psl\Channel\SenderInterface',
+        'Psl\Channel\ReceiverInterface',
+        'Psl\Channel\Exception\ExceptionInterface',
     ];
 
     public const TRAITS = [
@@ -665,6 +670,12 @@ final class Loader
         'Psl\TCP\Internal\Socket',
         'Psl\Unix\Server',
         'Psl\Unix\Internal\Socket',
+        'Psl\Channel\Internal\ChannelState',
+        'Psl\Channel\Internal\Sender',
+        'Psl\Channel\Internal\Receiver',
+        'Psl\Channel\Exception\ClosedChannelException',
+        'Psl\Channel\Exception\EmptyChannelException',
+        'Psl\Channel\Exception\FullChannelException',
     ];
 
     public const ENUMS = [

--- a/tests/unit/Channel/BoundedChannelTest.php
+++ b/tests/unit/Channel/BoundedChannelTest.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Channel;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Async;
+use Psl\Channel;
+
+final class BoundedChannelTest extends TestCase
+{
+    public function testCapacity(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        static::assertSame(1, $receiver->getCapacity());
+        static::assertSame(1, $sender->getCapacity());
+    }
+
+    public function testCloseSender(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        static::assertFalse($receiver->isClosed());
+        static::assertFalse($sender->isClosed());
+
+        $sender->close();
+
+        static::assertTrue($receiver->isClosed());
+        static::assertTrue($sender->isClosed());
+    }
+
+    public function testCloseReceiver(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        static::assertFalse($receiver->isClosed());
+        static::assertFalse($sender->isClosed());
+
+        $receiver->close();
+
+        static::assertTrue($receiver->isClosed());
+        static::assertTrue($sender->isClosed());
+    }
+
+    public function testCount(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(2);
+
+        static::assertSame(0, $receiver->count());
+        static::assertSame(0, $sender->count());
+
+        $sender->send('foo');
+        $sender->send('bar');
+
+        static::assertSame(2, $receiver->count());
+        static::assertSame(2, $sender->count());
+
+        static::assertSame('foo', $receiver->receive());
+
+        static::assertSame(1, $receiver->count());
+        static::assertSame(1, $sender->count());
+
+        static::assertSame('bar', $receiver->tryReceive());
+
+        static::assertSame(0, $receiver->count());
+        static::assertSame(0, $sender->count());
+
+        $sender->trySend('baz');
+
+        static::assertSame(1, $receiver->count());
+        static::assertSame(1, $sender->count());
+    }
+
+    public function testIsFull(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        static::assertFalse($receiver->isFull());
+        static::assertFalse($sender->isFull());
+
+        $sender->send('foo');
+
+        static::assertTrue($receiver->isFull());
+        static::assertTrue($sender->isFull());
+    }
+
+    public function testTrySendThrowsOnFullChannel(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        $sender->send('hello');
+
+        $this->expectException(Channel\Exception\FullChannelException::class);
+
+        $sender->trySend('world');
+    }
+
+    public function testSendWaitsForFullChannel(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        $sender->send('hello');
+
+        Async\Scheduler::delay(0.001, static function () use ($receiver) {
+            $receiver->receive();
+        });
+
+        static::assertTrue($receiver->isFull());
+
+        $sender->send('world');
+    }
+
+    public function testSendThrowsForClosedChannel(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        $receiver->close();
+
+        $this->expectException(Channel\Exception\ClosedChannelException::class);
+
+        $sender->send('world');
+    }
+
+    public function testSendThrowsForLateClosedChannel(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        $sender->send('hello');
+
+        Async\Scheduler::delay(0.001, static function () use ($receiver): void {
+            $receiver->close();
+        });
+
+        $this->expectException(Channel\Exception\ClosedChannelException::class);
+
+        $sender->send('world');
+    }
+
+    public function testTrySendThrowsForClosedChannel(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        $receiver->close();
+
+        $this->expectException(Channel\Exception\ClosedChannelException::class);
+
+        $sender->trySend('world');
+    }
+
+    public function testReceiveThrowsForClosedChannel(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        $sender->close();
+
+        $this->expectException(Channel\Exception\ClosedChannelException::class);
+
+        $receiver->receive();
+    }
+
+    public function testReceiveThrowsForLateClosedChannel(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        Async\Scheduler::delay(0.0001, static function () use ($sender): void {
+            $sender->close();
+        });
+
+        $this->expectException(Channel\Exception\ClosedChannelException::class);
+
+        $receiver->receive();
+    }
+
+    public function testTryReceiveThrowsForClosedChannel(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        $sender->close();
+
+        $this->expectException(Channel\Exception\ClosedChannelException::class);
+
+        $receiver->tryReceive();
+    }
+
+    public function testReceiveWaitsWhenChannelIsEmpty(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        Async\Scheduler::delay(0.001, static function () use ($sender) {
+            $sender->send('hello');
+        });
+
+        static::assertTrue($receiver->isEmpty());
+
+        static::assertSame('hello', $receiver->receive());
+    }
+
+    public function testTryReceiveThrowsForEmptyChannel(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\bounded(1);
+
+        $this->expectException(Channel\Exception\EmptyChannelException::class);
+
+        $receiver->tryReceive();
+    }
+}

--- a/tests/unit/Channel/UnboundedChannelTest.php
+++ b/tests/unit/Channel/UnboundedChannelTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Channel;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Channel;
+
+final class UnboundedChannelTest extends TestCase
+{
+    public function testCapacity(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\unbounded();
+
+        static::assertNull($receiver->getCapacity());
+        static::assertNull($sender->getCapacity());
+    }
+
+    public function testCloseSender(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\unbounded();
+
+        static::assertFalse($receiver->isClosed());
+        static::assertFalse($sender->isClosed());
+
+        $sender->close();
+
+        static::assertTrue($receiver->isClosed());
+        static::assertTrue($sender->isClosed());
+    }
+
+    public function testCloseReceiver(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\unbounded();
+
+        static::assertFalse($receiver->isClosed());
+        static::assertFalse($sender->isClosed());
+
+        $receiver->close();
+
+        static::assertTrue($receiver->isClosed());
+        static::assertTrue($sender->isClosed());
+    }
+
+    public function testCount(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\unbounded();
+
+        static::assertSame(0, $receiver->count());
+        static::assertSame(0, $sender->count());
+
+        $sender->send('foo');
+        $sender->send('bar');
+
+        static::assertSame(2, $receiver->count());
+        static::assertSame(2, $sender->count());
+
+        static::assertSame('foo', $receiver->receive());
+
+        static::assertSame(1, $receiver->count());
+        static::assertSame(1, $sender->count());
+
+        static::assertSame('bar', $receiver->tryReceive());
+
+        static::assertSame(0, $receiver->count());
+        static::assertSame(0, $sender->count());
+
+        $sender->trySend('baz');
+
+        static::assertSame(1, $receiver->count());
+        static::assertSame(1, $sender->count());
+    }
+
+    public function testIsFull(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\unbounded();
+
+        static::assertFalse($receiver->isFull());
+        static::assertFalse($sender->isFull());
+
+        $sender->send('foo');
+
+        static::assertFalse($receiver->isFull());
+        static::assertFalse($sender->isFull());
+    }
+
+    public function testIsEmpty(): void
+    {
+        /**
+         * @var Channel\ReceiverInterface<string> $receiver
+         * @var Channel\SenderInterface<string> $sender
+         */
+        [$receiver, $sender] = Channel\unbounded();
+
+        static::assertTrue($receiver->isEmpty());
+        static::assertTrue($sender->isEmpty());
+
+        $sender->send('foo');
+
+        static::assertFalse($receiver->isEmpty());
+        static::assertFalse($sender->isEmpty());
+    }
+}


### PR DESCRIPTION
Inspired by [async_std::channel](https://docs.rs/async-std/1.10.0/async_std/channel/index.html) module, The `Channel` component provides asynchronous channels for communication between different component of an application.

e.g:

```php
use Psl\Async;
use Psl\Channel;

/**
 * @var Channel\ReceiverInterface<string> $receiver
 * @var Channel\SenderInterface<string> $sender
 */
[$receiver, $sender] = Channel\bounded(2);

Async\Scheduler::defer(function() use($sender) {
  Async\sleep(1); // sleep for a second.

  $sender->send('hello');
});

$message = $receiver->receive(); // 'hello'
```