### PR TITLE
chore(io): rename `readImmediately` to `tryRead`, and `writeImmediately` to `tryWrite`

### DIFF
--- a/src/Psl/File/ReadHandle.php
+++ b/src/Psl/File/ReadHandle.php
@@ -32,9 +32,9 @@ final class ReadHandle extends Internal\AbstractHandleWrapper implements ReadHan
     /**
      * {@inheritDoc}
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
-        return $this->readHandle->readImmediately($max_bytes);
+        return $this->readHandle->tryRead($max_bytes);
     }
 
     /**

--- a/src/Psl/File/ReadWriteHandle.php
+++ b/src/Psl/File/ReadWriteHandle.php
@@ -57,9 +57,9 @@ final class ReadWriteHandle extends Internal\AbstractHandleWrapper implements Re
     /**
      * {@inheritDoc}
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
-        return $this->readWriteHandle->readImmediately($max_bytes);
+        return $this->readWriteHandle->tryRead($max_bytes);
     }
 
     /**
@@ -73,9 +73,9 @@ final class ReadWriteHandle extends Internal\AbstractHandleWrapper implements Re
     /**
      * {@inheritDoc}
      */
-    public function writeImmediately(string $bytes): int
+    public function tryWrite(string $bytes): int
     {
-        return $this->readWriteHandle->writeImmediately($bytes);
+        return $this->readWriteHandle->tryWrite($bytes);
     }
 
     /**

--- a/src/Psl/File/WriteHandle.php
+++ b/src/Psl/File/WriteHandle.php
@@ -52,9 +52,9 @@ final class WriteHandle extends Internal\AbstractHandleWrapper implements WriteH
     /**
      * {@inheritDoc}
      */
-    public function writeImmediately(string $bytes): int
+    public function tryWrite(string $bytes): int
     {
-        return $this->writeHandle->writeImmediately($bytes);
+        return $this->writeHandle->tryWrite($bytes);
     }
 
     /**

--- a/src/Psl/IO/Internal/ResourceHandle.php
+++ b/src/Psl/IO/Internal/ResourceHandle.php
@@ -135,7 +135,7 @@ class ResourceHandle implements IO\Stream\CloseSeekReadWriteHandleInterface
      */
     public function write(string $bytes, ?float $timeout = null): int
     {
-        $written = $this->writeImmediately($bytes);
+        $written = $this->tryWrite($bytes);
         if ($this->blocks || $written === strlen($bytes)) {
             return $written;
         }
@@ -176,13 +176,13 @@ class ResourceHandle implements IO\Stream\CloseSeekReadWriteHandleInterface
             }
         }
 
-        return $written + $this->writeImmediately($bytes);
+        return $written + $this->tryWrite($bytes);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function writeImmediately(string $bytes): int
+    public function tryWrite(string $bytes): int
     {
         // there's a pending write operation, wait for it first.
         $this->writeDeferred?->getAwaitable()->then(static fn() => null, static fn() => null)->await();
@@ -246,7 +246,7 @@ class ResourceHandle implements IO\Stream\CloseSeekReadWriteHandleInterface
      */
     public function read(?int $max_bytes = null, ?float $timeout = null): string
     {
-        $chunk = $this->readImmediately($max_bytes);
+        $chunk = $this->tryRead($max_bytes);
         if ('' !== $chunk || $this->blocks) {
             return $chunk;
         }
@@ -287,13 +287,13 @@ class ResourceHandle implements IO\Stream\CloseSeekReadWriteHandleInterface
             }
         }
 
-        return $this->readImmediately($max_bytes);
+        return $this->tryRead($max_bytes);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
         // there's a pending read operation, wait for it.
         $this->readDeferred?->getAwaitable()->then(static fn() => null, static fn() => null)->await();

--- a/src/Psl/IO/MemoryHandle.php
+++ b/src/Psl/IO/MemoryHandle.php
@@ -37,7 +37,7 @@ final class MemoryHandle implements CloseSeekReadWriteHandleInterface
      *
      * @return string the read data on success, or an empty string if the end of file is reached.
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
         $this->assertHandleIsOpen();
 
