### PR TITLE
feat(html): use Str\Encoding instead of string|null for $encoding argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@
 * introduced a new `IO\write_line()` function.
 * introduced a new `IO\write_error()` function.
 * introduced a new `IO\write_error_line()` functions.
+* **BC** - `$encoding` argument for `Psl\Html` functions now accepts `Psl\Str\Encoding` instead of `?string`.

--- a/src/Psl/Html/decode.php
+++ b/src/Psl/Html/decode.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Psl\Html;
 
 use Psl\Exception;
-use Psl\Internal;
+use Psl\Str;
 
 use function html_entity_decode;
 
@@ -14,15 +14,13 @@ use const ENT_QUOTES;
 /**
  * Convert HTML entities to their corresponding characters.
  *
- * @param string $encoding defines character set used in conversion.
+ * @param Str\Encoding $encoding defines character set used in conversion.
  *
  * @throws Exception\InvariantViolationException If $encoding is invalid.
  *
  * @pure
  */
-function decode(string $html, ?string $encoding = null): string
+function decode(string $html, Str\Encoding $encoding = Str\Encoding::UTF_8): string
 {
-    $encoding = Internal\internal_encoding($encoding);
-
-    return html_entity_decode($html, ENT_QUOTES, $encoding);
+    return html_entity_decode($html, ENT_QUOTES, $encoding->value);
 }

--- a/src/Psl/Html/encode.php
+++ b/src/Psl/Html/encode.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Psl\Html;
 
 use Psl\Exception;
-use Psl\Internal;
+use Psl\Str;
 
 use function htmlentities;
 
@@ -16,7 +16,7 @@ use const ENT_QUOTES;
  *
  * @param bool $double_encoding If set to false, this function will not
  *                              encode existing html entities.
- * @param string $encoding defines character set used in conversion.
+ * @param Str\Encoding $encoding defines character set used in conversion.
  *
  * @throws Exception\InvariantViolationException If $encoding is invalid.
  *
@@ -24,9 +24,7 @@ use const ENT_QUOTES;
  *
  * @pure
  */
-function encode(string $html, bool $double_encoding = true, ?string $encoding = null): string
+function encode(string $html, bool $double_encoding = true, Str\Encoding $encoding = Str\Encoding::UTF_8): string
 {
-    $encoding = Internal\internal_encoding($encoding);
-
-    return htmlentities($html, ENT_QUOTES, $encoding, $double_encoding);
+    return htmlentities($html, ENT_QUOTES, $encoding->value, $double_encoding);
 }

--- a/src/Psl/Html/encode_special_characters.php
+++ b/src/Psl/Html/encode_special_characters.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Psl\Html;
 
 use Psl\Exception;
-use Psl\Internal;
+use Psl\Str;
 
 use function htmlspecialchars;
 
@@ -18,7 +18,7 @@ use const ENT_SUBSTITUTE;
  *
  * @param bool $double_encoding If set to false, this function will not
  *                              encode existing html entities.
- * @param string $encoding defines character set used in conversion.
+ * @param Str\Encoding $encoding defines character set used in conversion.
  *
  * @throws Exception\InvariantViolationException If $encoding is invalid.
  *
@@ -26,9 +26,7 @@ use const ENT_SUBSTITUTE;
  *
  * @pure
  */
-function encode_special_characters(string $html, bool $double_encoding = true, ?string $encoding = null): string
+function encode_special_characters(string $html, bool $double_encoding = true, Str\Encoding $encoding = Str\Encoding::UTF_8): string
 {
-    $encoding = Internal\internal_encoding($encoding);
-
-    return htmlspecialchars($html, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $encoding, $double_encoding);
+    return htmlspecialchars($html, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $encoding->value, $double_encoding);
 }

--- a/tests/unit/Html/DecodeTest.php
+++ b/tests/unit/Html/DecodeTest.php
@@ -6,29 +6,30 @@ namespace Psl\Tests\Unit\Html;
 
 use PHPUnit\Framework\TestCase;
 use Psl\Html;
