### PR TITLE
fix(vec): `reproduce` and `range` return type is always non-empty-list

### DIFF
--- a/docs/component/vec.md
+++ b/docs/component/vec.md
@@ -29,7 +29,7 @@
 - [partition](./../../src/Psl/Vec/partition.php#L20)
 - [range](./../../src/Psl/Vec/range.php#L49)
 - [reductions](./../../src/Psl/Vec/reductions.php#L29)
-- [reproduce](./../../src/Psl/Vec/reproduce.php#L24)
+- [reproduce](./../../src/Psl/Vec/reproduce.php#L27)
 - [reverse](./../../src/Psl/Vec/reverse.php#L22)
 - [shuffle](./../../src/Psl/Vec/shuffle.php#L26)
 - [slice](./../../src/Psl/Vec/slice.php#L26)

--- a/src/Psl/Vec/range.php
+++ b/src/Psl/Vec/range.php
@@ -36,7 +36,7 @@ namespace Psl\Vec;
  *
  * @throws Exception\LogicException If $start < $end, and $step is negative.
  *
- * @return list<T>
+ * @return non-empty-list<T>
  *
  * @psalm-suppress InvalidReturnType
  * @psalm-suppress InvalidReturnStatement

--- a/src/Psl/Vec/reproduce.php
+++ b/src/Psl/Vec/reproduce.php
@@ -19,7 +19,10 @@ use Closure;
  * @param positive-int $size
  * @param (Closure(int): T) $factory
  *
- * @return list<T>
+ * @return non-empty-list<T>
+ *
+ * @psalm-suppress InvalidReturnType
+ * @psalm-suppress InvalidReturnStatement
  */
 function reproduce(int $size, Closure $factory): array
 {


### PR DESCRIPTION
`Psl\Vec\reproduce` and `Psl\Vec\range` will always return `non-empty-list`.