### PR TITLE
feat(range): add wither methods

### DIFF
--- a/docs/component/range.md
+++ b/docs/component/range.md
@@ -25,7 +25,7 @@
 
 #### `Classes`
 
-- [BetweenRange](./../../src/Psl/Range/BetweenRange.php#L45)
+- [BetweenRange](./../../src/Psl/Range/BetweenRange.php#L48)
 - [FromRange](./../../src/Psl/Range/FromRange.php#L36)
 - [FullRange](./../../src/Psl/Range/FullRange.php#L20)
 - [ToRange](./../../src/Psl/Range/ToRange.php#L22)

--- a/src/Psl/Range/BetweenRange.php
+++ b/src/Psl/Range/BetweenRange.php
@@ -36,8 +36,11 @@ use Psl\Iter;
  * @implements UpperBoundRangeInterface<T>
  *
  * @see RangeInterface::contains()
+ * @see RangeInterface::withLowerBound()
+ * @see RangeInterface::withUpperBound()
  * @see LowerBoundRangeInterface::getLowerBound()
  * @see UpperBoundRangeInterface::getUpperBound()
+ * @see UpperBoundRangeInterface::withUpperInclusive()
  * @see UpperBoundRangeInterface::isUpperInclusive()
  *
  * @immutable
@@ -80,13 +83,97 @@ final class BetweenRange implements LowerBoundRangeInterface, UpperBoundRangeInt
     /**
      * {@inheritDoc}
      *
-     * @return T
+     * @param T $upper_bound
+     *
+     * @return BetweenRange<T>
      *
      * @psalm-mutation-free
      */
-    public function getLowerBound(): int|float
+    public function withUpperBound(float|int $upper_bound, bool $upper_inclusive): BetweenRange
     {
-        return $this->lower_bound;
+        return new BetweenRange(
+            $this->lower_bound,
+            $upper_bound,
+            $upper_inclusive,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return BetweenRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBoundInclusive(float|int $upper_bound): BetweenRange
+    {
+        return new BetweenRange(
+            $this->lower_bound,
+            $upper_bound,
+            true,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return BetweenRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBoundExclusive(float|int $upper_bound): BetweenRange
+    {
+        return new BetweenRange(
+            $this->lower_bound,
+            $upper_bound,
+            false,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return ToRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withoutLowerBound(): ToRange
+    {
+        return new ToRange($this->upper_bound, $this->upper_inclusive);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $lower_bound
+     *
+     * @return BetweenRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withLowerBound(int|float $lower_bound): BetweenRange
+    {
+        return new static(
+            $lower_bound,
+            $this->upper_bound,
+            $this->upper_inclusive,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return FromRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withoutUpperBound(): FromRange
+    {
+        return new FromRange($this->lower_bound);
     }
 
     /**
@@ -109,6 +196,34 @@ final class BetweenRange implements LowerBoundRangeInterface, UpperBoundRangeInt
     public function isUpperInclusive(): bool
     {
         return $this->upper_inclusive;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return static<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperInclusive(bool $upper_inclusive): static
+    {
+        return new static(
+            $this->lower_bound,
+            $this->upper_bound,
+            $upper_inclusive,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return T
+     *
+     * @psalm-mutation-free
+     */
+    public function getLowerBound(): int|float
+    {
+        return $this->lower_bound;
     }
 
     /**

--- a/src/Psl/Range/FromRange.php
+++ b/src/Psl/Range/FromRange.php
@@ -60,6 +60,89 @@ final class FromRange implements LowerBoundRangeInterface
     /**
      * {@inheritDoc}
      *
+     * @param T $lower_bound
+     *
+     * @return FromRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withLowerBound(int|float $lower_bound): FromRange
+    {
+        return new FromRange(
+            $lower_bound,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return BetweenRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBound(float|int $upper_bound, bool $upper_inclusive): BetweenRange
+    {
+        return new BetweenRange(
+            $this->lower_bound,
+            $upper_bound,
+            $upper_inclusive,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return FullRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withoutLowerBound(): FullRange
+    {
+        /** @var FullRange<T> */
+        return new FullRange();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return BetweenRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBoundInclusive(float|int $upper_bound): BetweenRange
+    {
+        return new BetweenRange(
+            $this->lower_bound,
+            $upper_bound,
+            true,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return BetweenRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBoundExclusive(float|int $upper_bound): BetweenRange
+    {
+        return new BetweenRange(
+            $this->lower_bound,
+            $upper_bound,
+            false,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @return T
      *
      * @psalm-mutation-free

--- a/src/Psl/Range/FullRange.php
+++ b/src/Psl/Range/FullRange.php
@@ -32,4 +32,62 @@ final class FullRange implements RangeInterface
     {
         return true;
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $lower_bound
+     *
+     * @return FromRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withLowerBound(int|float $lower_bound): FromRange
+    {
+        return new FromRange(
+            $lower_bound,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return ToRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBound(float|int $upper_bound, bool $upper_inclusive): ToRange
+    {
+        return new ToRange($upper_bound, $upper_inclusive);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return ToRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBoundInclusive(float|int $upper_bound): ToRange
+    {
+        return new ToRange($upper_bound, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return ToRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBoundExclusive(float|int $upper_bound): ToRange
+    {
+        return new ToRange($upper_bound, false);
+    }
 }

--- a/src/Psl/Range/LowerBoundRangeInterface.php
+++ b/src/Psl/Range/LowerBoundRangeInterface.php
@@ -18,6 +18,48 @@ use Psl\Iter;
 interface LowerBoundRangeInterface extends IteratorAggregate, RangeInterface
 {
     /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return UpperBoundRangeInterface<T>&LowerBoundRangeInterface<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBound(int|float $upper_bound, bool $upper_inclusive): UpperBoundRangeInterface&LowerBoundRangeInterface;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return UpperBoundRangeInterface<T>&LowerBoundRangeInterface<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBoundInclusive(int|float $upper_bound): UpperBoundRangeInterface&LowerBoundRangeInterface;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return UpperBoundRangeInterface<T>&LowerBoundRangeInterface<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBoundExclusive(int|float $upper_bound): UpperBoundRangeInterface&LowerBoundRangeInterface;
+
+    /**
+     * Remove the lower bound from the range.
+     *
+     * @return RangeInterface<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withoutLowerBound(): RangeInterface;
+
+    /**
      * Returns the lower bound of the range.
      *
      * @return T
@@ -25,7 +67,7 @@ interface LowerBoundRangeInterface extends IteratorAggregate, RangeInterface
      * @psalm-mutation-free
      */
     public function getLowerBound(): int|float;
-
+    
     /**
      * Returns an iterator for the range.
      *

--- a/src/Psl/Range/RangeInterface.php
+++ b/src/Psl/Range/RangeInterface.php
@@ -21,4 +21,48 @@ interface RangeInterface
      * @psalm-mutation-free
      */
     public function contains(int|float $value): bool;
+
+    /**
+     * Combine this range with the given lower bound.
+     *
+     * @param T $lower_bound
+     *
+     * @return LowerBoundRangeInterface<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withLowerBound(int|float $lower_bound): LowerBoundRangeInterface;
+
+    /**
+     * Combine this range with the given upper bound.
+     *
+     * @param T $upper_bound
+     *
+     * @return UpperBoundRangeInterface<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBound(int|float $upper_bound, bool $upper_inclusive): UpperBoundRangeInterface;
+
+    /**
+     * Combine this range with the given upper bound, and make it inclusive.
+     *
+     * @param T $upper_bound
+     *
+     * @return UpperBoundRangeInterface<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBoundInclusive(int|float $upper_bound): UpperBoundRangeInterface;
+
+    /**
+     * Combine this range with the given upper bound, and make it exclusive.
+     *
+     * @param T $upper_bound
+     *
+     * @return UpperBoundRangeInterface<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBoundExclusive(int|float $upper_bound): UpperBoundRangeInterface;
 }

--- a/src/Psl/Range/ToRange.php
+++ b/src/Psl/Range/ToRange.php
@@ -51,6 +51,79 @@ final class ToRange implements UpperBoundRangeInterface
     /**
      * {@inheritDoc}
      *
+     * @param T $lower_bound
+     *
+     * @return BetweenRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withLowerBound(int|float $lower_bound): BetweenRange
+    {
+        return new BetweenRange(
+            $lower_bound,
+            $this->upper_bound,
+            $this->upper_inclusive,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return FullRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withoutUpperBound(): FullRange
+    {
+        /** @var FullRange<T> */
+        return new FullRange();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return ToRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBound(float|int $upper_bound, bool $upper_inclusive): ToRange
+    {
+        return new self($upper_bound, $upper_inclusive);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return ToRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBoundInclusive(float|int $upper_bound): ToRange
+    {
+        return new self($upper_bound, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param T $upper_bound
+     *
+     * @return ToRange<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperBoundExclusive(float|int $upper_bound): ToRange
+    {
+        return new self($upper_bound, false);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @return T
      *
      * @psalm-mutation-free
@@ -59,7 +132,7 @@ final class ToRange implements UpperBoundRangeInterface
     {
         return $this->upper_bound;
     }
-
+    
     /**
      * {@inheritDoc}
      *
@@ -68,5 +141,20 @@ final class ToRange implements UpperBoundRangeInterface
     public function isUpperInclusive(): bool
     {
         return $this->upper_inclusive;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return static<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperInclusive(bool $upper_inclusive): static
+    {
+        return new static(
+            $this->upper_bound,
+            $upper_inclusive,
+        );
     }
 }

--- a/src/Psl/Range/UpperBoundRangeInterface.php
+++ b/src/Psl/Range/UpperBoundRangeInterface.php
@@ -14,6 +14,26 @@ namespace Psl\Range;
 interface UpperBoundRangeInterface extends RangeInterface
 {
     /**
+     * {@inheritDoc}
+     *
+     * @param T $lower_bound
+     *
+     * @return UpperBoundRangeInterface<T>&LowerBoundRangeInterface<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withLowerBound(int|float $lower_bound): UpperBoundRangeInterface&LowerBoundRangeInterface;
+
+    /**
+     * Remove the upper bound from the range.
+     *
+     * @return RangeInterface<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withoutUpperBound(): RangeInterface;
+    
+    /**
      * Returns the upper bound of the range.
      *
      * @return T
@@ -28,4 +48,13 @@ interface UpperBoundRangeInterface extends RangeInterface
      * @psalm-mutation-free
      */
     public function isUpperInclusive(): bool;
+
+    /**
+     * Return a new instance, where the upper bound inclusive flag is set to the given value.
+     *
+     * @return static<T>
+     *
+     * @psalm-mutation-free
+     */
+    public function withUpperInclusive(bool $upper_inclusive): static;
 }

--- a/tests/unit/Range/BetweenRangeTest.php
+++ b/tests/unit/Range/BetweenRangeTest.php
@@ -43,7 +43,7 @@ final class BetweenRangeTest extends TestCase
         static::assertTrue($range->contains(Math\INT16_MAX));
         static::assertTrue($range->contains(Math\INT16_MAX - 1));
         static::assertTrue($range->contains(Math\INT16_MIN));
-        
+
         $range = new Range\BetweenRange(Math\INT16_MIN, Math\INT16_MAX);
 
         static::assertTrue($range->contains(100));
@@ -70,7 +70,7 @@ final class BetweenRangeTest extends TestCase
         static::assertTrue($range->contains(Math\INT16_MIN));
         static::assertTrue($range->contains(Math\INT16_MIN + 1));
     }
-    
+
     public function testBounds(): void
     {
         $range = Range\between(Math\INT16_MIN, Math\INT16_MAX);
@@ -84,7 +84,7 @@ final class BetweenRangeTest extends TestCase
         $range = Range\between(Math\INT16_MIN, Math\INT16_MAX, upper_inclusive: true);
         static::assertSame(Math\INT16_MIN, $range->getLowerBound());
         static::assertSame(Math\INT16_MAX, $range->getUpperBound());
-        
+
         $range = new Range\BetweenRange(Math\INT16_MIN, Math\INT16_MAX);
         static::assertSame(Math\INT16_MIN, $range->getLowerBound());
         static::assertSame(Math\INT16_MAX, $range->getUpperBound());
@@ -120,6 +120,45 @@ final class BetweenRangeTest extends TestCase
 
         $range = new Range\BetweenRange(0, 100);
         static::assertFalse($range->isUpperInclusive());
+    }
+
+    public function testWithers(): void
+    {
+        $range = new Range\BetweenRange(0, 100);
+
+        static::assertSame(0, $range->getLowerBound());
+        static::assertSame(100, $range->getUpperBound());
+        static::assertSame(0, $range->withLowerBound(0)->getLowerBound());
+        static::assertSame(1, $range->withUpperBound(1, false)->getUpperBound());
+        static::assertSame(1, $range->withUpperBoundExclusive(1)->getUpperBound());
+        static::assertSame(1, $range->withUpperBoundInclusive(1)->getUpperBound());
+        static::assertSame(false, $range->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(false, $range->withUpperInclusive(false)->isUpperInclusive());
+        static::assertSame(true, $range->withUpperInclusive(true)->isUpperInclusive());
+        static::assertSame(false, $range->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(true, $range->withUpperBound(0, true)->isUpperInclusive());
+        static::assertSame(false, $range->withUpperBoundExclusive(0)->isUpperInclusive());
+        static::assertSame(true, $range->withUpperBoundInclusive(0)->isUpperInclusive());
+
+        static::assertSame(0, $range->withoutUpperBound()->withLowerBound(0)->getLowerBound());
+        static::assertSame(1, $range->withoutUpperBound()->withUpperBound(1, false)->getUpperBound());
+        static::assertSame(1, $range->withoutUpperBound()->withUpperBoundExclusive(1)->getUpperBound());
+        static::assertSame(1, $range->withoutUpperBound()->withUpperBoundInclusive(1)->getUpperBound());
+        static::assertSame(false, $range->withoutUpperBound()->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(false, $range->withoutUpperBound()->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(true, $range->withoutUpperBound()->withUpperBound(0, true)->isUpperInclusive());
+        static::assertSame(false, $range->withoutUpperBound()->withUpperBoundExclusive(0)->isUpperInclusive());
+        static::assertSame(true, $range->withoutUpperBound()->withUpperBoundInclusive(0)->isUpperInclusive());
+
+        static::assertSame(0, $range->withoutLowerBound()->withLowerBound(0)->getLowerBound());
+        static::assertSame(1, $range->withoutLowerBound()->withUpperBound(1, false)->getUpperBound());
+        static::assertSame(1, $range->withoutLowerBound()->withUpperBoundExclusive(1)->getUpperBound());
+        static::assertSame(1, $range->withoutLowerBound()->withUpperBoundInclusive(1)->getUpperBound());
+        static::assertSame(false, $range->withoutLowerBound()->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(false, $range->withoutLowerBound()->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(true, $range->withoutLowerBound()->withUpperBound(0, true)->isUpperInclusive());
+        static::assertSame(false, $range->withoutLowerBound()->withUpperBoundExclusive(0)->isUpperInclusive());
+        static::assertSame(true, $range->withoutLowerBound()->withUpperBoundInclusive(0)->isUpperInclusive());
     }
 
     public function testIterate(): void

--- a/tests/unit/Range/FromRangeTest.php
+++ b/tests/unit/Range/FromRangeTest.php
@@ -46,7 +46,35 @@ final class FromRangeTest extends TestCase
         $range = Range\from(-24.24);
         static::assertSame(-24.24, $range->getLowerBound());
     }
-    
+
+    public function testWithers(): void
+    {
+        $range = new Range\FromRange(0);
+
+        static::assertSame(0, $range->getLowerBound());
+        static::assertSame(0, $range->withLowerBound(0)->getLowerBound());
+        static::assertSame(1, $range->withUpperBound(1, false)->getUpperBound());
+        static::assertSame(1, $range->withUpperBoundExclusive(1)->getUpperBound());
+        static::assertSame(1, $range->withUpperBoundInclusive(1)->getUpperBound());
+        static::assertSame(false, $range->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(false, $range->withUpperBound(0, true)->withUpperInclusive(false)->isUpperInclusive());
+        static::assertSame(true, $range->withUpperBound(0, false)->withUpperInclusive(true)->isUpperInclusive());
+        static::assertSame(false, $range->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(true, $range->withUpperBound(0, true)->isUpperInclusive());
+        static::assertSame(false, $range->withUpperBoundExclusive(0)->isUpperInclusive());
+        static::assertSame(true, $range->withUpperBoundInclusive(0)->isUpperInclusive());
+
+        static::assertSame(0, $range->withoutLowerBound()->withLowerBound(0)->getLowerBound());
+        static::assertSame(1, $range->withoutLowerBound()->withUpperBound(1, false)->getUpperBound());
+        static::assertSame(1, $range->withoutLowerBound()->withUpperBoundExclusive(1)->getUpperBound());
+        static::assertSame(1, $range->withoutLowerBound()->withUpperBoundInclusive(1)->getUpperBound());
+        static::assertSame(false, $range->withoutLowerBound()->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(false, $range->withoutLowerBound()->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(true, $range->withoutLowerBound()->withUpperBound(0, true)->isUpperInclusive());
+        static::assertSame(false, $range->withoutLowerBound()->withUpperBoundExclusive(0)->isUpperInclusive());
+        static::assertSame(true, $range->withoutLowerBound()->withUpperBoundInclusive(0)->isUpperInclusive());
+    }
+
     public function testIterate(): void
     {
         $range = Range\from(10);

--- a/tests/unit/Range/FullRangeTest.php
+++ b/tests/unit/Range/FullRangeTest.php
@@ -34,4 +34,21 @@ final class FullRangeTest extends TestCase
         static::assertTrue($range->contains(Math\UINT64_MAX));
         static::assertTrue($range->contains(Math\INFINITY));
     }
+
+    public function testWithers(): void
+    {
+        $range = new Range\FullRange();
+
+        static::assertSame(0, $range->withLowerBound(0)->getLowerBound());
+        static::assertSame(1, $range->withUpperBound(1, false)->getUpperBound());
+        static::assertSame(1, $range->withUpperBoundExclusive(1)->getUpperBound());
+        static::assertSame(1, $range->withUpperBoundInclusive(1)->getUpperBound());
+        static::assertSame(false, $range->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(false, $range->withUpperBound(0, true)->withUpperInclusive(false)->isUpperInclusive());
+        static::assertSame(true, $range->withUpperBound(0, false)->withUpperInclusive(true)->isUpperInclusive());
+        static::assertSame(false, $range->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(true, $range->withUpperBound(0, true)->isUpperInclusive());
+        static::assertSame(false, $range->withUpperBoundExclusive(0)->isUpperInclusive());
+        static::assertSame(true, $range->withUpperBoundInclusive(0)->isUpperInclusive());
+    }
 }

--- a/tests/unit/Range/ToRangeTest.php
+++ b/tests/unit/Range/ToRangeTest.php
@@ -130,7 +130,35 @@ final class ToRangeTest extends TestCase
         $range = new Range\ToRange(100);
         static::assertFalse($range->isUpperInclusive());
     }
-    
+
+    public function testWithers(): void
+    {
+        $range = new Range\ToRange(100);
+
+        static::assertSame(100, $range->getUpperBound());
+        static::assertSame(0, $range->withLowerBound(0)->getLowerBound());
+        static::assertSame(1, $range->withUpperBound(1, false)->getUpperBound());
+        static::assertSame(1, $range->withUpperBoundExclusive(1)->getUpperBound());
+        static::assertSame(1, $range->withUpperBoundInclusive(1)->getUpperBound());
+        static::assertSame(false, $range->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(false, $range->withUpperInclusive(false)->isUpperInclusive());
+        static::assertSame(true, $range->withUpperInclusive(true)->isUpperInclusive());
+        static::assertSame(false, $range->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(true, $range->withUpperBound(0, true)->isUpperInclusive());
+        static::assertSame(false, $range->withUpperBoundExclusive(0)->isUpperInclusive());
+        static::assertSame(true, $range->withUpperBoundInclusive(0)->isUpperInclusive());
+
+        static::assertSame(0, $range->withoutUpperBound()->withLowerBound(0)->getLowerBound());
+        static::assertSame(1, $range->withoutUpperBound()->withUpperBound(1, false)->getUpperBound());
+        static::assertSame(1, $range->withoutUpperBound()->withUpperBoundExclusive(1)->getUpperBound());
+        static::assertSame(1, $range->withoutUpperBound()->withUpperBoundInclusive(1)->getUpperBound());
+        static::assertSame(false, $range->withoutUpperBound()->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(false, $range->withoutUpperBound()->withUpperBound(0, false)->isUpperInclusive());
+        static::assertSame(true, $range->withoutUpperBound()->withUpperBound(0, true)->isUpperInclusive());
+        static::assertSame(false, $range->withoutUpperBound()->withUpperBoundExclusive(0)->isUpperInclusive());
+        static::assertSame(true, $range->withoutUpperBound()->withUpperBoundInclusive(0)->isUpperInclusive());
+    }
+
     public function testUpperBound(): void
     {
         $range = Range\to(10, inclusive: true);


### PR DESCRIPTION
adding `with` and `without` methods, allowing the modification of a range.

```php
$range = Range\full()             // ..
    ->withUpperBound(10, false)   // ..10
    ->withUpperBound(10, true)    // ..=10
    ->withUpperBoundExclusive(10) // ..10
    ->withUpperBoundInclusive(10) // ..=10
    ->withUpperInclusive(false)   // ..10
    ->withLowerBound(2)           // 2..10
    ->withUpperBoundInclusive(10) // 2..=10
    ->withoutUpperBound()         // 2..
    ->withoutLowerBound()         // ..
;
```