### PR TITLE
feat(io): introduce write(), write_line(), write_error(), and write_error_line() functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,7 @@
 * introduced a new `Psl\TCP` component.
 * introduced a new `Psl\Unix` component.
 * introduced a new `Psl\Channel` component.
+* introduced a new `IO\write()` function.
+* introduced a new `IO\write_line()` function.
+* introduced a new `IO\write_error()` function.
+* introduced a new `IO\write_error_line()` functions.

--- a/docs/component/io.md
+++ b/docs/component/io.md
@@ -16,6 +16,10 @@
 - [input_handle](./../../src/Psl/IO/input_handle.php#L20)
 - [output_handle](./../../src/Psl/IO/output_handle.php#L20)
 - [pipe](./../../src/Psl/IO/pipe.php#L24)
+- [write](./../../src/Psl/IO/write.php#L21)
+- [write_error](./../../src/Psl/IO/write_error.php#L23)
+- [write_error_line](./../../src/Psl/IO/write_error_line.php#L23)
+- [write_line](./../../src/Psl/IO/write_line.php#L21)
 
 #### `Interfaces`
 

--- a/examples/async/usleep.php
+++ b/examples/async/usleep.php
@@ -20,7 +20,7 @@ Async\main(static function (): int {
 
     $duration = time() - $start;
 
-    IO\output_handle()->writeAll("duration: $duration\n");
+    IO\write_error_line("duration: %d.", $duration);
 
     return 0;
 });

--- a/examples/channel/bounded.php
+++ b/examples/channel/bounded.php
@@ -24,7 +24,7 @@ Async\main(static function () {
                 $receiver->receive();
             }
         } catch (Channel\Exception\ClosedChannelException) {
-            IO\output_handle()->write("[ receiver ]: completed.\n");
+            IO\write_error_line("[ receiver ]: completed.");
         }
     });
 
@@ -38,7 +38,7 @@ Async\main(static function () {
         }
     }
 
-    IO\output_handle()->writeAll("[ sender   ]: completed.\n");
+    IO\write_error_line("[ sender   ]: completed.");
     $sender->close();
 
     return 0;

--- a/examples/channel/main.php
+++ b/examples/channel/main.php
@@ -22,4 +22,4 @@ Async\Scheduler::delay(1, static function () use ($sender) {
 
 $message = $receiver->receive();
 
-IO\output_handle()->writeAll($message);
+IO\write_error_line($message);

--- a/examples/io/benchmark.php
+++ b/examples/io/benchmark.php
@@ -18,7 +18,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 
 Async\main(static function (): int {
     if (PHP_OS_FAMILY === 'Windows') {
-        IO\output_handle()->writeAll('This example does not support Windows.');
+        IO\write_error_line('This example does not support Windows.');
 
         return 0;
     }
@@ -32,11 +32,10 @@ Async\main(static function (): int {
     $input_file = Regex\replace($input_file, '(^/dev/fd/)', 'php://fd/');
     $output_file = Regex\replace($output_file, '(^/dev/fd/)', 'php://fd/');
 
-    $stdout = IO\output_handle();
     $input = new IO\Stream\CloseReadHandle(fopen($input_file, 'rb'));
     $output = new IO\Stream\CloseWriteHandle(fopen($output_file, 'wb'));
 
-    $stdout->writeAll('piping from ' . $input_file . ' to ' . $output_file . ' (for max ' . $seconds . ' second(s)) ...' . PHP_EOL);
+    IO\write_error_line('piping from %s to %s (for max %d second(s)) ...', $input_file, $output_file, $seconds);
 
     Async\Scheduler::delay($seconds, $input->close(...));
 
@@ -56,8 +55,8 @@ Async\main(static function (): int {
     $bytes = $i * 65536;
     $bytes_formatted = round($bytes / 1024 / 1024 / $seconds, 1);
 
-    $stdout->writeAll('read ' . $bytes . ' byte(s) in ' . round($seconds, 3) . ' second(s) => ' . $bytes_formatted . ' MiB/s' . PHP_EOL);
-    $stdout->writeAll('peak memory usage of ' . round(memory_get_peak_usage(true) / 1024 / 1024, 1) . ' MiB' . PHP_EOL);
+    IO\write_error_line('read %d byte(s) in %d second(s) => %dMiB/s', $bytes, round($seconds, 3), $bytes_formatted);
+    IO\write_error_line('peak memory usage of %dMiB', round(memory_get_peak_usage(true) / 1024 / 1024, 1));
 
     return 0;
 });

--- a/examples/io/pipe.php
+++ b/examples/io/pipe.php
@@ -12,35 +12,33 @@ require __DIR__ . '/../../vendor/autoload.php';
 Async\main(static function(): int {
     [$read, $write] = IO\pipe();
 
-    $output = IO\output_handle();
-
     Async\parallel([
-        static function() use($read, $output): void {
-            $output->writeAll("< sleeping.\n");
+        static function() use($read): void {
+            IO\write_error_line("< sleeping.");
 
             Async\sleep(0.01);
 
-            $output->writeAll("< waiting for content.\n");
+            IO\write_error_line("< waiting for content.");
 
             $content = $read->readAll();
 
-            $output->writeAll("< received '$content'.\n");
-            $output->writeAll("< closing.\n");
+            IO\write_error_line('< received "%s".', $content);
+            IO\write_error_line("< closing.");
 
             $read->close();
         },
-        static function() use($write, $output): void {
-            $output->writeAll("> sleeping.\n");
+        static function() use($write): void {
+            IO\write_error_line('> sleeping.');
 
             Async\sleep(0.1);
 
-            $output->writeAll("> writing.\n");
+            IO\write_error_line('> writing.');
 
             $write->writeAll('hello, world');
 
-            $output->write("> written 'hello, world'.\n");
+            IO\write_error_line('> written "hello, world".');
 
-            $output->write("> closing'.\n");
+            IO\write_error_line('> closing.');
 
             $write->close();
         },

--- a/examples/io/queued.php
+++ b/examples/io/queued.php
@@ -24,7 +24,7 @@ Async\main(static function(): int {
     Psl\invariant($he->isComplete(), 'First read should have completed before second one.');
     Psl\invariant('llo' === $llo, 'First read should have completed before second one.');
 
-    IO\output_handle()->write($he->await() . $llo);
+    IO\write_error_line($he->await() . $llo);
 
     return 0;
 });

--- a/examples/run.php
+++ b/examples/run.php
@@ -13,8 +13,6 @@ use Psl\Shell;
 require __DIR__ . '/../vendor/autoload.php';
 
 Async\main(static function (): int {
-    $output = IO\output_handle();
-
     $awaitables = [];
     $folders = Filesystem\read_directory(__DIR__);
     foreach ($folders as $folder) {
@@ -33,7 +31,7 @@ Async\main(static function (): int {
                 continue;
             }
 
-            $output->writeAll("- $component/$script   -> started\n");
+            IO\write_error_line('- %s/%s   -> started', $component, $script);
 
             $awaitables[] = Async\run(static function() use($component, $script, $file): array {
                 $start = microtime(true);
@@ -48,7 +46,7 @@ Async\main(static function (): int {
     foreach (Async\Awaitable::iterate($awaitables) as $awaitable) {
         [$component, $script, $duration] = $awaitable->await();
 
-        $output->writeAll("+ $component/$script   -> finished in {$duration}s\n");
+        IO\write_error_line('+ %s/%s   -> finished in %ds', $component, $script, $duration);
     }
 
     return 0;

--- a/examples/shell/concurrent.php
+++ b/examples/shell/concurrent.php
@@ -24,7 +24,7 @@ Async\main(static function (): int {
 
     $duration = time() - $start;
 
-    IO\output_handle()->writeAll("duration: $duration.\n");
+    IO\write_error_line('duration: %d.', $duration);
 
     return 0;
 });

--- a/examples/shell/main.php
+++ b/examples/shell/main.php
@@ -13,5 +13,5 @@ require __DIR__ . '/../../vendor/autoload.php';
 Async\main(static function (): void {
     $result = Shell\execute('echo', ['hello']);
 
-    IO\output_handle()->writeAll("result: $result");
+    IO\write_error_line('result: "%s".', $result);
 });

--- a/examples/shell/timeout.php
+++ b/examples/shell/timeout.php
@@ -14,6 +14,6 @@ Async\main(static function (): void {
     try {
         Shell\execute('sleep', ['1'], timeout: 0.5);
     } catch (Shell\Exception\TimeoutException $exception) {
-        IO\output_handle()->write($exception->getMessage() . "\n");
+        IO\write_error_line($exception->getMessage());
     }
 });

--- a/examples/tcp/basic-http-client.php
+++ b/examples/tcp/basic-http-client.php
@@ -23,7 +23,7 @@ function fetch(string $host, string $path): string
 Async\main(static function (): int {
     $response = fetch('example.com', '/');
 
-    IO\output_handle()->writeAll($response);
+    IO\write_error_line($response);
 
     return 0;
 });

--- a/examples/tcp/basic-http-server.php
+++ b/examples/tcp/basic-http-server.php
@@ -15,9 +15,10 @@ require __DIR__ . '/../../vendor/autoload.php';
 Async\main(static function (): int {
     $server = TCP\Server::create('localhost', 3030);
 
-    IO\output_handle()->writeAll("Server is listening on http://localhost:3030\n");
+    IO\write_error_line('Server is listening on http://localhost:3030');
 
-    Async\Scheduler::onSignal(SIGINT, $server->stopListening(...));
+    $watcher = Async\Scheduler::onSignal(SIGINT, $server->stopListening(...));
+    Async\Scheduler::unreference($watcher);
 
     try {
         while (true) {
@@ -34,11 +35,13 @@ Async\main(static function (): int {
                     $connection->writeAll("Hello, World!");
                     $connection->close();
                 } catch (Throwable) {
+                    echo 'error';
                 }
             });
         }
     } catch (AlreadyStoppedException) {
-        IO\output_handle()->writeAll("\nGoodbye 👋\n");
+        IO\write_error_line('');
+        IO\write_error_line('Goodbye 👋');
     }
 
     return 0;

--- a/examples/tcp/concurrent.php
+++ b/examples/tcp/concurrent.php
@@ -12,34 +12,48 @@ use Psl\TCP;
 require __DIR__ . '/../../vendor/autoload.php';
 
 Async\main(static function (): int {
-    $output = IO\output_handle();
-
     Async\parallel([
-        'server' => static function () use ($output): void {
+        'server' => static function (): void {
             $server = TCP\Server::create('localhost', 91337);
-            $output->writeAll("< server is listening\n");
+
+            IO\write_error_line('< server is listening.');
+
             $connection = $server->nextConnection();
-            $output->writeAll("< connection received\n");
-            $output->writeAll("> awaiting request\n");
+
+            IO\write_error_line('< connection received.');
+            IO\write_error_line('< awaiting request.');
+
             $request = $connection->read();
-            $output->writeAll("< received request: $request\n");
-            $output->writeAll("< sending response\n");
+
+            IO\write_error_line('< received request: "%s".', $request);
+            IO\write_error_line('< sending response.');
+
             $connection->writeAll(Str\reverse($request));
             $connection->close();
-            $output->writeAll("< connection closed\n");
+
+            IO\write_error_line('< connection closed.');
+
             $server->stopListening();
-            $output->writeAll("< server stopped\n");
+
+            IO\write_error_line('< server stopped.');
         },
-        'client' => static function () use ($output): void {
+        'client' => static function (): void {
             $client = TCP\connect('localhost', 91337);
-            $output->writeAll("> client connected\n");
-            $output->writeAll("> sending request\n");
+
+            IO\write_error_line('> client connected');
+            IO\write_error_line('> sending request');
+
             $client->writeAll('Hello, World!');
-            $output->writeAll("> awaiting response\n");
+
+            IO\write_error_line('> awaiting response');
+
             $response = $client->readAll();
-            $output->writeAll("> received response: $response\n");
+
+            IO\write_error_line('> received response: "%s".', $response);
+
             $client->close();
-            $output->writeAll("> client disconnected\n");
+
+            IO\write_error_line('> client disconnected');
         },
     ]);
 

--- a/examples/unix/concurrent.php
+++ b/examples/unix/concurrent.php
@@ -15,41 +15,55 @@ require __DIR__ . '/../../vendor/autoload.php';
 
 Async\main(static function (): int {
     if (PHP_OS_FAMILY === 'Windows') {
-        IO\output_handle()->writeAll('This example requires does not support Windows.');
+        IO\write_error_line('This example requires does not support Windows.');
 
         return 0;
     }
 
     $file = Filesystem\create_temporary_file(prefix: 'psl-examples') . ".sock";
 
-    $output = IO\output_handle();
-
     Async\parallel([
-        'server' => static function () use ($file, $output): void {
+        'server' => static function () use ($file): void {
             $server = Unix\Server::create($file);
-            $output->writeAll("< server is listening\n");
+
+            IO\write_error_line('< server is listening.');
+
             $connection = $server->nextConnection();
-            $output->writeAll("< connection received\n");
-            $output->writeAll("> awaiting request\n");
+
+            IO\write_error_line('< connection received.');
+            IO\write_error_line('< awaiting request.');
+
             $request = $connection->read();
-            $output->writeAll("< received request: $request\n");
-            $output->writeAll("< sending response\n");
+
+            IO\write_error_line('< received request: "%s".', $request);
+            IO\write_error_line('< sending response.');
+
             $connection->writeAll(Str\reverse($request));
             $connection->close();
-            $output->writeAll("< connection closed\n");
+
+            IO\write_error_line('< connection closed.');
+
             $server->stopListening();
-            $output->writeAll("< server stopped\n");
+
+            IO\write_error_line("< server stopped\n");
         },
-        'client' => static function () use ($file, $output): void {
+        'client' => static function () use ($file): void {
             $client = Unix\connect($file);
-            $output->writeAll("> client connected\n");
-            $output->writeAll("> sending request\n");
+
+            IO\write_error_line('> client connected.');
+            IO\write_error_line('> sending request.');
+
             $client->writeAll('Hello, World!');
-            $output->writeAll("> awaiting response\n");
+
+            IO\write_error_line('> awaiting response.');
+
             $response = $client->readAll();
-            $output->writeAll("> received response: $response\n");
+
+            IO\write_error_line('> received response: "%s".', $response);
+
             $client->close();
-            $output->writeAll("> client disconnected\n");
+
+            IO\write_error_line('> client disconnected.');
         },
     ]);
 

--- a/src/Psl/IO/write.php
+++ b/src/Psl/IO/write.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\IO;
+
+use Psl\Str;
+
+/**
+ * Write all of the requested data to the output handle.
+ *
+ * The $message will be formatted using the given arguments ( ...$args ).
+ *
+ * @param int|float|string ...$args
+ *
+ * @throws Exception\AlreadyClosedException If the output handle has been already closed.
+ * @throws Exception\RuntimeException If an error occurred during the operation.
+ *
+ * @codeCoverageIgnore
+ */
+function write(string $message, ...$args): void
+{
+    /**
+     * @psalm-suppress MissingThrowsDocblock - we won't encounter timeout.
+     */
+    output_handle()->writeAll(Str\format($message, ...$args));
+}

--- a/src/Psl/IO/write_error.php
+++ b/src/Psl/IO/write_error.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\IO;
+
+use Psl\Str;
+
+/**
+ * Write all of the requested data to the error output handle.
+ *
+ * The $message will be formatted using the given arguments ( ...$args ).
+ *
+ * If the error output handle is not available, this function will return immediately.
+ *
+ * @param int|float|string ...$args
+ *
+ * @throws Exception\AlreadyClosedException If the output handle has been already closed.
+ * @throws Exception\RuntimeException If an error occurred during the operation.
+ *
+ * @codeCoverageIgnore
+ */
+function write_error(string $message, ...$args): void
+{
+    /**
+     * @psalm-suppress MissingThrowsDocblock - we won't encounter timeout, or already closed exception.
+     */
+    error_handle()?->writeAll(Str\format($message, ...$args));
+}

--- a/src/Psl/IO/write_error_line.php
+++ b/src/Psl/IO/write_error_line.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\IO;
+
+use Psl\Str;
+
+/**
+ * Write all of the requested data to the error output handle, followed by a new line.
+ *
+ * The $message will be formatted using the given arguments ( ...$args ).
+ *
+ * If the error output handle is not available, this function will return immediately.
+ *
+ * @param int|float|string ...$args
+ *
+ * @throws Exception\AlreadyClosedException If the output handle has been already closed.
+ * @throws Exception\RuntimeException If an error occurred during the operation.
+ *
+ * @codeCoverageIgnore
+ */
+function write_error_line(string $message, ...$args): void
+{
+    /**
+     * @psalm-suppress MissingThrowsDocblock - we won't encounter timeout, or already closed exception.
+     */
+    error_handle()?->writeAll(Str\format($message, ...$args) . "\n");
+}

--- a/src/Psl/IO/write_line.php
+++ b/src/Psl/IO/write_line.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\IO;
+
+use Psl\Str;
+
+/**
+ * Write all of the requested data to the output handle, followed by a new line.
+ *
+ * The $message will be formatted using the given arguments ( ...$args ).
+ *
+ * @param int|float|string ...$args
+ *
+ * @throws Exception\AlreadyClosedException If the output handle has been already closed.
+ * @throws Exception\RuntimeException If an error occurred during the operation.
+ *
+ * @codeCoverageIgnore
+ */
+function write_line(string $message, ...$args): void
+{
+    /**
+     * @psalm-suppress MissingThrowsDocblock - we won't encounter timeout, or already closed exception.
+     */
+    output_handle()->writeAll(Str\format($message, ...$args) . "\n");
+}

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -481,6 +481,10 @@ final class Loader
         'Psl\Unix\connect',
         'Psl\Channel\bounded',
         'Psl\Channel\unbounded',
+        'Psl\IO\write',
+        'Psl\IO\write_line',
+        'Psl\IO\write_error',
+        'Psl\IO\write_error_line',
     ];
 
     public const INTERFACES = [

--- a/src/Psl/TCP/Server.php
+++ b/src/Psl/TCP/Server.php
@@ -106,7 +106,7 @@ final class Server implements Network\ServerInterface
         }
 
         /** @var Async\Deferred<resource> */
-        $this->deferred =  new Async\Deferred();
+        $this->deferred = new Async\Deferred();
 
         /** @psalm-suppress MissingThrowsDocblock */
         Async\Scheduler::enable($this->watcher);
@@ -142,22 +142,18 @@ final class Server implements Network\ServerInterface
      */
     public function stopListening(): void
     {
+        Async\Scheduler::cancel($this->watcher);
+
         if (null === $this->impl) {
             return;
         }
 
         $resource = $this->impl;
-
-        $deferred = null;
-        if (null !== $this->watcher) {
-            Async\Scheduler::cancel($this->watcher);
-            $deferred = $this->deferred;
-            $this->deferred = null;
-        }
-
         $this->impl = null;
         fclose($resource);
 
+        $deferred = $this->deferred;
+        $this->deferred = null;
         $deferred?->error(new Network\Exception\AlreadyStoppedException('Server socket has already been stopped.'));
     }
 }


### PR DESCRIPTION
Initially i wanted to also introduce `IO\read()` and `IO\read_line()`, but left them out of this PR for later time.

---

Note for later: while the write functions use `writeAll`, the read functions shouldn't use `readAll()`, as that will keep waiting forever if $max_bytes and/or $timeout have not been specified.

