### PR TITLE
Allow an empty string to be coerced to bool

### DIFF
--- a/src/Psl/Type/Internal/BoolType.php
+++ b/src/Psl/Type/Internal/BoolType.php
@@ -34,7 +34,7 @@ final class BoolType extends Type\Type
             return $value;
         }
 
-        if (0 === $value || '0' === $value) {
+        if (0 === $value || '0' === $value || '' === $value) {
             return false;
         }
 

--- a/tests/unit/Type/BoolTypeTest.php
+++ b/tests/unit/Type/BoolTypeTest.php
@@ -15,6 +15,7 @@ final class BoolTypeTest extends TypeTest
 
     public function getValidCoercions(): iterable
     {
+        yield ['', false];
         yield [false, false];
         yield [0, false];
         yield ['0', false];


### PR DESCRIPTION
Since casting `false` to a string results in an empty string, it would feel fair to be able to coerce an empty string into false.

