### PR TITLE
feat(option): introduce `Option\from_nullable` function 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@
 - [Psl\Network](./component/network.md)
 - [Psl\OS](./component/os.md)
 - [Psl\Observer](./component/observer.md)
+- [Psl\Option](./component/option.md)
 - [Psl\Password](./component/password.md)
 - [Psl\Promise](./component/promise.md)
 - [Psl\PseudoRandom](./component/pseudo-random.md)

--- a/docs/component/channel.md
+++ b/docs/component/channel.md
@@ -17,6 +17,7 @@
 
 #### `Interfaces`
 
+- [ChannelInterface](./../../src/Psl/Channel/ChannelInterface.php#L12)
 - [ReceiverInterface](./../../src/Psl/Channel/ReceiverInterface.php#L12)
 - [SenderInterface](./../../src/Psl/Channel/SenderInterface.php#L12)
 

--- a/docs/component/option.md
+++ b/docs/component/option.md
@@ -1,0 +1,23 @@
+<!--
+    This markdown file was generated using `docs/documenter.php`.
+
+    Any edits to it will likely be lost.
+-->
+
+[*index](./../README.md)
+
+---
+
+### `Psl\Option` Component
+
+#### `Functions`
+
+- [from_nullable](./../../src/Psl/Option/from_nullable.php#L16)
+- [none](./../../src/Psl/Option/none.php#L14)
+- [some](./../../src/Psl/Option/some.php#L16)
+
+#### `Classes`
+
+- [Option](./../../src/Psl/Option/Option.php#L12)
+
+

--- a/docs/documenter.php
+++ b/docs/documenter.php
@@ -206,6 +206,7 @@ function get_all_components(): array
         'Psl\\Json',
         'Psl\\Math',
         'Psl\\Network',
+        'Psl\\Option',
         'Psl\\Observer',
         'Psl\\OS',
         'Psl\\Password',

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -480,6 +480,7 @@ final class Loader
         'Psl\\OS\\is_darwin' => 'Psl/OS/is_darwin.php',
         'Psl\\Option\\some' => 'Psl/Option/some.php',
         'Psl\\Option\\none' => 'Psl/Option/none.php',
+        'Psl\\Option\\from_nullable' => 'Psl/Option/from_nullable.php',
     ];
 
     public const INTERFACES = [

--- a/src/Psl/Option/from_nullable.php
+++ b/src/Psl/Option/from_nullable.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Option;
+
+/**
+ * Create an option from a mixed value (Some) or null (None).
+ *
+ * @template T
+ *
+ * @param null|T $value
+ *
+ * @return Option<T>
+ */
+function from_nullable(mixed $value): Option
+{
+    return $value !== null ? Option::some($value) : Option::none();
+}

--- a/tests/static-analysis/Option/from_nullable.php
+++ b/tests/static-analysis/Option/from_nullable.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Psl\Option\Option;
+
+use function Psl\Option\from_nullable;
+
+/**
+ * @return Option<string>
+ */
+function test_some(): Option
+{
+    return from_nullable('hello');
+}
+
+/**
+ * @return Option<null>
+ */
+function test_none(): Option
+{
+    return from_nullable(null);
+}
+
+/**
+ * @template T
+ *
+ * @param T|null $param
+ *
+ * @return Option<T>
+ */
+function test_generic($param): Option
+{
+    return from_nullable($param);
+}
+
+/**
+ * @return Option<string>
+ */
+function test_some_generic(): Option
+{
+    return test_generic('some');
+}
+
+/**
+ * @return Option<null>
+ */
+function test_none_generic(): Option
+{
+    return test_generic(null);
+}
+
+/**
+ * @param string|null $x
+ *
+ * @return Option<string>
+ */
+function test_all_posibilities_generic($x): Option
+{
+    return test_generic($x);
+}

--- a/tests/unit/Option/FromNullableTest.php
+++ b/tests/unit/Option/FromNullableTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Option;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Option;
+use stdClass;
+
+final class FromNullableTest extends TestCase
+{
+    public function testIsSome(): void
+    {
+        static::assertTrue(Option\from_nullable(1)->isSome());
+        static::assertTrue(Option\from_nullable(1.1)->isSome());
+        static::assertTrue(Option\from_nullable(true)->isSome());
+        static::assertTrue(Option\from_nullable(false)->isSome());
+        static::assertTrue(Option\from_nullable('hello')->isSome());
+        static::assertTrue(Option\from_nullable([])->isSome());
+        static::assertTrue(Option\from_nullable(new stdClass())->isSome());
+        static::assertTrue(Option\from_nullable(static fn() => '')->isSome());
+        static::assertTrue(Option\from_nullable(static function () {
+            yield 'hello';
+        })->isSome());
+    }
+
+    public function testIsNone(): void
+    {
+        $option = Option\from_nullable(null);
+
+        static::assertTrue($option->isNone());
+    }
+}


### PR DESCRIPTION
Introduces a new `Option\from_nullable()` factory that takes a `T|null` and converts it into an `Option<T>`

```php
/**
 * @param string|null $x
 *
 * @return Option<string>
 */
function foo($x): Option
{
    return Option\from_nullable($x);
}

```

it can be used as a shortcut function to opt-in on the Option component from functions that return something `nullable`.