### PR TITLE
Introduce Result\try_catch shortcut

### DIFF
--- a/docs/component/result.md
+++ b/docs/component/result.md
@@ -14,6 +14,7 @@
 
 - [collect_stats](./../../src/Psl/Result/collect_stats.php#L14)
 - [reflect](./../../src/Psl/Result/reflect.php#L24)
+- [try_catch](./../../src/Psl/Result/try_catch.php#L24)
 - [wrap](./../../src/Psl/Result/wrap.php#L20)
 
 #### `Interfaces`

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -463,6 +463,7 @@ final class Loader
         'Psl\\Async\\run' => 'Psl/Async/run.php',
         'Psl\\Async\\concurrently' => 'Psl/Async/concurrently.php',
         'Psl\\Result\\reflect' => 'Psl/Result/reflect.php',
+        'Psl\\Result\\try_catch' => 'Psl/Result/try_catch.php',
         'Psl\\Async\\series' => 'Psl/Async/series.php',
         'Psl\\Async\\await' => 'Psl/Async/await.php',
         'Psl\\Async\\any' => 'Psl/Async/any.php',

--- a/src/Psl/Result/ResultInterface.php
+++ b/src/Psl/Result/ResultInterface.php
@@ -22,6 +22,68 @@ use Throwable;
 interface ResultInterface extends Psl\Promise\PromiseInterface
 {
     /**
+     * Transforms a promise's value by applying a function to the promise's fulfillment
+     * or rejection value.
+     *
+     * It is a shortcut for:
+     *
+     * ```php
+     * $promise->then($success, $failure);
+     * // same as:
+     * $promise->map($success)->catch($failure);
+     * ```
+     *
+     * @template Ts
+     *
+     * @param (Closure(T): Ts) $success
+     * @param (Closure(Throwable): Ts) $failure
+     *
+     * @return ResultInterface<Ts>
+     */
+    public function then(Closure $success, Closure $failure): ResultInterface;
+
+    /**
+     * Attaches a callback that is invoked if this promise is fulfilled.
+     *
+     * The returned promise is resolved with the return value of the callback,
+     * or is rejected with a throwable thrown from the callback.
+     *
+     * @template Ts
+     *
+     * @param (Closure(T): Ts) $success
+     *
+     * @return ResultInterface<Ts>
+     */
+    public function map(Closure $success): ResultInterface;
+
+    /**
+     * Attaches a callback that is invoked if this promise is rejected.
+     *
+     * The returned promise is resolved with the return value of the callback,
+     * or is rejected with a throwable thrown from the callback.
+     *
+     * @template Ts
+     *
+     * @param (Closure(Throwable): Ts) $failure
+     *
+     * @return ResultInterface<T|Ts>
+     */
+    public function catch(Closure $failure): ResultInterface;
+
+    /**
+     * Attaches a callback that is always invoked when the promise is resolved.
+     *
+     * The returned promise resolves with the same value as this promise once the callback has finished execution.
+     *
+     * If the callback throws, the returned promise will be rejected with the thrown throwable.
+     *
+     * @param (Closure(): void) $always
+     *
+     * @return ResultInterface<T>
+     */
+    public function always(Closure $always): ResultInterface;
+
+    /**
      * Return the result of the operation, or throw underlying throwable.
      *
      * - if the operation succeeded: return its result.

--- a/src/Psl/Result/try_catch.php
+++ b/src/Psl/Result/try_catch.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Result;
+
+use Closure;
+use Throwable;
+
+/**
+ * Try running an action $try.
+ * In case of success, it will return the result of the $try Closure.
+ * In case of failure, it will try to recover with the $catch Closure.
+ * The $catch Closure may still throw exceptions of which it will not recover.
+ *
+ * @template T
+ * @template Ts
+ *
+ * @param (Closure(): T) $try
+ * @param (Closure(Throwable): Ts) $catch
+ *
+ * @return T|Ts
+ */
+function try_catch(Closure $try, Closure $catch): mixed
+{
+    return namespace\wrap($try)->catch($catch)->getResult();
+}

--- a/tests/static-analysis/Result/try_catch.php
+++ b/tests/static-analysis/Result/try_catch.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Psl\Result;
+
+function test_try_catch(): ?string
+{
+    return Result\try_catch(
+        static fn(): string => 'hello',
+        static fn(): ?string => null,
+    );
+}
+
+
+function test_try_catch_composed(): ?string
+{
+    return (
+        static fn (int $id) => Result\try_catch(
+            static fn(): string => 'hello ' . (string) $id,
+            static fn(): ?string => null,
+        )
+    )(1);
+}

--- a/tests/unit/Result/TryCatchTest.php
+++ b/tests/unit/Result/TryCatchTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Result;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Psl\Result;
+use Throwable;
+
+final class TryCatchTest extends TestCase
+{
+    public function testTryResulting(): void
+    {
+        $actual = Result\try_catch(
+            static fn () => true,
+            static fn () => false,
+        );
+
+        static::assertTrue($actual);
+    }
+
+    public function testTryFailing(): void
+    {
+        $actual = Result\try_catch(
+            static fn () => throw new Exception('Not my style'),
+            static fn () => false,
+        );
+
+        static::assertFalse($actual);
+    }
+
+    public function testTryThrowing(): void
+    {
+        $this->expectExceptionObject(
+            $expected = new Exception('Mine either')
+        );
+
+        Result\try_catch(
+            static fn () => throw new Exception('Not my style'),
+            static fn () => throw $expected,
+        );
+    }
+
+    public function testReThrowing(): void
+    {
+        $this->expectExceptionObject(
+            $expected = new Exception('Not my style')
+        );
+
+        Result\try_catch(
+            static fn () => throw $expected,
+            static fn (Throwable $previous) => throw $previous,
+        );
+    }
+}


### PR DESCRIPTION
Inspired on ramda's tryCatch function:
https://ramdajs.com/docs/#tryCatch

> tryCatch takes two functions, a tryer and a catcher. The returned function evaluates the tryer; if it does not throw, it simply returns the result. If the tryer does throw, the returned function evaluates the catcher function and returns its result.


It can be seen as a shortcut for dealing with code that you know might error, for which you want to continue the flow with e.g. a default or calculated default value.

For example:

```php
$nullable_entity = Result\try_catch(
    static fn (): MyEntity => $repo->fetchById(1),
    static fn (): ?MyEntity => null,
);
```

I decided not to go the `Fun` way as it is in ramda, since it would require another dynamic psalm plugin.
Instead, you could make it composable yourself like this:

```php
$tryFetchById = static fn(int $id): ?MyEntity => Result\try_catch(
    static fn (): MyEntity => $repo->fetchById($id),
    static fn (): ?MyEntity => null,
);
```

It also works fine with `Option\from_nullable()` as you can from the examples above.


❗  Note: I inlined the `PromiseInterface` methods into the `ResultInterface` and made sure the return type for them is `ResultInterface`. Otherwise psalm thinks `ResultInterface::catch()` (and others) returns a `PromiseInterface` instead of a `ResultInterface`.
