### PR TITLE
Improve error messages for shape and vec -like types

### DIFF
--- a/src/Psl/Type/Exception/CoercionException.php
+++ b/src/Psl/Type/Exception/CoercionException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\Type\Exception;
 
+use Psl\Iter;
 use Psl\Str;
 use Throwable;
 
@@ -40,7 +41,15 @@ final class CoercionException extends Exception
         string $target,
         TypeTrace $typeTrace
     ): self {
-        return new self(get_debug_type($value), $target, $typeTrace);
+        return new self(
+            get_debug_type($value),
+            $target,
+            $typeTrace,
+            Iter\is_empty($typeTrace->getPath()) ? "" : Str\Format(
+                'at path %s',
+                Str\join($typeTrace->getPath(), '.')
+            )
+        );
     }
 
     public static function withConversionFailureOnValue(

--- a/src/Psl/Type/Exception/TypeTrace.php
+++ b/src/Psl/Type/Exception/TypeTrace.php
@@ -14,10 +14,24 @@ final class TypeTrace
      */
     private array $frames = [];
 
+    /**
+     * @var list<string> $path
+     */
+    private array $path = [];
+
     public function withFrame(string $frame): self
     {
         $self           = clone $this;
         $self->frames[] = $frame;
+
+        return $self;
+    }
+
+    public function withFrameAtPath(string $frame, string $path): self
+    {
+        $self           = clone $this;
+        $self->frames[] = $frame;
+        $self->path[] = $path;
 
         return $self;
     }
@@ -30,5 +44,15 @@ final class TypeTrace
     public function getFrames(): array
     {
         return $this->frames;
+    }
+
+    /**
+     * @return list<string>
+     *
+     * @psalm-mutation-free
+     */
+    public function getPath(): array
+    {
+        return $this->path;
     }
 }

--- a/src/Psl/Type/Internal/DictType.php
+++ b/src/Psl/Type/Internal/DictType.php
@@ -44,8 +44,6 @@ final class DictType extends Type\Type
 
         $trace = $this->getTrace();
         $key_type = $this->key_type->withTrace($trace->withFrame('dict<' . $this->key_type->toString() . ', _>'));
-        $value_type = $this->value_type->withTrace($trace->withFrame('dict<_, ' . $this->value_type->toString() . '>'));
-
         $result = [];
 
         /**
@@ -53,6 +51,12 @@ final class DictType extends Type\Type
          * @var Tv $v
          */
         foreach ($value as $k => $v) {
+            $value_type = $this->value_type->withTrace(
+                $trace->withFrameAtPath(
+                    'dict<_, ' . $this->value_type->toString() . '>',
+                    (string) $k
+                )
+            );
             $result[$key_type->coerce($k)] = $value_type->coerce($v);
         }
 

--- a/src/Psl/Type/Internal/ShapeType.php
+++ b/src/Psl/Type/Internal/ShapeType.php
@@ -223,7 +223,7 @@ final class ShapeType extends Type\Type
     private function getTypeAndTraceForElement(string|int $element, Type\TypeInterface $type): array
     {
         $element_name = $this->getElementName($element);
-        $trace = $this->getTrace()->withFrame('array{' . $element_name . ': _}');
+        $trace = $this->getTrace()->withFrameAtPath('array{' . $element_name . ': _}', (string) $element);
 
         return [
             $trace,

--- a/src/Psl/Type/Internal/VecType.php
+++ b/src/Psl/Type/Internal/VecType.php
@@ -58,19 +58,21 @@ final class VecType extends Type\Type
             throw CoercionException::withValue($value, $this->toString(), $this->getTrace());
         }
 
-        /** @var Type\Type<Tv> $value_type */
-        $value_type = $this->value_type->withTrace(
-            $this->getTrace()
-                ->withFrame($this->toString())
-        );
-
         /**
          * @var list<Tv> $entries
          */
         $result = [];
 
-        /** @var Tv $v */
-        foreach ($value as $v) {
+        /**
+         * @var array-key $i
+         * @var Tv $v
+         */
+        foreach ($value as $i => $v) {
+            /** @var Type\Type<Tv> $value_type */
+            $value_type = $this->value_type->withTrace(
+                $this->getTrace()
+                    ->withFrameAtPath($this->toString(), (string) $i)
+            );
             $result[] = $value_type->coerce($v);
         }
 

--- a/tests/unit/Type/Exception/TypeCoercionExceptionTest.php
+++ b/tests/unit/Type/Exception/TypeCoercionExceptionTest.php
@@ -94,4 +94,29 @@ final class TypeCoercionExceptionTest extends TestCase
             static::assertCount(0, $frames);
         }
     }