@@ -72,7 +72,7 @@ final class MemoryHandle implements CloseSeekReadWriteHandleInterface
      */
     public function read(?int $max_bytes = null, ?float $timeout = null): string
     {
-        return $this->readImmediately($max_bytes);
+        return $this->tryRead($max_bytes);
     }
 
     /**
@@ -100,7 +100,7 @@ final class MemoryHandle implements CloseSeekReadWriteHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function writeImmediately(string $bytes, ?float $timeout = null): int
+    public function tryWrite(string $bytes, ?float $timeout = null): int
     {
         $this->assertHandleIsOpen();
         $length = strlen($this->buffer);
@@ -127,7 +127,7 @@ final class MemoryHandle implements CloseSeekReadWriteHandleInterface
      */
     public function write(string $bytes, ?float $timeout = null): int
     {
-        return $this->writeImmediately($bytes);
+        return $this->tryWrite($bytes);
     }
 
     /**

--- a/src/Psl/IO/ReadHandleInterface.php
+++ b/src/Psl/IO/ReadHandleInterface.php
@@ -10,7 +10,7 @@ namespace Psl\IO;
 interface ReadHandleInterface extends HandleInterface
 {
     /**
-     * An immediate, unordered read.
+     * Try to read from the handle immediately, without waiting.
      *
      * Up to `$max_bytes` may be allocated in a buffer; large values may lead to
      * unnecessarily hitting the request memory limit.
@@ -20,12 +20,12 @@ interface ReadHandleInterface extends HandleInterface
      * @throws Exception\AlreadyClosedException If the handle has been already closed.
      * @throws Exception\RuntimeException If an error occurred during the operation.
      *
-     * @return string the read data on success, or an empty string if the end of file is reached.
+     * @return string the read data on success, or an empty string if the handle is not ready for read, or the end of file is reached.
      *
      * @see ReadHandleInterface::read()
      * @see ReadHandleInterface::readAll()
      */
-    public function readImmediately(?int $max_bytes = null): string;
+    public function tryRead(?int $max_bytes = null): string;
 
     /**
      * Read from the handle, waiting for data if necessary.

--- a/src/Psl/IO/Reader.php
+++ b/src/Psl/IO/Reader.php
@@ -203,13 +203,13 @@ final class Reader implements ReadHandleInterface
 
         // We either have a buffer, or reached EOF; either way, behavior matches
         // read, so just delegate
-        return $this->readImmediately($max_bytes);
+        return $this->tryRead($max_bytes);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
         if (null !== $max_bytes) {
             /** @psalm-suppress MissingThrowsDocblock */
@@ -220,15 +220,13 @@ final class Reader implements ReadHandleInterface
             return '';
         }
 
-        // @codeCoverageIgnoreStart
         if ($this->buffer === '') {
-            $this->buffer = $this->getHandle()->readImmediately();
+            $this->buffer = $this->getHandle()->tryRead();
             if ($this->buffer === '') {
                 $this->eof = true;
                 return '';
             }
         }
-        // @codeCoverageIgnoreEnd
 
         $buffer = $this->buffer;
         if ($max_bytes === null || $max_bytes >= strlen($buffer)) {

--- a/src/Psl/IO/Stream/CloseReadHandle.php
+++ b/src/Psl/IO/Stream/CloseReadHandle.php
@@ -27,9 +27,9 @@ final class CloseReadHandle implements CloseReadHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
-        return $this->handle->readImmediately($max_bytes);
+        return $this->handle->tryRead($max_bytes);
     }
 
     /**

--- a/src/Psl/IO/Stream/CloseReadWriteHandle.php
+++ b/src/Psl/IO/Stream/CloseReadWriteHandle.php
@@ -28,9 +28,9 @@ final class CloseReadWriteHandle implements CloseReadWriteHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
-        return $this->handle->readImmediately($max_bytes);
+        return $this->handle->tryRead($max_bytes);
     }
 
     /**
@@ -44,9 +44,9 @@ final class CloseReadWriteHandle implements CloseReadWriteHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function writeImmediately(string $bytes): int
+    public function tryWrite(string $bytes): int
     {
-        return $this->handle->writeImmediately($bytes);
+        return $this->handle->tryWrite($bytes);
     }
 
     /**

--- a/src/Psl/IO/Stream/CloseSeekReadHandle.php
+++ b/src/Psl/IO/Stream/CloseSeekReadHandle.php
@@ -27,9 +27,9 @@ final class CloseSeekReadHandle implements CloseSeekReadHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
-        return $this->handle->readImmediately($max_bytes);
+        return $this->handle->tryRead($max_bytes);
     }
 
     /**

--- a/src/Psl/IO/Stream/CloseSeekReadWriteHandle.php
+++ b/src/Psl/IO/Stream/CloseSeekReadWriteHandle.php
@@ -28,9 +28,9 @@ final class CloseSeekReadWriteHandle implements CloseSeekReadWriteHandleInterfac
     /**
      * {@inheritDoc}
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
-        return $this->handle->readImmediately($max_bytes);
+        return $this->handle->tryRead($max_bytes);
     }
 
     /**
@@ -44,9 +44,9 @@ final class CloseSeekReadWriteHandle implements CloseSeekReadWriteHandleInterfac
     /**
      * {@inheritDoc}
      */
