### PR TITLE
Imrovements on file creation during write modes

### DIFF
--- a/docs/component/file.md
+++ b/docs/component/file.md
@@ -30,7 +30,7 @@
 - [Lock](./../../src/Psl/File/Lock.php#L9)
 - [ReadHandle](./../../src/Psl/File/ReadHandle.php#L10)
 - [ReadWriteHandle](./../../src/Psl/File/ReadWriteHandle.php#L11)
-- [WriteHandle](./../../src/Psl/File/WriteHandle.php#L10)
+- [WriteHandle](./../../src/Psl/File/WriteHandle.php#L11)
 
 #### `Enums`
 

--- a/docs/component/filesystem.md
+++ b/docs/component/filesystem.md
@@ -22,6 +22,7 @@
 - [change_permissions](./../../src/Psl/Filesystem/change_permissions.php#L21)
 - [copy](./../../src/Psl/Filesystem/copy.php#L22)
 - [create_directory](./../../src/Psl/Filesystem/create_directory.php#L19)
+- [create_directory_for_file](./../../src/Psl/Filesystem/create_directory_for_file.php#L16)
 - [create_file](./../../src/Psl/Filesystem/create_file.php#L24)
 - [create_hard_link](./../../src/Psl/Filesystem/create_hard_link.php#L23)
 - [create_symbolic_link](./../../src/Psl/Filesystem/create_symbolic_link.php#L22)

--- a/src/Psl/Filesystem/create_directory_for_file.php
+++ b/src/Psl/Filesystem/create_directory_for_file.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Filesystem;
+
+/**
+ * Create the directory where the $filename is or will be stored.
+ *
+ * @param non-empty-string $filename
+ *
+ * @throws Exception\RuntimeException If unable to create the directory.
+ *
+ * @return non-empty-string
+ */
+function create_directory_for_file(string $filename, int $permissions = 0777): string
+{
+    $directory = namespace\get_directory($filename);
+    namespace\create_directory($directory, $permissions);
+
+    return $directory;
+}

--- a/src/Psl/Filesystem/create_file.php
+++ b/src/Psl/Filesystem/create_file.php
@@ -33,8 +33,7 @@ function create_file(string $filename, ?int $time = null, ?int $access_time = nu
         $fun = static fn(): bool => touch($filename, $time, Math\maxva($access_time, $time));
     }
 
-    $directory = namespace\get_directory($filename);
-    namespace\create_directory($directory);
+    namespace\create_directory_for_file($filename);
 
     [$result, $error_message] = Internal\box($fun);
     // @codeCoverageIgnoreStart

--- a/src/Psl/Filesystem/create_hard_link.php
+++ b/src/Psl/Filesystem/create_hard_link.php
@@ -42,9 +42,7 @@ function create_hard_link(string $source, string $destination): void
             namespace\delete_file($destination);
         }
     } else {
-        namespace\create_directory(
-            namespace\get_directory($destination)
-        );
+        namespace\create_directory_for_file($destination);
     }
 
     [$result, $error_message] = Internal\box(static fn() => link($source, $destination));

--- a/src/Psl/Filesystem/create_symbolic_link.php
+++ b/src/Psl/Filesystem/create_symbolic_link.php
@@ -25,8 +25,7 @@ function create_symbolic_link(string $source, string $destination): void
         throw Exception\NotFoundException::forNode($source);
     }
 
-    $destination_directory = namespace\get_directory($destination);
-    namespace\create_directory($destination_directory);
+    namespace\create_directory_for_file($destination);
 
     try {
         if (namespace\read_symbolic_link($destination) === $source) {

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -414,6 +414,7 @@ final class Loader
         'Psl\\Filesystem\\change_permissions' => 'Psl/Filesystem/change_permissions.php',
         'Psl\\Filesystem\\copy' => 'Psl/Filesystem/copy.php',
         'Psl\\Filesystem\\create_directory' => 'Psl/Filesystem/create_directory.php',
+        'Psl\\Filesystem\\create_directory_for_file' => 'Psl/Filesystem/create_directory_for_file.php',
         'Psl\\Filesystem\\create_file' => 'Psl/Filesystem/create_file.php',
         'Psl\\Filesystem\\delete_directory' => 'Psl/Filesystem/delete_directory.php',
         'Psl\\Filesystem\\delete_file' => 'Psl/Filesystem/delete_file.php',

--- a/tests/unit/File/ReadHandleTest.php
+++ b/tests/unit/File/ReadHandleTest.php
@@ -26,4 +26,13 @@ final class ReadHandleTest extends TestCase
 
         static::assertSame('hello, world!', $content);
     }
+
+    public function testNonExisting(): void
+    {
+        $temporary_file = Filesystem\create_temporary_file();
+        Filesystem\delete_file($temporary_file);
+
+        $this->expectException(File\Exception\NotFoundException::class);
+        File\open_read_only($temporary_file);
+    }
 }


### PR DESCRIPTION
There are some inconsistencies between `ReadWriteHandle` and `WriteHandle`.
The first one tries to create the file (and directories), the other does not.
The logic inside the handles are not in line with the docblocks above `WriteMode`: If all write-modes are trying to create the file, it doesn't make sense to disallow creation during e.g. `APPEND` and `TRUNCATE`.

This PR is a little draft to discuss a better approach that is consistent in between both handles and in line with the dockblocks of the write mode.