### PR TITLE
feat(option): new `Option::merge()` method

### DIFF
--- a/src/Psl/Option/Option.php
+++ b/src/Psl/Option/Option.php
@@ -279,4 +279,23 @@ final class Option
 
         return some($default());
     }
+
+    /**
+     * Merges an `Option<T>` and other `Option<T>` to `Option<Tu>` by applying a function to both contained values.
+     *
+     * @template Tu
+     *
+     * @param Option<T> $other
+     * @param (Closure(T, T): Tu) $closure
+     *
+     * @return Option<Tu>
+     */
+    public function merge(Option $other, Closure $closure)
+    {
+        if ($this->option !== null && $other->option !== null) {
+            return some($closure($this->option[0], $other->option[0]));
+        }
+
+        return none();
+    }
 }

--- a/tests/unit/Option/NoneTest.php
+++ b/tests/unit/Option/NoneTest.php
@@ -108,4 +108,25 @@ final class NoneTest extends TestCase
 
         static::assertNull($option->andThen(static fn($i) => Option\some($i + 1))->unwrapOr(null));
     }
+
+    /**
+     * @param Option\Option<int> $value1
+     * @param Option\Option<int> $value2
+     *
+     * @dataProvider provideMerge
+     */
+    public function testMerge(Option\Option $value1, Option\Option $value2): void
+    {
+        $this->expectException(NoneException::class);
+        $this->expectExceptionMessage('Attempting to unwrap a none option.');
+
+        $value1->merge($value2, static fn($a, $b) => $a + $b)->unwrap();
+    }
+
+    public function provideMerge(): iterable
+    {
+        yield [Option\none(), Option\none()];
+        yield [Option\none(), Option\some(2)];
+        yield [Option\some(1), Option\none()];
+    }
 }

--- a/tests/unit/Option/SomeTest.php
+++ b/tests/unit/Option/SomeTest.php
@@ -105,4 +105,12 @@ final class SomeTest extends TestCase
 
         static::assertSame(3, $option->andThen(static fn($i) => Option\some($i + 1))->unwrapOr(null));
     }
+
+    public function testMerge(): void
+    {
+        $value1 = Option\some(1);
+        $value2 = Option\some(2);
+
+        static::assertSame(3, $value1->merge($value2, static fn($a, $b) => $a + $b)->unwrap());
+    }
 }


### PR DESCRIPTION
The idea, as shown, is easy.

I propose a versatile `merge` method to make several operations easier between two `Option`s:

```php
Option\some(1)->merge(Option\some(2), static fn (int $a, int $b) => $a + $b)); // Option<3>
Option\none()->merge(Option\some(2), static fn (int $a, int $b) => $a + $b)); // Option<*never*>
Option\some(1)->merge(Option\none(), static fn (int $a, int $b) => $a + $b)); // Option<*never*>

Option\some('Hello')->merge(
    Option\some('World'), 
    static fn (string $a, string $b) => $a.' '.$b)
); // Option<"Hello World">
```

This is what triggered this particular need in my case:

```php
$value1 = Option\some(false);
$value2 = Option\some(true);

$value1->merge($value2, static fn (bool $a, bool $b) => $a && $b)->unwrapOr(false); // false

$value1 = Option\some(Money::EUR(100));
$value2 = Option\some(Money::USD(100));

$value1->merge($value2, static fn (Money $a, Money $b) => $a->equals($b))->unwrapOr(false); // false
```

Probably there is a better name for this method, for sure!