+use Psl\Str;
 
 final class DecodeTest extends TestCase
 {
     /**
      * @dataProvider provideData
      */
-    public function testEncode(string $expected, string $html, ?string $encoding): void
+    public function testEncode(string $expected, string $html, Str\Encoding $encoding): void
     {
         static::assertSame($expected, Html\decode($html, $encoding));
     }
 
     public function provideData(): iterable
     {
-        yield ['hello', 'hello', 'UTF-8'];
-        yield ['héllo', 'h&eacute;llo', 'UTF-8'];
-        yield ['<hello />', '&lt;hello /&gt;', 'UTF-8'];
-        yield ['<p>Hello</p>', '&lt;p&gt;Hello&lt;/p&gt;', 'UTF-8'];
-        yield ['<p>&lt; </p>', '&lt;p&gt;&amp;lt; &lt;/p&gt;', 'UTF-8'];
+        yield ['hello', 'hello', Str\Encoding::UTF_8];
+        yield ['héllo', 'h&eacute;llo', Str\Encoding::UTF_8];
+        yield ['<hello />', '&lt;hello /&gt;', Str\Encoding::UTF_8];
+        yield ['<p>Hello</p>', '&lt;p&gt;Hello&lt;/p&gt;', Str\Encoding::UTF_8];
+        yield ['<p>&lt; </p>', '&lt;p&gt;&amp;lt; &lt;/p&gt;', Str\Encoding::UTF_8];
 
-        yield ['hello', 'hello', 'UTF-8'];
-        yield ['héllo', 'h&eacute;llo', 'UTF-8'];
-        yield ['<hello />', '&lt;hello /&gt;', 'UTF-8'];
-        yield ['<p>Hello</p>', '&lt;p&gt;Hello&lt;/p&gt;', 'UTF-8'];
-        yield ['<p>< </p>', '&lt;p&gt;&lt; &lt;/p&gt;', 'UTF-8'];
+        yield ['hello', 'hello', Str\Encoding::UTF_8];
+        yield ['héllo', 'h&eacute;llo', Str\Encoding::UTF_8];
+        yield ['<hello />', '&lt;hello /&gt;', Str\Encoding::UTF_8];
+        yield ['<p>Hello</p>', '&lt;p&gt;Hello&lt;/p&gt;', Str\Encoding::UTF_8];
+        yield ['<p>< </p>', '&lt;p&gt;&lt; &lt;/p&gt;', Str\Encoding::UTF_8];
     }
 }

--- a/tests/unit/Html/EncodeSpecialCharactersTest.php
+++ b/tests/unit/Html/EncodeSpecialCharactersTest.php
@@ -6,29 +6,30 @@ namespace Psl\Tests\Unit\Html;
 
 use PHPUnit\Framework\TestCase;
 use Psl\Html;
+use Psl\Str;
 
 final class EncodeSpecialCharactersTest extends TestCase
 {
     /**
      * @dataProvider provideData
      */
-    public function testEncode(string $expected, string $html, bool $double_encoding, ?string $encoding): void
+    public function testEncode(string $expected, string $html, bool $double_encoding, Str\Encoding $encoding): void
     {
         static::assertSame($expected, Html\encode_special_characters($html, $double_encoding, $encoding));
     }
 
     public function provideData(): iterable
     {
-        yield ['hello', 'hello', true, 'UTF-8'];
-        yield ['héllo', 'héllo', true, 'UTF-8'];
-        yield ['&lt;hello /&gt;', '<hello />', true, 'UTF-8'];
-        yield ['&lt;p&gt;Hello&lt;/p&gt;', '<p>Hello</p>', true, 'UTF-8'];
-        yield ['&lt;p&gt;&amp;lt; &lt;/p&gt;', '<p>&lt; </p>', true, 'UTF-8'];
+        yield ['hello', 'hello', true, Str\Encoding::UTF_8];
+        yield ['héllo', 'héllo', true, Str\Encoding::UTF_8];
+        yield ['&lt;hello /&gt;', '<hello />', true, Str\Encoding::UTF_8];
+        yield ['&lt;p&gt;Hello&lt;/p&gt;', '<p>Hello</p>', true, Str\Encoding::UTF_8];
+        yield ['&lt;p&gt;&amp;lt; &lt;/p&gt;', '<p>&lt; </p>', true, Str\Encoding::UTF_8];
 
-        yield ['hello', 'hello', false, 'UTF-8'];
-        yield ['héllo', 'héllo', false, 'UTF-8'];
-        yield ['&lt;hello /&gt;', '<hello />', false, 'UTF-8'];
-        yield ['&lt;p&gt;Hello&lt;/p&gt;', '<p>Hello</p>', false, 'UTF-8'];
-        yield ['&lt;p&gt;&lt; &lt;/p&gt;', '<p>&lt; </p>', false, 'UTF-8'];
+        yield ['hello', 'hello', false, Str\Encoding::UTF_8];
+        yield ['héllo', 'héllo', false, Str\Encoding::UTF_8];
+        yield ['&lt;hello /&gt;', '<hello />', false, Str\Encoding::UTF_8];
+        yield ['&lt;p&gt;Hello&lt;/p&gt;', '<p>Hello</p>', false, Str\Encoding::UTF_8];
+        yield ['&lt;p&gt;&lt; &lt;/p&gt;', '<p>&lt; </p>', false, Str\Encoding::UTF_8];
     }
 }