-    public function writeImmediately(string $bytes): int
+    public function tryWrite(string $bytes): int
     {
-        return $this->handle->writeImmediately($bytes);
+        return $this->handle->tryWrite($bytes);
     }
 
     /**

--- a/src/Psl/IO/Stream/CloseSeekWriteHandle.php
+++ b/src/Psl/IO/Stream/CloseSeekWriteHandle.php
@@ -27,9 +27,9 @@ final class CloseSeekWriteHandle implements CloseSeekWriteHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function writeImmediately(string $bytes): int
+    public function tryWrite(string $bytes): int
     {
-        return $this->handle->writeImmediately($bytes);
+        return $this->handle->tryWrite($bytes);
     }
 
     /**

--- a/src/Psl/IO/Stream/CloseWriteHandle.php
+++ b/src/Psl/IO/Stream/CloseWriteHandle.php
@@ -27,9 +27,9 @@ final class CloseWriteHandle implements CloseWriteHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function writeImmediately(string $bytes): int
+    public function tryWrite(string $bytes): int
     {
-        return $this->handle->writeImmediately($bytes);
+        return $this->handle->tryWrite($bytes);
     }
 
     /**

--- a/src/Psl/IO/Stream/ReadHandle.php
+++ b/src/Psl/IO/Stream/ReadHandle.php
@@ -27,9 +27,9 @@ final class ReadHandle implements ReadHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
-        return $this->handle->readImmediately($max_bytes);
+        return $this->handle->tryRead($max_bytes);
     }
 
     /**

--- a/src/Psl/IO/Stream/ReadWriteHandle.php
+++ b/src/Psl/IO/Stream/ReadWriteHandle.php
@@ -28,9 +28,9 @@ final class ReadWriteHandle implements ReadWriteHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
-        return $this->handle->readImmediately($max_bytes);
+        return $this->handle->tryRead($max_bytes);
     }
 
     /**
@@ -44,9 +44,9 @@ final class ReadWriteHandle implements ReadWriteHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function writeImmediately(string $bytes): int
+    public function tryWrite(string $bytes): int
     {
-        return $this->handle->writeImmediately($bytes);
+        return $this->handle->tryWrite($bytes);
     }
 
     /**

--- a/src/Psl/IO/Stream/SeekReadHandle.php
+++ b/src/Psl/IO/Stream/SeekReadHandle.php
@@ -27,9 +27,9 @@ final class SeekReadHandle implements SeekReadHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
-        return $this->handle->readImmediately($max_bytes);
+        return $this->handle->tryRead($max_bytes);
     }
 
     /**

--- a/src/Psl/IO/Stream/SeekReadWriteHandle.php
+++ b/src/Psl/IO/Stream/SeekReadWriteHandle.php
@@ -28,9 +28,9 @@ final class SeekReadWriteHandle implements SeekReadWriteHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
-        return $this->handle->readImmediately($max_bytes);
+        return $this->handle->tryRead($max_bytes);
     }
 
     /**
@@ -44,9 +44,9 @@ final class SeekReadWriteHandle implements SeekReadWriteHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function writeImmediately(string $bytes): int
+    public function tryWrite(string $bytes): int
     {
-        return $this->handle->writeImmediately($bytes);
+        return $this->handle->tryWrite($bytes);
     }
 
     /**

--- a/src/Psl/IO/Stream/SeekWriteHandle.php
+++ b/src/Psl/IO/Stream/SeekWriteHandle.php
@@ -27,9 +27,9 @@ final class SeekWriteHandle implements SeekWriteHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function writeImmediately(string $bytes): int
+    public function tryWrite(string $bytes): int
     {
-        return $this->handle->writeImmediately($bytes);
+        return $this->handle->tryWrite($bytes);
     }
 
     /**

--- a/src/Psl/IO/Stream/WriteHandle.php
+++ b/src/Psl/IO/Stream/WriteHandle.php
@@ -27,9 +27,9 @@ final class WriteHandle implements WriteHandleInterface
     /**
      * {@inheritDoc}
      */
