### PR TITLE
Introduce a comparison component

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
 - [Psl\Channel](./component/channel.md)
 - [Psl\Class](./component/class.md)
 - [Psl\Collection](./component/collection.md)
+- [Psl\Comparison](./component/comparison.md)
 - [Psl\DataStructure](./component/data-structure.md)
 - [Psl\Dict](./component/dict.md)
 - [Psl\Encoding\Base64](./component/encoding-base64.md)

--- a/docs/component/comparison.md
+++ b/docs/component/comparison.md
@@ -1,0 +1,33 @@
+<!--
+    This markdown file was generated using `docs/documenter.php`.
+
+    Any edits to it will likely be lost.
+-->
+
+[*index](./../README.md)
+
+---
+
+### `Psl\Comparison` Component
+
+#### `Functions`
+
+- [compare](./../../src/Psl/Comparison/compare.php#L19)
+- [equal](./../../src/Psl/Comparison/equal.php#L13)
+- [greater](./../../src/Psl/Comparison/greater.php#L13)
+- [greater_or_equal](./../../src/Psl/Comparison/greater_or_equal.php#L13)
+- [less](./../../src/Psl/Comparison/less.php#L13)
+- [less_or_equal](./../../src/Psl/Comparison/less_or_equal.php#L13)
+- [not_equal](./../../src/Psl/Comparison/not_equal.php#L13)
+- [sort](./../../src/Psl/Comparison/sort.php#L17)
+
+#### `Interfaces`
+
+- [Comparable](./../../src/Psl/Comparison/Comparable.php#L12)
+- [Equable](./../../src/Psl/Comparison/Equable.php#L10)
+
+#### `Enums`
+
+- [Order](./../../src/Psl/Comparison/Order.php#L7)
+
+

--- a/docs/component/option.md
+++ b/docs/component/option.md
@@ -18,6 +18,6 @@
 
 #### `Classes`
 
-- [Option](./../../src/Psl/Option/Option.php#L12)
+- [Option](./../../src/Psl/Option/Option.php#L16)
 
 

--- a/docs/documenter.php
+++ b/docs/documenter.php
@@ -189,6 +189,7 @@ function get_all_components(): array
         'Psl\\Channel',
         'Psl\\Class',
         'Psl\\Collection',
+        'Psl\\Comparison',
         'Psl\\DataStructure',
         'Psl\\Dict',
         'Psl\\Encoding\\Base64',

--- a/src/Psl/Comparison/Comparable.php
+++ b/src/Psl/Comparison/Comparable.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Comparison;
+
+use Psl\Comparison\Exception\IncomparableException;
+
+/**
+ * @template T
+ */
+interface Comparable
+{
+    /**
+     * @param T $other
+     *
+     * @optionallyThrows IncomparableException - In case you want to bail out on specific comparisons.
+     */
+    public function compare(mixed $other): Order;
+}

--- a/src/Psl/Comparison/Equable.php
+++ b/src/Psl/Comparison/Equable.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Comparison;
+
+/**
+ * @template T
+ */
+interface Equable
+{
+    /**
+     * @param T $other
+     */
+    public function equals(mixed $other): bool;
+}

--- a/src/Psl/Comparison/Exception/IncomparableException.php
+++ b/src/Psl/Comparison/Exception/IncomparableException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Comparison\Exception;
+
+use InvalidArgumentException as InvalidArgumentRootException;
+use Psl\Exception\ExceptionInterface;
+use Psl\Str;
+
+use function get_debug_type;
+
+class IncomparableException extends InvalidArgumentRootException implements ExceptionInterface
+{
+    public static function fromValues(mixed $a, mixed $b, string $additionalInfo = ''): self
+    {
+        return new self(
+            Str\format(
+                'Unable to compare "%s" with "%s"%s',
+                get_debug_type($a),
+                get_debug_type($b),
+                $additionalInfo ? ': ' . $additionalInfo : '.',
+            )
+        );
+    }
+}

--- a/src/Psl/Comparison/Order.php
+++ b/src/Psl/Comparison/Order.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Comparison;
+
+enum Order : int
+{
+    case Less = -1;
+    case Equal = 0;
+    case Greater = 1;
+}

--- a/src/Psl/Comparison/compare.php
+++ b/src/Psl/Comparison/compare.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Comparison;
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ *
+ * This function can compare 2 values of a similar type.
+ * When the type happens to be mixed or never, it will fall back to PHP's internal comparison rules:
+ *
+ * @link https://www.php.net/manual/en/language.operators.comparison.php
+ * @link https://www.php.net/manual/en/types.comparisons.php
+ */
+function compare(mixed $a, mixed $b): Order
+{
+    if ($a instanceof Comparable) {
+        return $a->compare($b);
+    }
+
+    return Order::from($a <=> $b);
+}

--- a/src/Psl/Comparison/equal.php
+++ b/src/Psl/Comparison/equal.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Comparison;
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ */
+function equal(mixed $a, mixed $b): bool
+{
+    return compare($a, $b) === Order::Equal;
+}

--- a/src/Psl/Comparison/greater.php
+++ b/src/Psl/Comparison/greater.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Comparison;
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ */
+function greater(mixed $a, mixed $b): bool
+{
+    return compare($a, $b) === Order::Greater;
+}

--- a/src/Psl/Comparison/greater_or_equal.php
+++ b/src/Psl/Comparison/greater_or_equal.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Comparison;
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ */
+function greater_or_equal(mixed $a, mixed $b): bool
+{
+    $order = compare($a, $b);
+
+    return $order === Order::Equal || $order === Order::Greater;
+}

--- a/src/Psl/Comparison/less.php
+++ b/src/Psl/Comparison/less.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Comparison;
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ */
+function less(mixed $a, mixed $b): bool
+{
+    return compare($a, $b) === Order::Less;
+}

--- a/src/Psl/Comparison/less_or_equal.php
+++ b/src/Psl/Comparison/less_or_equal.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Comparison;
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ */
+function less_or_equal(mixed $a, mixed $b): bool
+{
+    $order = compare($a, $b);
+
+    return $order === Order::Equal || $order === Order::Less;
+}

--- a/src/Psl/Comparison/not_equal.php
+++ b/src/Psl/Comparison/not_equal.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Comparison;
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ */
+function not_equal(mixed $a, mixed $b): bool
+{
+    return compare($a, $b) !== Order::Equal;
+}

--- a/src/Psl/Comparison/sort.php
+++ b/src/Psl/Comparison/sort.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Comparison;
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ *
+ * This method can be used as a sorter callback function for Comparable items.
+ *
+ * Vec\sort($list, Comparable\sort(...))
+ */
+function sort($a, $b): int
+{
+    return compare($a, $b)->value;
+}

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -57,6 +57,14 @@ final class Loader
     ];
 
     public const FUNCTIONS = [
+        'Psl\\Comparison\\compare' => 'Psl/Comparison/compare.php',
+        'Psl\\Comparison\\equal' => 'Psl/Comparison/equal.php',
+        'Psl\\Comparison\\greater' => 'Psl/Comparison/greater.php',
+        'Psl\\Comparison\\greater_or_equal' => 'Psl/Comparison/greater_or_equal.php',
+        'Psl\\Comparison\\less' => 'Psl/Comparison/less.php',
+        'Psl\\Comparison\\less_or_equal' => 'Psl/Comparison/less_or_equal.php',
+        'Psl\\Comparison\\not_equal' => 'Psl/Comparison/not_equal.php',
+        'Psl\\Comparison\\sort' => 'Psl/Comparison/sort.php',
         'Psl\\Dict\\associate' => 'Psl/Dict/associate.php',
         'Psl\\Dict\\count_values' => 'Psl/Dict/count_values.php',
         'Psl\\Dict\\drop' => 'Psl/Dict/drop.php',
@@ -514,6 +522,8 @@ final class Loader
     ];
 
     public const INTERFACES = [
+        'Psl\\Comparison\\Comparable' => 'Psl/Comparison/Comparable.php',
+        'Psl\\Comparison\\Equable' => 'Psl/Comparison/Equable.php',
         'Psl\\DataStructure\\PriorityQueueInterface' => 'Psl/DataStructure/PriorityQueueInterface.php',
         'Psl\\DataStructure\\QueueInterface' => 'Psl/DataStructure/QueueInterface.php',
         'Psl\\DataStructure\\StackInterface' => 'Psl/DataStructure/StackInterface.php',
@@ -611,6 +621,7 @@ final class Loader
 
     public const CLASSES = [
         'Psl\\Ref' => 'Psl/Ref.php',
+        'Psl\\Comparison\\Exception\\IncomparableException' => 'Psl/Comparison/Exception/IncomparableException.php',
         'Psl\\DataStructure\\PriorityQueue' => 'Psl/DataStructure/PriorityQueue.php',
         'Psl\\DataStructure\\Queue' => 'Psl/DataStructure/Queue.php',
         'Psl\\DataStructure\\Stack' => 'Psl/DataStructure/Stack.php',
@@ -805,6 +816,7 @@ final class Loader
     ];
 
     public const ENUMS = [
+        'Psl\\Comparison\\Order' => 'Psl/Comparison/Order.php',
         'Psl\\Encoding\\Base64\\Variant' => 'Psl/Encoding/Base64/Variant.php',
         'Psl\\File\\LockType' => 'Psl/File/LockType.php',
         'Psl\\File\\WriteMode' => 'Psl/File/WriteMode.php',

--- a/src/Psl/Option/Option.php
+++ b/src/Psl/Option/Option.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace Psl\Option;
 
 use Closure;
+use Psl\Comparison;
 
 /**
  * @template T
+ *
+ * @implements Comparison\Comparable<Option<T>>
+ * @implements Comparison\Equable<Option<T>>
  */
-final class Option
+final class Option implements Comparison\Comparable, Comparison\Equable
 {
     /**
      * @param ?array{T} $option
@@ -278,5 +282,27 @@ final class Option
         }
 
         return some($default());
+    }
+
+    /**
+     * @param Option<T> $other
+     */
+    public function compare(mixed $other): Comparison\Order
+    {
+        $aIsNone = $this->isNone();
+        $bIsNone = $other->isNone();
+
+        return match (true) {
+            $aIsNone || $bIsNone => Comparison\compare($bIsNone, $aIsNone),
+            default => Comparison\compare($this->unwrap(), $other->unwrap())
+        };
+    }
+
+    /**
+     * @param Option<T> $other
+     */
+    public function equals(mixed $other): bool
+    {
+        return Comparison\equal($this, $other);
     }
 }

--- a/tests/static-analysis/Comparison/comparable.php
+++ b/tests/static-analysis/Comparison/comparable.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols
+ *
+ * @phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses
+ */
+
+declare(strict_types=1);
+
+namespace Psl\Tests\StaticAnalysis\Comparison;
+
+use Psl\Comparison;
+use Psl\Comparison\Comparable;
+use Psl\Comparison\Order;
+use stdClass;
+
+/**
+ * @implements Comparable<Size>
+ */
+abstract class Size implements Comparable
+{
+    abstract public function normalizedValue(): int;
+
+    public function compare(mixed $other): Order
+    {
+        return Comparison\compare($this->normalizedValue(), $other->normalizedValue());
+    }
+}
+
+class Inches extends Size
+{
+    public function normalizedValue(): int
+    {
+        return 1;
+    }
+}
+
+class Centimeters extends Size
+{
+    public function normalizedValue(): int
+    {
+        return 2;
+    }
+}
+
+
+function test_covariant_limitations(): Order
+{
+    $cm = new Centimeters();
+    $inch = new Inches();
+
+    return $cm->compare($inch);
+}
+
+function compare_mixed(mixed $a, mixed $b): Order
+{
+    return Comparison\compare($a, $b);
+}
+
+function test_mixed(): void
+{
+    compare_mixed('a', 1);
+    compare_mixed(new stdClass(), []);
+}

--- a/tests/unit/Comparison/AbstractComparisonTest.php
+++ b/tests/unit/Comparison/AbstractComparisonTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Comparison;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Psl\Comparison\Comparable;
+use Psl\Comparison\Exception\IncomparableException;
+use Psl\Comparison\Order;
+
+abstract class AbstractComparisonTest extends TestCase
+{
+    public static function provideComparisonCases(): Generator
+    {
+        yield 'scalar-equal' => [0, 0, Order::Equal];
+        yield 'scalar-less' => [0, 1, Order::Less];
+        yield 'scalar-greater' => [1, 0, Order::Greater];
+
+        yield 'comparable-equal' => [
+            self::createComparableIntWrapper(0),
+            self::createComparableIntWrapper(0),
+            Order::Equal
+        ];
+        yield 'comparable-less' => [
+            self::createComparableIntWrapper(0),
+            self::createComparableIntWrapper(1),
+            Order::Less
+        ];
+        yield 'comparable-greater' => [
+            self::createComparableIntWrapper(1),
+            self::createComparableIntWrapper(0),
+            Order::Greater
+        ];
+    }
+
+    protected static function createComparableIntWrapper(int $i): Comparable
+    {
+        return new class ($i) implements Comparable {
+            public function __construct(
+                public readonly int $int
+            ) {
+            }
+            public function compare(mixed $other): Order
+            {
+                return Order::from($this->int <=> $other->int);
+            }
+        };
+    }
+
+    protected static function createIncomparableWrapper(int $i, string $additionalInfo = ''): Comparable
+    {
+        return new class ($i, $additionalInfo) implements Comparable {
+            public function __construct(
+                public readonly int $int,
+                public readonly string $additionalInfo
+            ) {
+            }
+
+            public function compare(mixed $other): Order
+            {
+                throw IncomparableException::fromValues($this->int, $other->int, $this->additionalInfo);
+            }
+        };
+    }
+}

--- a/tests/unit/Comparison/CompareTest.php
+++ b/tests/unit/Comparison/CompareTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Comparison;
+
+use Psl\Comparison;
+use Psl\Comparison\Order;
+
+class CompareTest extends AbstractComparisonTest
+{
+    /**
+     * @dataProvider provideComparisonCases
+     */
+    public function testItCanCompare(mixed $a, mixed $b, Order $expected): void
+    {
+        static::assertSame($expected, Comparison\compare($a, $b));
+    }
+
+
+    public function testItCanFailComparing(): void
+    {
+        $a = self::createIncomparableWrapper(1);
+        $b = self::createIncomparableWrapper(2);
+
+        $this->expectException(Comparison\Exception\IncomparableException::class);
+        $this->expectExceptionMessage('Unable to compare "int" with "int".');
+
+        Comparison\compare($a, $b);
+    }
+
+
+    public function testItCanFailComparingWithAdditionalInfo(): void
+    {
+        $a = self::createIncomparableWrapper(1, 'Can only compare even numbers');
+        $b = self::createIncomparableWrapper(2);
+
+        $this->expectException(Comparison\Exception\IncomparableException::class);
+        $this->expectExceptionMessage('Unable to compare "int" with "int": Can only compare even numbers');
+
+        Comparison\compare($a, $b);
+    }
+}

--- a/tests/unit/Comparison/EqualTest.php
+++ b/tests/unit/Comparison/EqualTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Comparison;
+
+use Psl\Comparison;
+use Psl\Comparison\Order;
+
+class EqualTest extends AbstractComparisonTest
+{
+    /**
+     * @dataProvider provideComparisonCases
+     */
+    public function testItCanEqual(mixed $a, mixed $b, Order $expected): void
+    {
+        static::assertSame($expected === Order::Equal, Comparison\equal($a, $b));
+    }
+}

--- a/tests/unit/Comparison/GreaterOrEqualTest.php
+++ b/tests/unit/Comparison/GreaterOrEqualTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Comparison;
+
+use Psl\Comparison;
+use Psl\Comparison\Order;
+
+class GreaterOrEqualTest extends AbstractComparisonTest
+{
+    /**
+     * @dataProvider provideComparisonCases
+     */
+    public function testItCanCheckGreaterOrEqual(mixed $a, mixed $b, Order $expected): void
+    {
+        static::assertSame($expected === Order::Greater || $expected === Order::Equal, Comparison\greater_or_equal($a, $b));
+    }
+}

--- a/tests/unit/Comparison/GreaterTest.php
+++ b/tests/unit/Comparison/GreaterTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Comparison;
+
+use Psl\Comparison;
+use Psl\Comparison\Order;
+
+class GreaterTest extends AbstractComparisonTest
+{
+    /**
+     * @dataProvider provideComparisonCases
+     */
+    public function testItCanCheckGreater(mixed $a, mixed $b, Order $expected): void
+    {
+        static::assertSame($expected === Order::Greater, Comparison\greater($a, $b));
+    }
+}

--- a/tests/unit/Comparison/LessOrEqualTest.php
+++ b/tests/unit/Comparison/LessOrEqualTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Comparison;
+
+use Psl\Comparison;
+use Psl\Comparison\Order;
+
+class LessOrEqualTest extends AbstractComparisonTest
+{
+    /**
+     * @dataProvider provideComparisonCases
+     */
+    public function testItCanCheckLessOrEqual(mixed $a, mixed $b, Order $expected): void
+    {
+        static::assertSame($expected === Order::Less || $expected === Order::Equal, Comparison\less_or_equal($a, $b));
+    }
+}

--- a/tests/unit/Comparison/LessTest.php
+++ b/tests/unit/Comparison/LessTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Comparison;
+
+use Psl\Comparison;
+use Psl\Comparison\Order;
+
+class LessTest extends AbstractComparisonTest
+{
+    /**
+     * @dataProvider provideComparisonCases
+     */
+    public function testItCanCheckLess(mixed $a, mixed $b, Order $expected): void
+    {
+        static::assertSame($expected === Order::Less, Comparison\less($a, $b));
+    }
+}

--- a/tests/unit/Comparison/NotEqualTest.php
+++ b/tests/unit/Comparison/NotEqualTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Comparison;
+
+use Psl\Comparison;
+use Psl\Comparison\Order;
+
+class NotEqualTest extends AbstractComparisonTest
+{
+    /**
+     * @dataProvider provideComparisonCases
+     */
+    public function testItCanNotEqual(mixed $a, mixed $b, Order $expected): void
+    {
+        static::assertSame($expected !== Order::Equal, Comparison\not_equal($a, $b));
+    }
+}

--- a/tests/unit/Comparison/SortTest.php
+++ b/tests/unit/Comparison/SortTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Comparison;
+
+use Psl\Comparison;
+use Psl\Comparison\Order;
+
+class SortTest extends AbstractComparisonTest
+{
+    /**
+     * @dataProvider provideComparisonCases
+     */
+    public function testItCanSort(mixed $a, mixed $b, Order $expected): void
+    {
+        static::assertSame($expected->value, Comparison\sort($a, $b));
+    }
+}

--- a/tests/unit/Option/NoneTest.php
+++ b/tests/unit/Option/NoneTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Psl\Tests\Unit\Option;
 
 use PHPUnit\Framework\TestCase;
+use Psl\Comparison\Comparable;
+use Psl\Comparison\Equable;
+use Psl\Comparison\Order;
 use Psl\Option;
 use Psl\Option\Exception\NoneException;
 
@@ -107,5 +110,24 @@ final class NoneTest extends TestCase
         $option = Option\none();
 
         static::assertNull($option->andThen(static fn($i) => Option\some($i + 1))->unwrapOr(null));
+    }
+
+    public function testComparable(): void
+    {
+        $a = Option\none();
+
+        static::assertInstanceOf(Comparable::class, $a);
+        static::assertSame(Order::Equal, $a->compare(Option\none()));
+        static::assertSame(Order::Less, $a->compare(Option\some('some')));
+        static::assertSame(Order::Greater, Option\some('some')->compare($a));
+    }
+
+    public function testEquality(): void
+    {
+        $a = Option\none();
+
+        static::assertInstanceOf(Equable::class, $a);
+        static::assertTrue($a->equals(Option\none()));
+        static::assertFalse($a->equals(Option\some('other')));
     }
 }

--- a/tests/unit/Option/SomeTest.php
+++ b/tests/unit/Option/SomeTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Psl\Tests\Unit\Option;
 
 use PHPUnit\Framework\TestCase;
+use Psl\Comparison\Comparable;
+use Psl\Comparison\Equable;
+use Psl\Comparison\Order;
 use Psl\Option;
 
 final class SomeTest extends TestCase
@@ -104,5 +107,26 @@ final class SomeTest extends TestCase
         $option = Option\some(2);
 
         static::assertSame(3, $option->andThen(static fn($i) => Option\some($i + 1))->unwrapOr(null));
+    }
+
+    public function testComparable(): void
+    {
+        $a = Option\some(2);
+
+        static::assertInstanceOf(Comparable::class, $a);
+        static::assertSame(Order::Equal, $a->compare(Option\some(2)));
+        static::assertSame(Order::Less, Option\none()->compare(Option\some(1)));
+        static::assertSame(Order::Greater, $a->compare(Option\none()));
+        static::assertSame(Order::Less, $a->compare(Option\some(3)));
+    }
+
+    public function testEquality()
+    {
+        $a = Option\some('a');
+
+        static::assertInstanceOf(Equable::class, $a);
+        static::assertFalse($a->equals(Option\none()));
+        static::assertFalse($a->equals(Option\some('other')));
+        static::assertTrue($a->equals(Option\some('a')));
     }
 }


### PR DESCRIPTION
This PR introduces a comparison component:

* It provides sensible interfaces for adding a `compare` and `equal` function to your own classes:
   * `Comparable<T>`
   * `Equable<T>`
* It provide functions for comparing values of the same (base)type:
    *  `compare(T $a, T $b): Order`
    *  `equal(T $a, T $b): bool`
    *  `not_equal(T $a, T $b): bool`
    *  `less(T $a, T $b): bool`
    *  `less_or_equal(T $a, T $b): bool`
    *  `greater(T $a, T $b): bool`
    *  `greater_or_equal(T $a, T $b): bool`
    *  `sort(T $a, T $b): -1 | 0 | 1` (as shortcut for e.g. vec sorting)
* Comparison of objects that implement Comparable<T> is done based on the internal logic of that specific class. An implementation for the `Option` component was added.
* Comparison of other types is being done based on PHPs `<=>` comparison operator
* In case you want to make 2 types incomparable, a user can trhow a `IncomparableException`
* It's fully typesafe until you end up with `mixed`. (At that moment, PHPs default compare system kicks in. A user could opt-in on throwing an exception manually in the class that implements Comparable)


<details>
  <summary>Some examples</summary>


**OPTION**

```php
/**
 * @template T
 *
 * @implements Comparison\Comparable<Option<T>>
 * @implements Comparison\Equable<Option<T>>
 */
final class Option implements Comparison\Comparable, Comparison\Equable
{
    /**
     * @param Option<T> $other
     */
    public function compare(mixed $other): Comparison\Order
    {
        $aIsNone = $this->isNone();
        $bIsNone = $other->isNone();

        return match (true) {
            $aIsNone || $bIsNone => Comparison\compare($bIsNone, $aIsNone),
            default => Comparison\compare($this->unwrap(), $other->unwrap())
        };
    }

    /**
     * @param Option<T> $other
     */
    public function equal(mixed $other): bool
    {
        return Comparison\equal($this, $other);
    }
}

```


**COVARIANCE**

```php
/**
 * @implements Comparable<Size>
 */
abstract class Size implements Comparable
{
    abstract public function normalizedValue(): int;

    public function compare(mixed $other): Order
    {
        return Comparison\compare($this->normalizedValue(), $other->normalizedValue());
    }
}

class Inches extends Size
{
    public function normalizedValue(): int
    {
        return 1;
    }
}

class Centimeters extends Size
{
    public function normalizedValue(): int
    {
        return 2;
    }
}


function test_covariant_limitations(): Order
{
    $cm = new Centimeters();
    $inch = new Inches();

    return $cm->compare($inch);
}
```

**MIXED**

I've tried throwing a lot of different types at the `<=>` operator and wasn't able to make PHP throw exceptions.
Therefore,  any non `Comparable` object falls back to [PHPs internal sorting system](https://www.php.net/manual/en/language.operators.comparison.php).

As long as I cannot find incomparable values, I won't enforce having to deal with `IncomparableException` from the API.

```php
function test_mixed_limitations(mixed $a, mixed $b): Order
{
    return Comparison\compare($a, $b);
}
```
</details>

(The mutation test issues are solved in #427)