### PR TITLE
feat(option): add `Option::proceed()` method

### DIFF
--- a/src/Psl/Option/Option.php
+++ b/src/Psl/Option/Option.php
@@ -205,6 +205,30 @@ final class Option implements Comparison\Comparable, Comparison\Equable
     }
 
     /**
+     * Matches the contained option value with the provided closures and returns the result.
+     *
+     * @template TNone
+     * @template TSome
+     *
+     * @param (Closure(): TNone) $none A closure to be called when the option is none.
+     *                                 The closure must not accept any arguments and can return a value.
+     *                                 Example: `fn() => 'Default value'`
+     * @param (Closure(T): TSome) $some A closure to be called when the option is some.
+     *                                  The closure must accept the option value as its only argument and can return a value.
+     *                                  Example: `fn($value) => $value + 10`
+     *
+     * @return TNone|TSome The result of calling the appropriate closure.
+     */
+    public function match(Closure $none, Closure $some): mixed
+    {
+        if ($this->option !== null) {
+            return $some($this->option[0]);
+        }
+
+        return $none();
+    }
+
+    /**
      * Maps an `Option<T>` to `Option<Tu>` by applying a function to a contained value.
      *
      * @template Tu

--- a/src/Psl/Option/Option.php
+++ b/src/Psl/Option/Option.php
@@ -207,19 +207,18 @@ final class Option implements Comparison\Comparable, Comparison\Equable
     /**
      * Matches the contained option value with the provided closures and returns the result.
      *
-     * @template TNone
-     * @template TSome
+     * @template Ts
      *
-     * @param (Closure(): TNone) $none A closure to be called when the option is none.
-     *                                 The closure must not accept any arguments and can return a value.
-     *                                 Example: `fn() => 'Default value'`
-     * @param (Closure(T): TSome) $some A closure to be called when the option is some.
-     *                                  The closure must accept the option value as its only argument and can return a value.
-     *                                  Example: `fn($value) => $value + 10`
+     * @param (Closure(T): Ts) $some A closure to be called when the option is some.
+     *                               The closure must accept the option value as its only argument and can return a value.
+     *                               Example: `fn($value) => $value + 10`
+     * @param (Closure(): Ts) $none A closure to be called when the option is none.
+     *                              The closure must not accept any arguments and can return a value.
+     *                              Example: `fn() => 'Default value'`
      *
-     * @return TNone|TSome The result of calling the appropriate closure.
+     * @return Ts The result of calling the appropriate closure.
      */
