### PR TITLE
curse(option): declare None as a constant

### DIFF
--- a/examples/option/none.php
+++ b/examples/option/none.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+use Psl\IO;
+use Psl\Option;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+/**
+ * @return Option\Option<string>
+ */
+function get_some_string(): Option\Option
+{
+    return Option\some('some string');
+}
+
+/**
+ * @return Option\Option<string>
+ */
+function get_none_string(): Option\Option
+{
+    return Option\none();
+}
+
+$some = get_some_string();
+$none = get_none_string();
+
+Psl\invariant($some->isSome(), 'Expected $some to be some.');
+Psl\invariant($none === Option\NONE, 'Expected $none to be none.');
+
+IO\write_line("OK");

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -50,6 +50,7 @@ final class Loader
         'Psl\\Str\\ALPHABET' => 'Psl/Str/constants.php',
         'Psl\\Str\\ALPHABET_ALPHANUMERIC' => 'Psl/Str/constants.php',
         'Psl\\Filesystem\\SEPARATOR' => 'Psl/Filesystem/constants.php',
+        'Psl\\Option\\NONE' => 'Psl/Option/constants.php',
     ];
 
     public const FUNCTIONS = [

--- a/src/Psl/Option/Option.php
+++ b/src/Psl/Option/Option.php
@@ -44,7 +44,12 @@ final class Option
      */
     public static function none(): Option
     {
-        return new self(null);
+        if (!defined('Psl\Option\NONE')) {
+            define('Psl\Option\NONE', new self(null));
+        }
+
+        /** @var Option<Tn> */
+        return NONE;
     }
 
     /**

--- a/src/Psl/Option/constants.php
+++ b/src/Psl/Option/constants.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Option;
+
+if (false) {
+    define('Psl\Option\NONE', Option::none());
+} else {
+    Option::none();
+}


### PR DESCRIPTION
I thought it would be nice to have a `NONE` constant, but i don't think maintaining this cursed code is worth it.


```php
use Psl\Option;

/**
 * @return Option\Option<string>
 */
function get_some_string(): Option\Option
{
    return Option\some('some string');
}

/**
 * @return Option\Option<string>
 */
function get_none_string(): Option\Option
{
    return Option\none();
}

$some = get_some_string();
$none = get_none_string();

Psl\invariant($some->isSome(), 'Expected $some to be some.');
Psl\invariant($none === Option\NONE, 'Expected $none to be none.');
```