### PR TITLE
`json_encode` never returns an empty string

### DIFF
--- a/docs/component/json.md
+++ b/docs/component/json.md
@@ -13,7 +13,7 @@
 #### `Functions`
 
 - [decode](./../../src/Psl/Json/decode.php#L22)
-- [encode](./../../src/Psl/Json/encode.php#L25)
+- [encode](./../../src/Psl/Json/encode.php#L27)
 - [typed](./../../src/Psl/Json/typed.php#L20)
 
 

--- a/src/Psl/Json/encode.php
+++ b/src/Psl/Json/encode.php
@@ -21,6 +21,8 @@ use const JSON_UNESCAPED_UNICODE;
  * @pure
  *
  * @throws Exception\EncodeException If an error occurred.
+ *
+ * @return non-empty-string
  */
 function encode(mixed $value, bool $pretty = false, int $flags = 0): string
 {


### PR DESCRIPTION
… at least I don't think it can:

https://3v4l.org/8G6ln
