### PR TITLE
feat(option): add `Option::zip()`, `Option::zipWith()` and `Option::unzip()` methods

### DIFF
--- a/docs/component/option.md
+++ b/docs/component/option.md
@@ -18,6 +18,6 @@
 
 #### `Classes`
 
-- [Option](./../../src/Psl/Option/Option.php#L16)
+- [Option](./../../src/Psl/Option/Option.php#L17)
 
 

--- a/src/Psl/Option/Option.php
+++ b/src/Psl/Option/Option.php
@@ -311,7 +311,7 @@ final class Option implements Comparison\Comparable, Comparison\Equable
      * Combines two `Option` values into a single `Option` containing a tuple of the two inner values.
      * If either of the `Option`s is `None`, the resulting `Option` will also be `None`.
      *
-     * @note: If an element is `None`, the corresponding element in the resulting tuple will be `None`.
+     * @note: If an element is `None`, both elements in the resulting tuple will be `None`.
      *
      * @template Tu
      *

--- a/src/Psl/Option/Option.php
+++ b/src/Psl/Option/Option.php
@@ -315,11 +315,7 @@ final class Option implements Comparison\Comparable, Comparison\Equable
      *
      * @param Option<Tu> $other The other `Option` to zip with.
      *
-     * @return (
-     *     T is never
-     *     ? Option<never>
-     *     : (Tu is never ? Option<never> : Option<array{T, Tu}>)
-     * )
+     * @return Option<array{T, Tu}> The resulting `Option` containing the combined tuple or `None`.
      */
     public function zip(Option $other): Option
     {

--- a/src/Psl/Option/Option.php
+++ b/src/Psl/Option/Option.php
@@ -311,8 +311,6 @@ final class Option implements Comparison\Comparable, Comparison\Equable
      * Combines two `Option` values into a single `Option` containing a tuple of the two inner values.
      * If either of the `Option`s is `None`, the resulting `Option` will also be `None`.
      *
-     * @note: If an element is `None`, both elements in the resulting tuple will be `None`.
-     *
      * @template Tu
      *
      * @param Option<Tu> $other The other `Option` to zip with.

--- a/tests/fixture/Point.php
+++ b/tests/fixture/Point.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Fixture;
+
+final class Point
+{
+    public function __construct(
+        public readonly float $x,
+        public readonly float $y,
+    ) {
+    }
+}

--- a/tests/fixture/Point.php
+++ b/tests/fixture/Point.php
@@ -7,8 +7,8 @@ namespace Psl\Tests\Fixture;
 final class Point
 {
     public function __construct(
-        public readonly float $x,
-        public readonly float $y,
+        public readonly int $x,
+        public readonly int $y,
     ) {
     }
 }

--- a/tests/static-analysis/Option/zip.php
+++ b/tests/static-analysis/Option/zip.php
@@ -6,7 +6,7 @@ use Psl\Option;
 use Psl\Type;
 
 /**
- * @return Option\Option<never>
+ * @return Option\Option<array{never, int}>
  */
 function test_partial_none_tuple_1(): Option\Option
 {
@@ -14,7 +14,7 @@ function test_partial_none_tuple_1(): Option\Option
 }
 
 /**
- * @return Option\Option<never>
+ * @return Option\Option<array{int, never}>
  */
 function test_partial_none_tuple_2(): Option\Option
 {
@@ -24,7 +24,7 @@ function test_partial_none_tuple_2(): Option\Option
 /**
  * @throws Type\Exception\AssertException
  *
- * @return array{Option\Option<never>, Option\Option<never>}
+ * @return array{Option\Option<never>, Option\Option<int>}
  */
 function test_partial_none_unzip_1(): array
 {
@@ -42,7 +42,7 @@ function test_some_zip(): Option\Option
 /**
  * @throws Type\Exception\AssertException
  *
- * @return array{Option\Option<never>, Option\Option<never>}
+ * @return array{Option\Option<int>, Option\Option<never>}
  */
 function test_partial_none_unzip_2(): array
 {

--- a/tests/static-analysis/Option/zip.php
+++ b/tests/static-analysis/Option/zip.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Psl\Option;
+use Psl\Type;
+
+/**
+ * @return Option\Option<never>
+ */
+function test_partial_none_tuple_1(): Option\Option
+{
+    return Option\none()->zip(Option\some(1));
+}
+
+/**
+ * @return Option\Option<never>
+ */
+function test_partial_none_tuple_2(): Option\Option
+{
+    return Option\some(1)->zip(Option\none());
+}
+
+/**
+ * @throws Type\Exception\AssertException
+ *
+ * @return array{Option\Option<never>, Option\Option<never>}
+ */
+function test_partial_none_unzip_1(): array
+{
+    return test_partial_none_tuple_1()->unzip();
+}
+
+/**
+ * @return Option\Option<array{int, string}>
+ */
+function test_some_zip(): Option\Option
+{
+    return Option\some(1)->zip(Option\some('2'));
+}
+
+/**
+ * @throws Type\Exception\AssertException
+ *
+ * @return array{Option\Option<never>, Option\Option<never>}
+ */
+function test_partial_none_unzip_2(): array
+{
+    return test_partial_none_tuple_2()->unzip();
+}
+
+/**
+ * @throws Type\Exception\AssertException
+ *
+ * @return array{Option\Option<int>, Option\Option<string>}
+ */
+function test_some_unzip(): array
+{
+    return test_some_zip()->unzip();
+}
+
+/**
+ * @return Option\Option<int>
+ */
+function test_some_zip_with()
+{
+    return Option\some(1)->zipWith(Option\some('2'), static fn($a, $b) => $a + (int) $b);
+}
+
+/**
+ * @return Option\Option<string>
+ */
+function test_some_zip_with_2()
+{
+    return Option\some(1)->zipWith(Option\some('2'), static fn($a, $b) => $b);
+}

--- a/tests/unit/Option/NoneTest.php
+++ b/tests/unit/Option/NoneTest.php
@@ -130,4 +130,44 @@ final class NoneTest extends TestCase
         static::assertTrue($a->equals(Option\none()));
         static::assertFalse($a->equals(Option\some('other')));
     }
+
+    public function testZip(): void
+    {
+        $x = Option\some(1);
+        $y = Option\none();
+
+        static::assertTrue($x->zip($y)->isNone());
+        static::assertTrue($y->zip($x)->isNone());
+    }
+
+    public function testZipWith(): void
+    {
+        $x = Option\some(1);
+        $y = Option\none();
+
+        static::assertTrue($x->zipWith($y, static fn($a, $b) => $a + $b)->isNone());
+        static::assertTrue($y->zipWith($x, static fn($a, $b) => $a + $b)->isNone());
+    }
+
+    /**
+     * @dataProvider provideTestUnzip
+     */
+    public function testUnzip(Option\Option $option): void
+    {
+        [$x, $y] = $option->unzip();
+
+        static::assertTrue($x->isNone());
+        static::assertTrue($y->isNone());
+    }
+
+    private function provideTestUnzip(): iterable
+    {
+        yield [Option\none()];
+        yield [Option\some(1)];
+        yield [Option\some([])];
+        yield [Option\some(['foo'])];
+        yield [Option\none()->zip(Option\none())];
+        yield [Option\none()->zip(Option\some(1))];
+        yield [Option\some(1)->zip(Option\none())];
+    }
 }

--- a/tests/unit/Option/NoneTest.php
+++ b/tests/unit/Option/NoneTest.php
@@ -163,9 +163,6 @@ final class NoneTest extends TestCase
     private function provideTestUnzip(): iterable
     {
         yield [Option\none()];
-        yield [Option\some(1)];
-        yield [Option\some([])];
-        yield [Option\some(['foo'])];
         yield [Option\none()->zip(Option\none())];
         yield [Option\none()->zip(Option\some(1))];
         yield [Option\some(1)->zip(Option\none())];

--- a/tests/unit/Option/SomeTest.php
+++ b/tests/unit/Option/SomeTest.php
@@ -10,6 +10,7 @@ use Psl\Comparison\Equable;
 use Psl\Comparison\Order;
 use Psl\Option;
 use Psl\Tests\Fixture;
+use Psl\Type;
 
 final class SomeTest extends TestCase
 {
@@ -142,12 +143,12 @@ final class SomeTest extends TestCase
 
     public function testZipWith(): void
     {
-        $x = Option\some(17.5);
-        $y = Option\some(42.7);
+        $x = Option\some(17);
+        $y = Option\some(42);
 
         $point = $x->zipWith($y, static fn($a, $b) => new Fixture\Point($a, $b));
 
-        static::assertTrue(Option\some(new Fixture\Point(17.5, 42.7))->equals($point));
+        static::assertTrue(Option\some(new Fixture\Point(17, 42))->equals($point));
     }
 
     /**
@@ -166,5 +167,21 @@ final class SomeTest extends TestCase
         yield [Option\some(null)->zip(Option\some('hi')), null, 'hi'];
         yield [Option\some(1)->zip(Option\some('hi')), 1, 'hi'];
         yield [Option\some([true, false]), true, false];
+    }
+
+    /**
+     * @dataProvider provideTestUnzipAssertionException
+     */
+    public function testUnzipAssertionException(Option\Option $option): void
+    {
+        static::expectException(Type\Exception\AssertException::class);
+        $option->unzip();
+    }
+
+    private function provideTestUnzipAssertionException(): iterable
+    {
+        yield [Option\some(null)];
+        yield [Option\some(1)];
+        yield [Option\some([true])];
     }
 }

--- a/tests/unit/Option/SomeTest.php
+++ b/tests/unit/Option/SomeTest.php
@@ -9,6 +9,7 @@ use Psl\Comparison\Comparable;
 use Psl\Comparison\Equable;
 use Psl\Comparison\Order;
 use Psl\Option;
+use Psl\Tests\Fixture;
 
 final class SomeTest extends TestCase
 {
@@ -128,5 +129,42 @@ final class SomeTest extends TestCase
         static::assertFalse($a->equals(Option\none()));
         static::assertFalse($a->equals(Option\some('other')));
         static::assertTrue($a->equals(Option\some('a')));
+    }
+
+    public function testZip(): void
+    {
+        $x = Option\some(1);
+        $y = Option\some("hi");
+
+        static::assertTrue(Option\some([1, 'hi'])->equals($x->zip($y)));
+        static::assertTrue(Option\some(['hi', 1])->equals($y->zip($x)));
+    }
+
+    public function testZipWith(): void
+    {
+        $x = Option\some(17.5);
+        $y = Option\some(42.7);
+
+        $point = $x->zipWith($y, static fn($a, $b) => new Fixture\Point($a, $b));
+
+        static::assertTrue(Option\some(new Fixture\Point(17.5, 42.7))->equals($point));
+    }
+
+    /**
+     * @dataProvider provideTestUnzip
+     */
+    public function testUnzip(Option\Option $option, mixed $expectedX, mixed $expectedY): void
+    {
+        [$x, $y] = $option->unzip();
+
+        static::assertSame($expectedX, $x->unwrap());
+        static::assertSame($expectedY, $y->unwrap());
+    }
+
+    private function provideTestUnzip(): iterable
+    {
+        yield [Option\some(null)->zip(Option\some('hi')), null, 'hi'];
+        yield [Option\some(1)->zip(Option\some('hi')), 1, 'hi'];
+        yield [Option\some([true, false]), true, false];
     }
 }


### PR DESCRIPTION
Typing `unzip` generics has been a huge PITA. I've been able to make them work in Psalm, but not for PHPStan: https://github.com/phpstan/phpstan/discussions/10285

Eager to get feedback 😄 