### PR TITLE
chore(data-structure): rework exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,4 @@
 * **BC** - `Psl\Collection\IndexAccessInterface::at()` now throw `Psl\Collection\Exception\OutOfBoundsException` instead of `Psl\Exception\InvariantViolationException` if `$k` is out-of-bounds.
 * **BC** - `Psl\Collection\AccessibleCollectionInterface::slice` signature has changed from `slice(int $start, int $length): static` to `slice(int $start, ?int $length = null): static`
 * **BC** - All psl functions previously accepting `callable`, now accept only `Closure`.
+* **BC** - `Psl\DataStructure\QueueInterface::dequeue`, and `Psl\DataStructure\StackInterface::pop` now throw `Psl\DataStructure\Exception\UnderflowException` instead of `Psl\Exception\InvariantViolationException` when the data structure is empty.

--- a/docs/component/data-structure.md
+++ b/docs/component/data-structure.md
@@ -13,13 +13,13 @@
 #### `Interfaces`
 
 - [PriorityQueueInterface](./../../src/Psl/DataStructure/PriorityQueueInterface.php#L12)
-- [QueueInterface](./../../src/Psl/DataStructure/QueueInterface.php#L17)
-- [StackInterface](./../../src/Psl/DataStructure/StackInterface.php#L17)
+- [QueueInterface](./../../src/Psl/DataStructure/QueueInterface.php#L16)
+- [StackInterface](./../../src/Psl/DataStructure/StackInterface.php#L16)
 
 #### `Classes`
 
-- [PriorityQueue](./../../src/Psl/DataStructure/PriorityQueue.php#L20)
-- [Queue](./../../src/Psl/DataStructure/Queue.php#L21)
-- [Stack](./../../src/Psl/DataStructure/Stack.php#L19)
+- [PriorityQueue](./../../src/Psl/DataStructure/PriorityQueue.php#L18)
+- [Queue](./../../src/Psl/DataStructure/Queue.php#L17)
+- [Stack](./../../src/Psl/DataStructure/Stack.php#L17)
 
 

--- a/src/Psl/DataStructure/Exception/ExceptionInterface.php
+++ b/src/Psl/DataStructure/Exception/ExceptionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\DataStructure\Exception;
+
+use Psl\Exception;
+
+interface ExceptionInterface extends Exception\ExceptionInterface
+{
+}

--- a/src/Psl/DataStructure/Exception/UnderflowException.php
+++ b/src/Psl/DataStructure/Exception/UnderflowException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\DataStructure\Exception;
+
+use Psl\Exception;
+
+final class UnderflowException extends Exception\UnderflowException implements ExceptionInterface
+{
+}

--- a/src/Psl/DataStructure/Queue.php
+++ b/src/Psl/DataStructure/Queue.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\DataStructure;
 
-use Psl;
-use Psl\Dict;
-use Psl\Iter;
-use Psl\Vec;
-
+use function array_shift;
 use function count;
 
 /**
@@ -43,7 +39,7 @@ final class Queue implements QueueInterface
      */
     public function peek(): mixed
     {
-        return Iter\first($this->queue);
+        return $this->queue[0] ?? null;
     }
 
     /**
@@ -54,29 +50,24 @@ final class Queue implements QueueInterface
      */
     public function pull(): mixed
     {
-        if (0 === $this->count()) {
-            return null;
-        }
-
-        /** @psalm-suppress MissingThrowsDocblock - we are sure that the queue is not empty. */
-        return $this->dequeue();
+        return array_shift($this->queue);
     }
 
     /**
      * Dequeues a node from the queue.
      *
-     * @throws Psl\Exception\InvariantViolationException If the Queue is invalid.
+     * @throws Exception\UnderflowException If the queue is empty.
      *
      * @return T
      */
     public function dequeue(): mixed
     {
-        Psl\invariant(0 !== $this->count(), 'Cannot dequeue a node from an empty Queue.');
+        if ([] === $this->queue) {
+            throw new Exception\UnderflowException('Cannot dequeue a node from an empty queue.');
+        }
 
-        $node = $this->queue[0];
-        $this->queue = Vec\values(Dict\drop($this->queue, 1));
-
-        return $node;
+        /** @var T */
+        return array_shift($this->queue);
     }
 
     /**

--- a/src/Psl/DataStructure/QueueInterface.php
+++ b/src/Psl/DataStructure/QueueInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Psl\DataStructure;
 
 use Countable;
-use Psl;
 
 /**
  * An interface representing a queue data structure ( FIFO ).
@@ -42,7 +41,7 @@ interface QueueInterface extends Countable
     /**
      * Retrieves and removes the node at the head of this queue.
      *
-     * @throws Psl\Exception\InvariantViolationException If the Queue is invalid.
+     * @throws Exception\UnderflowException If the queue is empty.
      *
      * @return T
      */

--- a/src/Psl/DataStructure/Stack.php
+++ b/src/Psl/DataStructure/Stack.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\DataStructure;
 
-use Psl;
-use Psl\Dict;
-use Psl\Iter;
-use Psl\Vec;
+use function array_pop;
+use function count;
 
 /**
  * An basic implementation of a stack data structure ( LIFO ).
@@ -41,7 +39,9 @@ final class Stack implements StackInterface
      */
     public function peek(): mixed
     {
-        return Iter\last($this->items);
+        $items = $this->items;
+
+        return array_pop($items);
     }
 
     /**
@@ -52,38 +52,33 @@ final class Stack implements StackInterface
      */
     public function pull(): mixed
     {
-        if (0 === $this->count()) {
-            return null;
-        }
-
-        /** @psalm-suppress MissingThrowsDocblock - the stack is not empty. */
-        return $this->pop();
+        return array_pop($this->items);
     }
 
     /**
      * Retrieve and removes the most recently added item that was not yet removed.
      *
-     * @throws Psl\Exception\InvariantViolationException If the stack is empty.
+     * @throws Exception\UnderflowException If the stack is empty.
      *
      * @return T
      */
     public function pop(): mixed
     {
-        Psl\invariant(0 !== ($i = $this->count()), 'Cannot pop an item from an empty Stack.');
+        if ([] === $this->items) {
+            throw new Exception\UnderflowException('Cannot pop an item from an empty stack.');
+        }
 
-        /** @var int<0, max> $position */
-        $position = $i - 1;
-        $tail = $this->items[$position];
-        $this->items = Vec\values(Dict\take($this->items, $position));
-
-        return $tail;
+        /** @var T */
+        return array_pop($this->items);
     }
 
     /**
      * Count the items in the stack.
+     *
+     * @return int<0, max>
      */
     public function count(): int
     {
-        return Iter\count($this->items);
+        return count($this->items);
     }
 }

--- a/src/Psl/DataStructure/StackInterface.php
+++ b/src/Psl/DataStructure/StackInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Psl\DataStructure;
 
 use Countable;
-use Psl;
 
 /**
  * An interface representing a stack data structure ( LIFO ).
@@ -42,7 +41,7 @@ interface StackInterface extends Countable
     /**
      * Retrieve and removes the most recently added item that was not yet removed.
      *
-     * @throws Psl\Exception\InvariantViolationException If the stack is empty.
+     * @throws Exception\UnderflowException If the stack is empty.
      *
      * @return T
      */
@@ -50,6 +49,8 @@ interface StackInterface extends Countable
 
     /**
      * Count the items in the stack.
+     *
+     * @return int<0, max>
      */
     public function count(): int;
 }

--- a/src/Psl/Exception/UnderflowException.php
+++ b/src/Psl/Exception/UnderflowException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Exception;
+
+use UnderflowException as UnderflowRootException;
+
+class UnderflowException extends UnderflowRootException implements ExceptionInterface
+{
+}

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -560,6 +560,7 @@ final class Loader
         'Psl\Iter\Exception\ExceptionInterface',
         'Psl\Str\Exception\ExceptionInterface',
         'Psl\Collection\Exception\ExceptionInterface',
+        'Psl\DataStructure\Exception\ExceptionInterface',
     ];
 
     public const TRAITS = [
@@ -570,7 +571,6 @@ final class Loader
 
     public const CLASSES = [
         'Psl\Ref',
-        'Psl\Exception\OutOfBoundsException',
         'Psl\DataStructure\PriorityQueue',
         'Psl\DataStructure\Queue',
         'Psl\DataStructure\Stack',
@@ -582,6 +582,8 @@ final class Loader
         'Psl\Exception\InvalidArgumentException',
         'Psl\Exception\RuntimeException',
         'Psl\Exception\InvariantViolationException',
+        'Psl\Exception\UnderflowException',
+        'Psl\Exception\OutOfBoundsException',
         'Psl\Result\Failure',
         'Psl\Result\Success',
         'Psl\Type\Internal\ArrayKeyType',
@@ -701,6 +703,7 @@ final class Loader
         'Psl\Iter\Exception\OutOfBoundsException',
         'Psl\Str\Exception\OutOfBoundsException',
         'Psl\Collection\Exception\OutOfBoundsException',
+        'Psl\DataStructure\Exception\UnderflowException',
     ];
 
     public const ENUMS = [

--- a/tests/unit/DataStructure/PriorityQueueTest.php
+++ b/tests/unit/DataStructure/PriorityQueueTest.php
@@ -2,10 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Psl\DataStructure;
+namespace Psl\Tests\Unit\DataStructure;
 
 use PHPUnit\Framework\TestCase;
-use Psl;
 use Psl\DataStructure;
 
 final class PriorityQueueTest extends TestCase
@@ -90,8 +89,8 @@ final class PriorityQueueTest extends TestCase
     {
         $queue = new DataStructure\PriorityQueue();
 
-        $this->expectException(Psl\Exception\InvariantViolationException::class);
-        $this->expectExceptionMessage('Cannot dequeue a node from an empty Queue.');
+        $this->expectException(DataStructure\Exception\UnderflowException::class);
+        $this->expectExceptionMessage('Cannot dequeue a node from an empty queue.');
 
         $queue->dequeue();
     }

--- a/tests/unit/DataStructure/QueueTest.php
+++ b/tests/unit/DataStructure/QueueTest.php
@@ -2,10 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Psl\DataStructure;
+namespace Psl\Tests\Unit\DataStructure;
 
 use PHPUnit\Framework\TestCase;
-use Psl;
 use Psl\DataStructure;
 
 final class QueueTest extends TestCase
@@ -75,8 +74,8 @@ final class QueueTest extends TestCase
     {
         $queue = new DataStructure\Queue();
 
-        $this->expectException(Psl\Exception\InvariantViolationException::class);
-        $this->expectExceptionMessage('Cannot dequeue a node from an empty Queue.');
+        $this->expectException(DataStructure\Exception\UnderflowException::class);
+        $this->expectExceptionMessage('Cannot dequeue a node from an empty queue.');
 
         $queue->dequeue();
     }

--- a/tests/unit/DataStructure/StackTest.php
+++ b/tests/unit/DataStructure/StackTest.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace Psl\Tests\Unit\DataStructure;
 
 use PHPUnit\Framework\TestCase;
-use Psl;
-use Psl\DataStructure\Stack;
+use Psl\DataStructure;
 
 final class StackTest extends TestCase
 {
     public function testPushAndPop(): void
     {
-        $stack = new Stack();
+        $stack = new DataStructure\Stack();
         $stack->push('hello');
         $stack->push('hey');
         $stack->push('hi');
@@ -30,7 +29,7 @@ final class StackTest extends TestCase
 
     public function testPeek(): void
     {
-        $stack = new Stack();
+        $stack = new DataStructure\Stack();
 
         static::assertNull($stack->peek());
 
@@ -38,24 +37,29 @@ final class StackTest extends TestCase
 
         static::assertNotNull($stack->peek());
         static::assertSame('hello', $stack->peek());
+
+        static::assertSame('hello', $stack->pop());
+
+        static::assertNull($stack->peek());
     }
 
     public function testPopThrowsForEmptyStack(): void
     {
-        $stack = new Stack();
+        $stack = new DataStructure\Stack();
         $stack->push('hello');
 
         static::assertSame('hello', $stack->pop());
+        static::assertNull($stack->peek());
 
-        $this->expectException(Psl\Exception\InvariantViolationException::class);
-        $this->expectExceptionMessage('Cannot pop an item from an empty Stack.');
+        $this->expectException(DataStructure\Exception\UnderflowException::class);
+        $this->expectExceptionMessage('Cannot pop an item from an empty stack.');
 
         $stack->pop();
     }
 
     public function testPullReturnsNullForEmptyStack(): void
     {
-        $stack = new Stack();
+        $stack = new DataStructure\Stack();
         $stack->push('hello');
 
         static::assertSame('hello', $stack->pull());
@@ -64,10 +68,18 @@ final class StackTest extends TestCase
 
     public function testCount(): void
     {
-        $stack = new Stack();
+        $stack = new DataStructure\Stack();
         static::assertSame(0, $stack->count());
 
         $stack->push('hello');
         static::assertSame(1, $stack->count());
+        $stack->pop();
+        static::assertSame(0, $stack->count());
+        $stack->push('hello');
+        $stack->push('hello');
+        $stack->push('hello');
+        static::assertSame(3, $stack->count());
+        $stack->pop();
+        static::assertSame(2, $stack->count());
     }
 }

--- a/tests/unit/Dict/TakeTest.php
+++ b/tests/unit/Dict/TakeTest.php
@@ -12,7 +12,9 @@ final class TakeTest extends TestCase
     public function testTake(): void
     {
         $result = Dict\take([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5], 3);
-
         static::assertSame([-5, -4, -3], $result);
+
+        $result = Dict\take([1, 2], 0);
+        static::assertSame([], $result);
     }
 }


### PR DESCRIPTION
1. throw underflow exception instead of invariant violation ( ref #198 )
2. optimize data structures by using builtin functions instead of PSL ( while messier, it's faster, and is not exposed in the public API )