-    public function match(Closure $none, Closure $some): mixed
+    public function proceed(Closure $some, Closure $none): mixed
     {
         if ($this->option !== null) {
             return $some($this->option[0]);

--- a/tests/static-analysis/Option/proceed.php
+++ b/tests/static-analysis/Option/proceed.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Psl\Option;
+
+function proceed(): void
+{
+    /**
+     * @param Option\Option<int> $option
+     *
+     * @return non-empty-string
+     */
+    function test_proceed(Option\Option $option): string
+    {
+        return $option->proceed(
+            static fn (int $value) => "There is $value of them.",
+            static fn () => 'There are none.',
+        );
+    }
+}

--- a/tests/unit/Option/NoneTest.php
+++ b/tests/unit/Option/NoneTest.php
@@ -10,6 +10,7 @@ use Psl\Comparison\Equable;
 use Psl\Comparison\Order;
 use Psl\Option;
 use Psl\Option\Exception\NoneException;
+use Psl\Str;
 
 final class NoneTest extends TestCase
 {
@@ -86,22 +87,12 @@ final class NoneTest extends TestCase
 
     public function testProceed(): void
     {
-        $checked_divisor = static function (int $dividend, int $divisor): Option\Option {
-            if ($divisor === 0) {
-                return Option\none();
-            }
+        $result = Option\none()->proceed(
+            static fn ($i) => Str\format('Value is %d', $i),
+            static fn () => 'There is no value',
+        );
 
-            return Option\some($dividend / $divisor);
-        };
-
-        $try_division = static function (int $dividend, int $divisor) use ($checked_divisor): string {
-            return $checked_divisor($dividend, $divisor)->proceed(
-                some: static fn ($value) => sprintf('%s / %s = %s', $dividend, $divisor, $value),
-                none: static fn() => sprintf('%s / %s failed!', $dividend, $divisor),
-            );
-        };
-
-        static::assertSame('2 / 0 failed!', $try_division(2, 0));
+        static::assertSame('There is no value', $result);
     }
 
     public function testMap(): void

--- a/tests/unit/Option/NoneTest.php
+++ b/tests/unit/Option/NoneTest.php
@@ -84,7 +84,7 @@ final class NoneTest extends TestCase
         static::assertFalse($option->contains(4));
     }
 
-    public function testMatch(): void
+    public function testProceed(): void
     {
         $checked_divisor = static function (int $dividend, int $divisor): Option\Option {
             if ($divisor === 0) {
@@ -95,9 +95,9 @@ final class NoneTest extends TestCase
         };
 
         $try_division = static function (int $dividend, int $divisor) use ($checked_divisor): string {
-            return $checked_divisor($dividend, $divisor)->match(
-                none: static fn () => sprintf('%s / %s failed!', $dividend, $divisor),
+            return $checked_divisor($dividend, $divisor)->proceed(
                 some: static fn ($value) => sprintf('%s / %s = %s', $dividend, $divisor, $value),
+                none: static fn() => sprintf('%s / %s failed!', $dividend, $divisor),
             );
         };
 

--- a/tests/unit/Option/NoneTest.php
+++ b/tests/unit/Option/NoneTest.php
@@ -84,6 +84,26 @@ final class NoneTest extends TestCase
         static::assertFalse($option->contains(4));
     }
 
+    public function testMatch(): void
+    {
+        $checked_divisor = static function (int $dividend, int $divisor): Option\Option {
+            if ($divisor === 0) {
+                return Option\none();
+            }
+
+            return Option\some($dividend / $divisor);
+        };
+
+        $try_division = static function (int $dividend, int $divisor) use ($checked_divisor): string {
+            return $checked_divisor($dividend, $divisor)->match(
+                none: static fn () => sprintf('%s / %s failed!', $dividend, $divisor),
+                some: static fn ($value) => sprintf('%s / %s = %s', $dividend, $divisor, $value),
+            );
+        };
+
+        static::assertSame('2 / 0 failed!', $try_division(2, 0));
+    }
+
     public function testMap(): void
     {
         $option = Option\none();

--- a/tests/unit/Option/SomeTest.php
+++ b/tests/unit/Option/SomeTest.php
@@ -9,6 +9,7 @@ use Psl\Comparison\Comparable;
 use Psl\Comparison\Equable;
 use Psl\Comparison\Order;
 use Psl\Option;
+use Psl\Str;
 use Psl\Tests\Fixture;
 use Psl\Type;
 
@@ -85,22 +86,12 @@ final class SomeTest extends TestCase
 
     public function testProceed(): void
     {
-        $checked_divisor = static function (int $dividend, int $divisor): Option\Option {
-            if ($divisor === 0) {
-                return Option\none();
-            }
+        $result = Option\some(1)->proceed(
+            static fn ($i) => Str\format('Value is %d', $i),
+            static fn () => 'There is no value',
+        );
 
-            return Option\some($dividend / $divisor);
-        };
-
-        $try_division = static function (int $dividend, int $divisor) use ($checked_divisor): string {
-            return $checked_divisor($dividend, $divisor)->proceed(
-                some: static fn ($value) => sprintf('%s / %s = %s', $dividend, $divisor, $value),
-                none: static fn () => sprintf('%s / %s failed!', $dividend, $divisor),
-            );
-        };
-
-        static::assertSame('10 / 2 = 5', $try_division(10, 2));
+        static::assertSame('Value is 1', $result);
     }
 
     public function testMap(): void

--- a/tests/unit/Option/SomeTest.php
+++ b/tests/unit/Option/SomeTest.php
@@ -83,7 +83,7 @@ final class SomeTest extends TestCase
         static::assertTrue($option->contains(2));
     }
 
-    public function testMatch(): void
+    public function testProceed(): void
     {
         $checked_divisor = static function (int $dividend, int $divisor): Option\Option {
             if ($divisor === 0) {
@@ -94,9 +94,9 @@ final class SomeTest extends TestCase
         };
 
         $try_division = static function (int $dividend, int $divisor) use ($checked_divisor): string {
-            return $checked_divisor($dividend, $divisor)->match(
-                none: static fn () => sprintf('%s / %s failed!', $dividend, $divisor),
+            return $checked_divisor($dividend, $divisor)->proceed(
                 some: static fn ($value) => sprintf('%s / %s = %s', $dividend, $divisor, $value),
+                none: static fn () => sprintf('%s / %s failed!', $dividend, $divisor),
             );
         };
 

--- a/tests/unit/Option/SomeTest.php
+++ b/tests/unit/Option/SomeTest.php
@@ -83,6 +83,26 @@ final class SomeTest extends TestCase
         static::assertTrue($option->contains(2));
     }
 
+    public function testMatch(): void
+    {
+        $checked_divisor = static function (int $dividend, int $divisor): Option\Option {
+            if ($divisor === 0) {
+                return Option\none();
+            }
+
+            return Option\some($dividend / $divisor);
+        };
+
+        $try_division = static function (int $dividend, int $divisor) use ($checked_divisor): string {
+            return $checked_divisor($dividend, $divisor)->match(
+                none: static fn () => sprintf('%s / %s failed!', $dividend, $divisor),
+                some: static fn ($value) => sprintf('%s / %s = %s', $dividend, $divisor, $value),
+            );
+        };
+
+        static::assertSame('10 / 2 = 5', $try_division(10, 2));
+    }
+
     public function testMap(): void
     {
         $option = Option\some(2);


### PR DESCRIPTION
This is another idea of implementing a `match` method that I had after learning more bits of Rust: https://doc.rust-lang.org/rust-by-example/std/option.html

WDYT?