-    public function writeImmediately(string $bytes): int
+    public function tryWrite(string $bytes): int
     {
-        return $this->handle->writeImmediately($bytes);
+        return $this->handle->tryWrite($bytes);
     }
 
     /**

--- a/src/Psl/IO/WriteHandleInterface.php
+++ b/src/Psl/IO/WriteHandleInterface.php
@@ -10,7 +10,7 @@ namespace Psl\IO;
 interface WriteHandleInterface extends HandleInterface
 {
     /**
-     * An immediate, unordered write.
+     * Try to write to the handle immediately, without waiting.
      *
      * @throws Exception\AlreadyClosedException If the handle has been already closed.
      * @throws Exception\RuntimeException If an error occurred during the operation.
@@ -20,7 +20,7 @@ interface WriteHandleInterface extends HandleInterface
      * @see WriteHandleInterface::write()
      * @see WriteHandleInterface::writeAll()
      */
-    public function writeImmediately(string $bytes): int;
+    public function tryWrite(string $bytes): int;
 
     /**
      * Write data, waiting if necessary.
@@ -39,9 +39,9 @@ interface WriteHandleInterface extends HandleInterface
     /**
      * Write all of the requested data.
      *
-     * A wrapper around `write()` that will:
+     * A wrapper around {@see WriteHandleInterface::write()} that will:
      * - do multiple writes if necessary to write the entire provided buffer
-     * - throws `Exception\RuntimeException` if it is not possible to write all the requested data
+     * - throws {@see Exception\RuntimeException} if it is not possible to write all the requested data
      *
      * It is possible for this to never return, e.g. if called on a pipe or
      * or socket which the other end keeps open forever. Set a timeout if you

--- a/src/Psl/Network/Internal/Socket.php
+++ b/src/Psl/Network/Internal/Socket.php
@@ -35,9 +35,9 @@ final class Socket implements Network\StreamSocketInterface
     /**
      * {@inheritDoc}
      */
-    public function readImmediately(?int $max_bytes = null): string
+    public function tryRead(?int $max_bytes = null): string
     {
-        return $this->handle->readImmediately($max_bytes);
+        return $this->handle->tryRead($max_bytes);
     }
 
     /**
@@ -51,9 +51,9 @@ final class Socket implements Network\StreamSocketInterface
     /**
      * {@inheritDoc}
      */
