### PR TITLE
fix(composer): add `Psl` namespace mapped to `src/Psl`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Psl\\Integration\\": "integration"
+            "Psl\\Integration\\": "integration",
+            "Psl\\": "src/Psl"
         },
         "files": [
             "src/bootstrap.php"


### PR DESCRIPTION
Fixes #310

Tools such as `maglnet/ComposerRequireChecker` rely on symbols being autoloadable, but due to the way the autoloader works here, it seems the symbols can't be picked up. The issue does not affect `2.0.x-dev` since the path `src/Psl` is mapped in `composer.json`, so the symbols are able to be loaded. So this path map is backported to `1.9.x` series, so that tools that
work in this way can see the `Psl\*` functions.