### PR TITLE
Fix PHP84 implicit nullable types

### DIFF
--- a/config/.php_cs.dist.php
+++ b/config/.php_cs.dist.php
@@ -76,5 +76,6 @@ return (new PhpCsFixer\Config())
         'phpdoc_trim_consecutive_blank_line_separation' => true,
         'no_empty_statement' => true,
         'semicolon_after_instruction' => true,
+        'nullable_type_declaration_for_default_null_value' => true,
     ])
     ;

--- a/src/Psl/Vec/range.php
+++ b/src/Psl/Vec/range.php
@@ -45,7 +45,7 @@ namespace Psl\Vec;
  *
  * @see https://github.com/vimeo/psalm/issues/2152#issuecomment-533363310
  */
-function range(int|float $start, int|float $end, int|float $step = null): array
+function range(int|float $start, int|float $end, int|float|null $step = null): array
 {
     if ((float) $start === (float) $end) {
         return [$start];

--- a/tests/unit/Dict/SliceTest.php
+++ b/tests/unit/Dict/SliceTest.php
@@ -12,7 +12,7 @@ final class SliceTest extends TestCase
     /**
      * @dataProvider provideData
      */
-    public function testSlice(array $expected, array $array, int $n, int $l = null): void
+    public function testSlice(array $expected, array $array, int $n, ?int $l = null): void
     {
         $result = Dict\slice($array, $n, $l);
 

--- a/tests/unit/Regex/EveryMatchTest.php
+++ b/tests/unit/Regex/EveryMatchTest.php
@@ -19,7 +19,7 @@ final class EveryMatchTest extends TestCase
         array $expected,
         string $subject,
         string $pattern,
-        TypeInterface $shape = null,
+        ?TypeInterface $shape = null,
         int $offset = 0
     ): void {
         static::assertSame($expected, Regex\every_match($subject, $pattern, $shape, $offset));

--- a/tests/unit/Regex/FirstMatchTest.php
+++ b/tests/unit/Regex/FirstMatchTest.php
@@ -19,7 +19,7 @@ final class FirstMatchTest extends TestCase
         array $expected,
         string $subject,
         string $pattern,
-        TypeInterface $shape = null,
+        ?TypeInterface $shape = null,
         int $offset = 0
     ): void {
         static::assertSame($expected, Regex\first_match($subject, $pattern, $shape, $offset));

--- a/tests/unit/Vec/SliceTest.php
+++ b/tests/unit/Vec/SliceTest.php
@@ -12,7 +12,7 @@ final class SliceTest extends TestCase
     /**
      * @dataProvider provideData
      */
-    public function testSlice(array $expected, array $array, int $n, int $l = null): void
+    public function testSlice(array $expected, array $array, int $n, ?int $l = null): void
     {
         $result = Vec\slice($array, $n, $l);
 


### PR DESCRIPTION
See https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

The added cs-fixer rule will enforce that nullable types are always explicitly set.

This PR is targeted to 2.9.x to make that PHP 8.4 compatible as well.
Once merged, it should be merged to next (3.x) as well.