-    public function writeImmediately(string $bytes): int
+    public function tryWrite(string $bytes): int
     {
-        return $this->handle->writeImmediately($bytes);
+        return $this->handle->tryWrite($bytes);
     }
 
     /**

--- a/tests/unit/File/ReadHandleTest.php
+++ b/tests/unit/File/ReadHandleTest.php
@@ -17,12 +17,12 @@ final class ReadHandleTest extends TestCase
 
         $handle->writeAll('hello');
         static::assertSame(2, $handle->write(', '));
-        static::assertSame(6, $handle->writeImmediately('world!'));
+        static::assertSame(6, $handle->tryWrite('world!'));
 
         $handle->close();
 
         $handle = File\open_read_only($temporary_file);
-        $content = $handle->readImmediately();
+        $content = $handle->tryRead();
 
         static::assertSame('hello, world!', $content);
     }

--- a/tests/unit/File/ReadWriteHandleTest.php
+++ b/tests/unit/File/ReadWriteHandleTest.php
@@ -111,7 +111,7 @@ final class ReadWriteHandleTest extends TestCase
         static::assertFalse(Filesystem\is_file($temporary_file));
 
         $handle = File\open_read_write($temporary_file, File\WriteMode::MUST_CREATE);
-        $handle->writeImmediately('hello');
+        $handle->tryWrite('hello');
         $handle->seek(0);
 
         $content = $handle->readAll();
@@ -169,7 +169,7 @@ final class ReadWriteHandleTest extends TestCase
         ];
 
         yield [
-            static fn(File\ReadHandleInterface $handle) => $handle->readImmediately(),
+            static fn(File\ReadHandleInterface $handle) => $handle->tryRead(),
         ];
 
         yield [

--- a/tests/unit/File/WriteHandleTest.php
+++ b/tests/unit/File/WriteHandleTest.php
@@ -48,7 +48,7 @@ final class WriteHandleTest extends TestCase
 
         $handle->writeAll('hello');
         static::assertSame(2, $handle->write(', '));
-        static::assertSame(6, $handle->writeImmediately('world!'));
+        static::assertSame(6, $handle->tryWrite('world!'));
 
         $handle->close();
 

--- a/tests/unit/IO/MemoryHandleTest.php
+++ b/tests/unit/IO/MemoryHandleTest.php
@@ -57,7 +57,7 @@ final class MemoryHandleTest extends TestCase
         ];
 
         yield [
-            static fn(IO\ReadHandleInterface $handle) => $handle->readImmediately(),
+            static fn(IO\ReadHandleInterface $handle) => $handle->tryRead(),
         ];
     }
 

--- a/tests/unit/IO/PipeTest.php
+++ b/tests/unit/IO/PipeTest.php
@@ -15,11 +15,11 @@ final class PipeTest extends TestCase
     {
         [$read, $write] = IO\pipe();
 
-        static::assertSame('', $read->readImmediately());
+        static::assertSame('', $read->tryRead());
         $write->writeAll('hello');
         static::assertSame('hello', $read->read());
 
-        static::assertSame('', $read->readImmediately());
+        static::assertSame('', $read->tryRead());
         $write->writeAll('hello');
         static::assertSame('hello', $read->read());
 

--- a/tests/unit/IO/ReaderTest.php
+++ b/tests/unit/IO/ReaderTest.php
@@ -10,6 +10,15 @@ use Psl\IO;
 
 final class ReaderTest extends TestCase
 {
+    public function testReadEmptyHandle(): void
+    {
+        $handle = new IO\MemoryHandle();
+        $reader = new IO\Reader($handle);
+
+        static::assertEmpty($reader->tryRead());
+        static::assertTrue($reader->isEndOfFile());
+    }
+
     public function testReadingFile(): void
     {
         $handle = File\open_read_only(__FILE__);

--- a/tests/unit/IO/StreamTest.php
+++ b/tests/unit/IO/StreamTest.php
@@ -32,7 +32,7 @@ final class StreamTest extends TestCase
 
         $this->expectException(IO\Exception\AlreadyClosedException::class);
 
-        $stream->readImmediately();
+        $stream->tryRead();
     }
 
     public function testCloseWriteHandle(): void
@@ -48,7 +48,7 @@ final class StreamTest extends TestCase
 
         $this->expectException(IO\Exception\AlreadyClosedException::class);
 
-        $stream->writeImmediately('Hello');
+        $stream->tryWrite('Hello');
     }
 
     public function testCloseReadWriteHandle(): void
@@ -82,7 +82,7 @@ final class StreamTest extends TestCase
 
         $this->expectException(IO\Exception\AlreadyClosedException::class);
 
-        $stream->readImmediately();
+        $stream->tryRead();
     }
 
     public function testSeekReadWriteHandle(): void
@@ -97,7 +97,7 @@ final class StreamTest extends TestCase
 
         $this->expectException(IO\Exception\AlreadyClosedException::class);
 
-        $stream->readImmediately();
+        $stream->tryRead();
     }
 
     public function testCloseSeekReadWriteHandle(): void
@@ -112,7 +112,7 @@ final class StreamTest extends TestCase
 
         $this->expectException(IO\Exception\AlreadyClosedException::class);
 
-        $stream->readImmediately();
+        $stream->tryRead();
     }
 
     public function testSeekReadHandle(): void
@@ -128,7 +128,7 @@ final class StreamTest extends TestCase
 
         $this->expectException(IO\Exception\AlreadyClosedException::class);
 
-        $stream->readImmediately();
+        $stream->tryRead();
     }
 
     public function testSeekWriteHandle(): void
@@ -149,6 +149,6 @@ final class StreamTest extends TestCase
 
         $this->expectException(IO\Exception\AlreadyClosedException::class);
 
-        $stream->writeImmediately('hello');
+        $stream->tryWrite('hello');
     }
 }

--- a/tests/unit/TCP/ServerTest.php
+++ b/tests/unit/TCP/ServerTest.php
@@ -82,6 +82,8 @@ final class ServerTest extends TestCase
         $watcher = Async\Scheduler::onReadable($stream, static fn() => $deferred->complete(true));
         $client = TCP\connect('127.0.0.1', $server->getLocalAddress()->port);
 
+        $deferred->getAwaitable()->await();
+
         static::assertTrue($deferred->isComplete());
 
         Async\Scheduler::cancel($watcher);

--- a/tests/unit/Unix/ServerTest.php
+++ b/tests/unit/Unix/ServerTest.php
@@ -92,6 +92,8 @@ final class ServerTest extends TestCase
         $watcher = Async\Scheduler::onReadable($stream, static fn() => $deferred->complete(true));
         $client = Unix\connect($sock);
 
+        $deferred->getAwaitable()->await();
+
         static::assertTrue($deferred->isComplete());
 
         Async\Scheduler::cancel($watcher);


### PR DESCRIPTION
closes #306 

Signed-off-by: azjezz <azjezz@protonmail.com>