--- a/tests/unit/Html/EncodeTest.php
+++ b/tests/unit/Html/EncodeTest.php
@@ -6,29 +6,30 @@ namespace Psl\Tests\Unit\Html;
 
 use PHPUnit\Framework\TestCase;
 use Psl\Html;
+use Psl\Str;
 
 final class EncodeTest extends TestCase
 {
     /**
      * @dataProvider provideData
      */
-    public function testEncode(string $expected, string $html, bool $double_encoding, ?string $encoding): void
+    public function testEncode(string $expected, string $html, bool $double_encoding, Str\Encoding $encoding): void
     {
         static::assertSame($expected, Html\encode($html, $double_encoding, $encoding));
     }
 
     public function provideData(): iterable
     {
-        yield ['hello', 'hello', true, 'UTF-8'];
-        yield ['h&eacute;llo', 'héllo', true, 'UTF-8'];
-        yield ['&lt;hello /&gt;', '<hello />', true, 'UTF-8'];
-        yield ['&lt;p&gt;Hello&lt;/p&gt;', '<p>Hello</p>', true, 'UTF-8'];
-        yield ['&lt;p&gt;&amp;lt; &lt;/p&gt;', '<p>&lt; </p>', true, 'UTF-8'];
+        yield ['hello', 'hello', true, Str\Encoding::UTF_8];
+        yield ['h&eacute;llo', 'héllo', true, Str\Encoding::UTF_8];
+        yield ['&lt;hello /&gt;', '<hello />', true, Str\Encoding::UTF_8];
+        yield ['&lt;p&gt;Hello&lt;/p&gt;', '<p>Hello</p>', true, Str\Encoding::UTF_8];
+        yield ['&lt;p&gt;&amp;lt; &lt;/p&gt;', '<p>&lt; </p>', true, Str\Encoding::UTF_8];
 
-        yield ['hello', 'hello', false, 'UTF-8'];
-        yield ['h&eacute;llo', 'héllo', false, 'UTF-8'];
-        yield ['&lt;hello /&gt;', '<hello />', false, 'UTF-8'];
-        yield ['&lt;p&gt;Hello&lt;/p&gt;', '<p>Hello</p>', false, 'UTF-8'];
-        yield ['&lt;p&gt;&lt; &lt;/p&gt;', '<p>&lt; </p>', false, 'UTF-8'];
+        yield ['hello', 'hello', false, Str\Encoding::UTF_8];
+        yield ['h&eacute;llo', 'héllo', false, Str\Encoding::UTF_8];
+        yield ['&lt;hello /&gt;', '<hello />', false, Str\Encoding::UTF_8];
+        yield ['&lt;p&gt;Hello&lt;/p&gt;', '<p>Hello</p>', false, Str\Encoding::UTF_8];
+        yield ['&lt;p&gt;&lt; &lt;/p&gt;', '<p>&lt; </p>', false, Str\Encoding::UTF_8];
     }
 }


### PR DESCRIPTION
Signed-off-by: azjezz <azjezz@protonmail.com>