### PR TITLE
Added support for coercing `stdClass` to `array<TKey, TValue>`

### DIFF
--- a/src/Psl/Type/Internal/ShapeType.php
+++ b/src/Psl/Type/Internal/ShapeType.php
@@ -8,6 +8,7 @@ use Psl\Iter;
 use Psl\Type;
 use Psl\Type\Exception\AssertException;
 use Psl\Type\Exception\CoercionException;
+use stdClass;
 
 use function array_diff_key;
 use function array_filter;
@@ -51,6 +52,10 @@ final class ShapeType extends Type\Type
      */
     public function coerce(mixed $value): array
     {
+        if ($value instanceof stdClass) {
+            $value = (array) $value;
+        }
+
         // To whom reads this: yes, I hate this stuff as passionately as you do :-)
         if (! is_array($value)) {
             // Fallback to slow implementation - unhappy path

--- a/tests/unit/Type/ShapeTypeTest.php
+++ b/tests/unit/Type/ShapeTypeTest.php
@@ -120,6 +120,17 @@ final class ShapeTypeTest extends TypeTest
             ]],
         ];
 
+        yield 'stdClass containing a valid shape' => [
+            (object) ['name' => 'saif', 'articles' => new Collection\Vector([
+                ['title' => 'Foo', 'content' => 'Bar', 'likes' => 0, 'dislikes' => 5],
+                ['title' => 'Baz', 'content' => 'Qux', 'likes' => 13, 'dislikes' => 3],
+            ])],
+            ['name' => 'saif', 'articles' => [
+                ['title' => 'Foo', 'content' => 'Bar', 'likes' => 0],
+                ['title' => 'Baz', 'content' => 'Qux', 'likes' => 13],
+            ]],
+        ];
+
         yield [
             ['name' => 'saif', 'articles' => new Collection\Vector([
                 ['title' => 'Foo', 'content' => 'Bar', 'likes' => 0, 'dislikes' => 5],
@@ -148,6 +159,9 @@ final class ShapeTypeTest extends TypeTest
             ['title' => 'biz'] // missing 'content' and 'likes'
         ]]];
         yield [['name' => 'saif', 'articles' => [
+            ['title' => 'biz', 'content' => 'foo', 'upvotes' => 4] // 'likes' replaced by 'upvotes'
+        ]]];
+        yield [(object) ['name' => 'saif', 'articles' => [
             ['title' => 'biz', 'content' => 'foo', 'upvotes' => 4] // 'likes' replaced by 'upvotes'
         ]]];
     }


### PR DESCRIPTION
Fixes #436

This change is useful when decoding JSON hashmaps into PHP hashmaps, since PHP keeps JSON-decoded data as an `stdClass` unless explicitly told to do so.

Also note that preserving JSON structures as `stdClass` is sometimes very much required, since an empty hashmap is a lossy conversion to `[]` performed by `json_decode()`, when using `associative: true`. This patch makes preserving JSON data structures a bit easier.

This adds some very minimal overhead to `ShapeType#coerce()`, which should be imperceptible.