### PR TITLE
fix(option): return `Option<never>` for `Option::none()`

### DIFF
--- a/docs/component/option.md
+++ b/docs/component/option.md
@@ -13,7 +13,7 @@
 #### `Functions`
 
 - [from_nullable](./../../src/Psl/Option/from_nullable.php#L16)
-- [none](./../../src/Psl/Option/none.php#L14)
+- [none](./../../src/Psl/Option/none.php#L12)
 - [some](./../../src/Psl/Option/some.php#L16)
 
 #### `Classes`

--- a/src/Psl/Option/Option.php
+++ b/src/Psl/Option/Option.php
@@ -38,12 +38,11 @@ final class Option
     /**
      * Create an option with none value.
      *
-     * @template Tn
-     *
-     * @return Option<Tn>
+     * @return Option<never>
      */
     public static function none(): Option
     {
+        /** @var Option<never> */
         return new self(null);
     }
 

--- a/src/Psl/Option/none.php
+++ b/src/Psl/Option/none.php
@@ -7,9 +7,7 @@ namespace Psl\Option;
 /**
  * Create an option with none value.
  *
- * @template T
- *
- * @return Option<T>
+ * @return Option<never>
  */
 function none(): Option
 {


### PR DESCRIPTION
This change would make PHPStan generics work with these kinds of examples:

```php
/**
 * @return Option<string>
 */
public function test(): Option
{
    return none();
}
```

Which right now throws an error like
```
Method Test::test() should return Psl\Option\Option<string> but returns Psl\Option\Option<mixed>. 
```