+
+    public function testCoercionPath(): void
+    {
+        $type = Type\shape([
+            'articles' => Type\vec(Type\shape([
+                'name' => Type\string(),
+            ]))
+        ]);
+
+        try {
+            $type->coerce(['articles' => [['name' => null]]]);
+
+            static::fail(Str\format(
+                'Expected "%s" exception to be thrown.',
+                Type\Exception\CoercionException::class
+            ));
+        } catch (Type\Exception\CoercionException $e) {
+            static::assertSame(
+                'Could not coerce "null" to type "string": at path articles.0.name',
+                $e->getMessage()
+            );
+
+            static::assertCount(3, $e->getTypeTrace()->getPath());
+        }
+    }
 }


### PR DESCRIPTION
Given:
```php
use Psl\Type;
$shape = Type\shape([
    'name' => Type\string(),
    'articles' => Type\vec(Type\shape([
        'title' => Type\string(),
        'content' => Type\string(),
        'likes' => Type\int(),
        'comments' => Type\optional(Type\vec(Type\shape([
            'user' => Type\string(),
            'comment' => Type\string()
        ]))),
    ])),
    'dictionary' => Type\dict(Type\string(), Type\vec(Type\shape([
        'title' => Type\string(),
        'content' => Type\string(),
    ]))),
    'pagination' => Type\Shape([
        'currentPage' => Type\uint(),
        'totalPages' => Type\uint(),
        'perPage' => Type\uint(),
        'totalRows' => Type\uint(),
    ])
]);

try {
    $shape->coerce([
        'name' => 'ok',
        'articles' => [
            [
                'title' => 'ok',
                'content' => 'ok',
                'likes' => 1,
                'comments' => [
                    [
                        'user' => 'ok',
                        'comment' => 'ok'
                    ],
                    [
                        'user' => 'ok',
                        'comment' =>'ok',
                    ]
                ]
            ]
        ],
       'dictionary' => [
           'key' => [
               [
                   'title' => 'ok',
                   'content' => 'ok',
               ]
           ]
       ]
    ]);
} catch (Type\Exception\CoercionException $e) {
    echo $e->getMessage().PHP_EOL;
}
``` 
Results in:
```php
Could not coerce "array" to type "array{'name': string, 'articles': vec<array{'title': string, 'content': string, 'likes': int, 'comments'?: vec<array{'user': string, 'comment': string}>}>, 'dictionary': dict<string, vec<array{'title': string, 'content': string}>>, 'pagination': array{'currentPage': uint, 'totalPages': uint, 'perPage': uint, 'totalRows': uint}}": at path pagination
``` 

The changed I made do have quite an impact on performance, but tried to keep it at a minimum. Mainly vecs and dicts are suffering. Not sure what the accepted range is.
![image](https://github.com/azjezz/psl/assets/33426821/cac4d5f6-29c6-4ef3-a85a-23c068b274c9)

![image](https://github.com/azjezz/psl/assets/33426821/a34c1058-d6f4-4dde-b5a2-60bb7cf851ca)

The impact on shapes are minimal:
![image](https://github.com/azjezz/psl/assets/33426821/4d68372d-09af-4ed6-a646-6e99817a827a)


(See #412)