### PR TITLE
feat(types): Memoize simple types without arguments

### DIFF
--- a/src/Psl/Type/Internal/LiteralScalarType.php
+++ b/src/Psl/Type/Internal/LiteralScalarType.php
@@ -41,14 +41,16 @@ final class LiteralScalarType extends Type\Type
      */
     public function coerce(mixed $value): string|int|float|bool
     {
-        if ($value === $this->value) {
+        $expectedScalarValue = $this->value;
+        if ($value === $expectedScalarValue) {
             /** @var T $value */
             return $value;
         }
 
-        if (Type\string()->matches($this->value)) {
-            $coerced_value = Type\string()->coerce($value);
-            if ($this->value === $coerced_value) {
+        $stringType = Type\string();
+        if ($stringType->matches($this->value)) {
+            $coerced_value = $stringType->coerce($value);
+            if ($expectedScalarValue === $coerced_value) {
                 /** @var T $coerced_value */
                 return $coerced_value;
             }
@@ -56,9 +58,10 @@ final class LiteralScalarType extends Type\Type
             throw CoercionException::withValue($value, $this->toString());
         }
 
-        if (Type\int()->matches($this->value)) {
-            $coerced_value = Type\int()->coerce($value);
-            if ($this->value === $coerced_value) {
+        $intType = Type\int();
+        if ($intType->matches($this->value)) {
+            $coerced_value = $intType->coerce($value);
+            if ($expectedScalarValue === $coerced_value) {
                 /** @var T $coerced_value */
                 return $coerced_value;
             }
@@ -66,9 +69,10 @@ final class LiteralScalarType extends Type\Type
             throw CoercionException::withValue($value, $this->toString());
         }
 
-        if (Type\float()->matches($this->value)) {
-            $coerced_value = Type\float()->coerce($value);
-            if ($this->value === $coerced_value) {
+        $floatType = Type\float();
+        if ($floatType->matches($this->value)) {
+            $coerced_value = $floatType->coerce($value);
+            if ($expectedScalarValue === $coerced_value) {
                 /** @var T $coerced_value */
                 return $coerced_value;
             }
@@ -77,7 +81,7 @@ final class LiteralScalarType extends Type\Type
         }
 
         /** @var bool $literal_value */
-        $literal_value = $this->value;
+        $literal_value = $expectedScalarValue;
         $coerced_value = Type\bool()->coerce($value);
         if ($literal_value === $coerced_value) {
             /** @var T $coerced_value */

--- a/src/Psl/Type/array_key.php
+++ b/src/Psl/Type/array_key.php
@@ -9,5 +9,8 @@ namespace Psl\Type;
  */
 function array_key(): TypeInterface
 {
-    return new Internal\ArrayKeyType();
+    /** @var Internal\ArrayKeyType $instance */
+    static $instance = new Internal\ArrayKeyType();
+
+    return $instance;
 }

--- a/src/Psl/Type/bool.php
+++ b/src/Psl/Type/bool.php
@@ -9,5 +9,8 @@ namespace Psl\Type;
  */
 function bool(): TypeInterface
 {
-    return new Internal\BoolType();
+    /** @var Internal\BoolType $instance */
+    static $instance = new Internal\BoolType();
+
+    return $instance;
 }

--- a/src/Psl/Type/f32.php
+++ b/src/Psl/Type/f32.php
@@ -11,5 +11,8 @@ namespace Psl\Type;
  */
 function f32(): TypeInterface
 {
-    return new Internal\F32Type();
+    /** @var Internal\F32Type $instance */
+    static $instance = new Internal\F32Type();
+
+    return $instance;
 }

--- a/src/Psl/Type/f64.php
+++ b/src/Psl/Type/f64.php
@@ -11,5 +11,8 @@ namespace Psl\Type;
  */
 function f64(): TypeInterface
 {
-    return new Internal\F64Type();
+    /** @var Internal\F64Type $instance */
+    static $instance = new Internal\F64Type();
+
+    return $instance;
 }

--- a/src/Psl/Type/float.php
+++ b/src/Psl/Type/float.php
@@ -9,5 +9,8 @@ namespace Psl\Type;
  */
 function float(): TypeInterface
 {
-    return new Internal\FloatType();
+    /** @var Internal\FloatType $instance */
+    static $instance = new Internal\FloatType();
+
+    return $instance;
 }

--- a/src/Psl/Type/i16.php
+++ b/src/Psl/Type/i16.php
@@ -11,5 +11,8 @@ namespace Psl\Type;
  */
 function i16(): TypeInterface
 {
-    return new Internal\I16Type();
+    /** @var Internal\I16Type $instance */
+    static $instance = new Internal\I16Type();
+
+    return $instance;
 }

--- a/src/Psl/Type/i32.php
+++ b/src/Psl/Type/i32.php
@@ -11,5 +11,8 @@ namespace Psl\Type;
  */
 function i32(): TypeInterface
 {
-    return new Internal\I32Type();
+    /** @var Internal\I32Type $instance */
+    static $instance = new Internal\I32Type();
+
+    return $instance;
 }

--- a/src/Psl/Type/i64.php
+++ b/src/Psl/Type/i64.php
@@ -11,5 +11,8 @@ namespace Psl\Type;
  */
 function i64(): TypeInterface
 {
-    return new Internal\I64Type();
+    /** @var Internal\I64Type $instance */
+    static $instance = new Internal\I64Type();
+
+    return $instance;
 }

--- a/src/Psl/Type/i8.php
+++ b/src/Psl/Type/i8.php
@@ -11,5 +11,8 @@ namespace Psl\Type;
  */
 function i8(): TypeInterface
 {
-    return new Internal\I8Type();
+    /** @var Internal\I8Type $instance */
+    static $instance = new Internal\I8Type();
+
+    return $instance;
 }

--- a/src/Psl/Type/int.php
+++ b/src/Psl/Type/int.php
@@ -9,5 +9,8 @@ namespace Psl\Type;
  */
 function int(): TypeInterface
 {
-    return new Internal\IntType();
+    /** @var Internal\IntType $instance */
+    static $instance = new Internal\IntType();
+
+    return $instance;
 }

--- a/src/Psl/Type/mixed.php
+++ b/src/Psl/Type/mixed.php
@@ -9,5 +9,8 @@ namespace Psl\Type;
  */
 function mixed(): TypeInterface
 {
-    return new Internal\MixedType();
+    /** @var Internal\MixedType $instance */
+    static $instance = new Internal\MixedType();
+
+    return $instance;
 }

--- a/src/Psl/Type/non_empty_string.php
+++ b/src/Psl/Type/non_empty_string.php
@@ -9,5 +9,8 @@ namespace Psl\Type;
  */
 function non_empty_string(): TypeInterface
 {
-    return new Internal\NonEmptyStringType();
+    /** @var Internal\NonEmptyStringType $instance */
+    static $instance = new Internal\NonEmptyStringType();
+
+    return $instance;
 }

--- a/src/Psl/Type/nonnull.php
+++ b/src/Psl/Type/nonnull.php
@@ -11,5 +11,8 @@ namespace Psl\Type;
  */
 function nonnull(): TypeInterface
 {
-    return new Internal\NonNullType();
+    /** @var Internal\NonNullType $instance */
+    static $instance = new Internal\NonNullType();
+
+    return $instance;
 }

--- a/src/Psl/Type/null.php
+++ b/src/Psl/Type/null.php
@@ -9,5 +9,8 @@ namespace Psl\Type;
  */
 function null(): TypeInterface
 {
-    return new Internal\NullType();
+    /** @var Internal\NullType $instance */
+    static $instance = new Internal\NullType();
+
+    return $instance;
 }

--- a/src/Psl/Type/num.php
+++ b/src/Psl/Type/num.php
@@ -9,5 +9,8 @@ namespace Psl\Type;
  */
 function num(): TypeInterface
 {
-    return new Internal\NumType();
+    /** @var Internal\NumType $instance */
+    static $instance = new Internal\NumType();
+
+    return $instance;
 }

--- a/src/Psl/Type/numeric_string.php
+++ b/src/Psl/Type/numeric_string.php
@@ -9,5 +9,8 @@ namespace Psl\Type;
  */
 function numeric_string(): TypeInterface
 {
-    return new Internal\NumericStringType();
+    /** @var Internal\NumericStringType $instance */
+    static $instance = new Internal\NumericStringType();
+
+    return $instance;
 }

--- a/src/Psl/Type/object.php
+++ b/src/Psl/Type/object.php
@@ -9,5 +9,8 @@ namespace Psl\Type;
  */
 function object(): TypeInterface
 {
-    return new Internal\ObjectType();
+    /** @var Internal\ObjectType $instance */
+    static $instance = new Internal\ObjectType();
+
+    return $instance;
 }

--- a/src/Psl/Type/positive_int.php
+++ b/src/Psl/Type/positive_int.php
@@ -11,5 +11,8 @@ namespace Psl\Type;
  */
 function positive_int(): TypeInterface
 {
-    return new Internal\PositiveIntType();
+    /** @var Internal\PositiveIntType $instance */
+    static $instance = new Internal\PositiveIntType();
+
+    return $instance;
 }

--- a/src/Psl/Type/scalar.php
+++ b/src/Psl/Type/scalar.php
@@ -9,5 +9,8 @@ namespace Psl\Type;
  */
 function scalar(): TypeInterface
 {
-    return new Internal\ScalarType();
+    /** @var Internal\ScalarType $instance */
+    static $instance = new Internal\ScalarType();
+
+    return $instance;
 }

--- a/src/Psl/Type/string.php
+++ b/src/Psl/Type/string.php
@@ -9,5 +9,8 @@ namespace Psl\Type;
  */
 function string(): TypeInterface
 {
-    return new Internal\StringType();
+    /** @var Internal\StringType $instance */
+    static $instance = new Internal\StringType();
+
+    return $instance;
 }

--- a/src/Psl/Type/u16.php
+++ b/src/Psl/Type/u16.php
@@ -11,5 +11,8 @@ namespace Psl\Type;
  */
 function u16(): TypeInterface
 {
-    return new Internal\U16Type();
+    /** @var Internal\U16Type $instance */
+    static $instance = new Internal\U16Type();
+
+    return $instance;
 }

--- a/src/Psl/Type/u32.php
+++ b/src/Psl/Type/u32.php
@@ -11,5 +11,8 @@ namespace Psl\Type;
  */
 function u32(): TypeInterface
 {
-    return new Internal\U32Type();
+    /** @var Internal\U32Type $instance */
+    static $instance = new Internal\U32Type();
+
+    return $instance;
 }

--- a/src/Psl/Type/u8.php
+++ b/src/Psl/Type/u8.php
@@ -11,5 +11,8 @@ namespace Psl\Type;
  */
 function u8(): TypeInterface
 {
-    return new Internal\U8Type();
+    /** @var Internal\U8Type $instance */
+    static $instance = new Internal\U8Type();
+
+    return $instance;
 }

--- a/src/Psl/Type/uint.php
+++ b/src/Psl/Type/uint.php
@@ -11,5 +11,8 @@ namespace Psl\Type;
  */
 function uint(): TypeInterface
 {
-    return new Internal\UIntType();
+    /** @var Internal\UIntType $instance */
+    static $instance = new Internal\UIntType();
+
+    return $instance;
 }

--- a/tests/benchmark/Type/ShapeTypeBench.php
+++ b/tests/benchmark/Type/ShapeTypeBench.php
@@ -98,6 +98,58 @@ final class ShapeTypeBench extends GenericTypeBench
                     'war' => null,
                 ]),
             ],
+            'real-life-type-usage' => [
+                'type' => Type\shape([
+                    'name' => Type\string(),
+                    'articles' => Type\vec(Type\shape([
+                        'title' => Type\string(),
+                        'content' => Type\string(),
+                        'likes' => Type\int(),
+                        'comments' => Type\optional(Type\vec(Type\shape([
+                            'user' => Type\string(),
+                            'comment' => Type\string()
+                        ]))),
+                    ])),
+                    'dictionary' => Type\dict(Type\string(), Type\vec(Type\shape([
+                        'title' => Type\string(),
+                        'content' => Type\string(),
+                    ]))),
+                    'pagination' => Type\optional(Type\shape([
+                        'currentPage' => Type\uint(),
+                        'totalPages' => Type\uint(),
+                        'perPage' => Type\uint(),
+                        'totalRows' => Type\uint(),
+                    ]))
+                ]),
+                'value' => [
+                    'name' => 'ok',
+                    'articles' => [
+                        [
+                            'title' => 'ok',
+                            'content' => 'ok',
+                            'likes' => 1,
+                            'comments' => [
+                                [
+                                    'user' => 'ok',
+                                    'comment' => 'ok'
+                                ],
+                                [
+                                    'user' => 'ok',
+                                    'comment' => 'ok',
+                                ]
+                            ]
+                        ]
+                    ],
+                    'dictionary' => [
+                        'key' => [
+                            [
+                                'title' => 'ok',
+                                'content' => 'ok',
+                            ]
+                        ]
+                    ]
+                ]
+            ]
         ];
     }
 
@@ -146,6 +198,58 @@ final class ShapeTypeBench extends GenericTypeBench
                     'war' => null,
                 ],
             ],
+            'real-life-type-usage' => [
+                'type' => Type\shape([
+                    'name' => Type\string(),
+                    'articles' => Type\vec(Type\shape([
+                        'title' => Type\string(),
+                        'content' => Type\string(),
+                        'likes' => Type\int(),
+                        'comments' => Type\optional(Type\vec(Type\shape([
+                            'user' => Type\string(),
+                            'comment' => Type\string()
+                        ]))),
+                    ])),
+                    'dictionary' => Type\dict(Type\string(), Type\vec(Type\shape([
+                        'title' => Type\string(),
+                        'content' => Type\string(),
+                    ]))),
+                    'pagination' => Type\optional(Type\shape([
+                        'currentPage' => Type\uint(),
+                        'totalPages' => Type\uint(),
+                        'perPage' => Type\uint(),
+                        'totalRows' => Type\uint(),
+                    ]))
+                ]),
+                'value' => [
+                    'name' => 'ok',
+                    'articles' => [
+                        [
+                            'title' => 'ok',
+                            'content' => 'ok',
+                            'likes' => 1,
+                            'comments' => [
+                                [
+                                    'user' => 'ok',
+                                    'comment' => 'ok'
+                                ],
+                                [
+                                    'user' => 'ok',
+                                    'comment' => 'ok',
+                                ]
+                            ]
+                        ]
+                    ],
+                    'dictionary' => [
+                        'key' => [
+                            [
+                                'title' => 'ok',
+                                'content' => 'ok',
+                            ]
+                        ]
+                    ]
+                ]
+            ]
         ];
     }
 

--- a/tests/unit/Type/ArrayKeyTypeTest.php
+++ b/tests/unit/Type/ArrayKeyTypeTest.php
@@ -40,4 +40,9 @@ final class ArrayKeyTypeTest extends TypeTest
     {
         yield [$this->getType(), 'array-key'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\array_key(), Type\array_key());
+    }
 }

--- a/tests/unit/Type/BoolTypeTest.php
+++ b/tests/unit/Type/BoolTypeTest.php
@@ -36,4 +36,9 @@ final class BoolTypeTest extends TypeTest
     {
         yield [$this->getType(), 'bool'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\bool(), Type\bool());
+    }
 }

--- a/tests/unit/Type/F32TypeTest.php
+++ b/tests/unit/Type/F32TypeTest.php
@@ -67,4 +67,9 @@ final class F32TypeTest extends TypeTest
     {
         yield [$this->getType(), 'f32'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\f32(), Type\f32());
+    }
 }

--- a/tests/unit/Type/F64TypeTest.php
+++ b/tests/unit/Type/F64TypeTest.php
@@ -73,4 +73,9 @@ final class F64TypeTest extends TypeTest
     {
         yield [$this->getType(), 'f64'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\f64(), Type\f64());
+    }
 }

--- a/tests/unit/Type/FloatTypeTest.php
+++ b/tests/unit/Type/FloatTypeTest.php
@@ -69,4 +69,9 @@ final class FloatTypeTest extends TypeTest
     {
         yield [$this->getType(), 'float'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\float(), Type\float());
+    }
 }

--- a/tests/unit/Type/I16TypeTest.php
+++ b/tests/unit/Type/I16TypeTest.php
@@ -64,4 +64,9 @@ final class I16TypeTest extends TypeTest
     {
         yield [$this->getType(), 'i16'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\i16(), Type\i16());
+    }
 }

--- a/tests/unit/Type/I32TypeTest.php
+++ b/tests/unit/Type/I32TypeTest.php
@@ -64,4 +64,9 @@ final class I32TypeTest extends TypeTest
     {
         yield [$this->getType(), 'i32'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\i32(), Type\i32());
+    }
 }

--- a/tests/unit/Type/I64TypeTest.php
+++ b/tests/unit/Type/I64TypeTest.php
@@ -64,4 +64,9 @@ final class I64TypeTest extends TypeTest
     {
         yield [$this->getType(), 'i64'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\i64(), Type\i64());
+    }
 }

--- a/tests/unit/Type/I8TypeTest.php
+++ b/tests/unit/Type/I8TypeTest.php
@@ -61,4 +61,9 @@ final class I8TypeTest extends TypeTest
     {
         yield [$this->getType(), 'i8'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\i8(), Type\i8());
+    }
 }

--- a/tests/unit/Type/IntTypeTest.php
+++ b/tests/unit/Type/IntTypeTest.php
@@ -60,4 +60,9 @@ final class IntTypeTest extends TypeTest
     {
         yield [$this->getType(), 'int'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\int(), Type\int());
+    }
 }

--- a/tests/unit/Type/MixedTypeTest.php
+++ b/tests/unit/Type/MixedTypeTest.php
@@ -88,4 +88,9 @@ final class MixedTypeTest extends TypeTest
     {
         $this->addToAssertionCount(1);
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\mixed(), Type\mixed());
+    }
 }

--- a/tests/unit/Type/NonEmptyStringTypeTest.php
+++ b/tests/unit/Type/NonEmptyStringTypeTest.php
@@ -49,4 +49,9 @@ final class NonEmptyStringTypeTest extends TypeTest
     {
         yield [$this->getType(), 'non-empty-string'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\non_empty_string(), Type\non_empty_string());
+    }
 }

--- a/tests/unit/Type/NonNullTypeTest.php
+++ b/tests/unit/Type/NonNullTypeTest.php
@@ -38,4 +38,9 @@ final class NonNullTypeTest extends TypeTest
     {
         yield [$this->getType(), 'nonnull'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\nonnull(), Type\nonnull());
+    }
 }

--- a/tests/unit/Type/NullTypeTest.php
+++ b/tests/unit/Type/NullTypeTest.php
@@ -38,4 +38,9 @@ final class NullTypeTest extends TypeTest
     {
         yield [$this->getType(), 'null'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\null(), Type\null());
+    }
 }

--- a/tests/unit/Type/NumTypeTest.php
+++ b/tests/unit/Type/NumTypeTest.php
@@ -80,4 +80,9 @@ final class NumTypeTest extends TypeTest
     {
         yield [$this->getType(), 'num'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\num(), Type\num());
+    }
 }

--- a/tests/unit/Type/NumericStringTypeTest.php
+++ b/tests/unit/Type/NumericStringTypeTest.php
@@ -49,4 +49,9 @@ final class NumericStringTypeTest extends TypeTest
     {
         yield [$this->getType(), 'numeric-string'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\numeric_string(), Type\numeric_string());
+    }
 }

--- a/tests/unit/Type/ObjectTypeTest.php
+++ b/tests/unit/Type/ObjectTypeTest.php
@@ -37,4 +37,9 @@ final class ObjectTypeTest extends TypeTest
     {
         yield [Type\object(), 'object'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\object(), Type\object());
+    }
 }

--- a/tests/unit/Type/PositiveIntTypeTest.php
+++ b/tests/unit/Type/PositiveIntTypeTest.php
@@ -67,4 +67,9 @@ final class PositiveIntTypeTest extends TypeTest
     {
         yield [$this->getType(), 'positive-int'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\positive_int(), Type\positive_int());
+    }
 }

--- a/tests/unit/Type/StringTypeTest.php
+++ b/tests/unit/Type/StringTypeTest.php
@@ -42,4 +42,9 @@ final class StringTypeTest extends TypeTest
     {
         yield [$this->getType(), 'string'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\string(), Type\string());
+    }
 }

--- a/tests/unit/Type/U16TypeTest.php
+++ b/tests/unit/Type/U16TypeTest.php
@@ -64,4 +64,9 @@ final class U16TypeTest extends TypeTest
     {
         yield [$this->getType(), 'u16'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\u16(), Type\u16());
+    }
 }

--- a/tests/unit/Type/U32TypeTest.php
+++ b/tests/unit/Type/U32TypeTest.php
@@ -64,4 +64,9 @@ final class U32TypeTest extends TypeTest
     {
         yield [$this->getType(), 'u32'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\u32(), Type\u32());
+    }
 }

--- a/tests/unit/Type/U8TypeTest.php
+++ b/tests/unit/Type/U8TypeTest.php
@@ -66,4 +66,9 @@ final class U8TypeTest extends TypeTest
     {
         yield [$this->getType(), 'u8'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\u8(), Type\u8());
+    }
 }

--- a/tests/unit/Type/UIntTypeTest.php
+++ b/tests/unit/Type/UIntTypeTest.php
@@ -60,4 +60,9 @@ final class UIntTypeTest extends TypeTest
     {
         yield [$this->getType(), 'uint'];
     }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\uint(), Type\uint());
+    }
 }


### PR DESCRIPTION
Benchmarks (with `--warmup=20 --revs=200 --retry-threshold=1`)

The result there is that it has close to zero impact (+ or - 5% which is a matter of nanoseconds) on the regular types, but has a big impact on the `shape()` coercions.

The `ShapeTypeBench` is the only one that calls multiple types that now get memoized so it represents real-life wins better : In real applications, types tend to repeat more than in the benchmarks.

```
\Psl\Tests\Benchmark\Channel\CommunicationBench

    benchBoundedCommunication...............R1 I2 - [Mo2.436ms vs. Mo2.443ms] -0.29% (±0.71%)
    benchUnboundedCommunication.............R2 I3 - [Mo2.454ms vs. Mo2.444ms] +0.38% (±0.43%)

\Psl\Tests\Benchmark\Type\VecTypeBench

    benchCoerce # mixed, empty array........R2 I4 - [Mo0.145μs vs. Mo0.145μs] 0.00% (±0.00%)
    benchCoerce # mixed, empty iterable.....R5 I4 - [Mo0.180μs vs. Mo0.180μs] 0.00% (±0.00%)
    benchCoerce # mixed, non-empty array....R1 I0 - [Mo0.330μs vs. Mo0.330μs] -0.05% (±0.00%)
    benchCoerce # mixed, non-empty iterable.R5 I4 - [Mo0.460μs vs. Mo0.495μs] -7.07% (±0.44%)
    benchCoerce # mixed, large array........R2 I1 - [Mo5.276μs vs. Mo5.270μs] +0.12% (±0.55%)
    benchCoerce # mixed, large iterable.....R5 I4 - [Mo8.207μs vs. Mo8.198μs] +0.11% (±0.47%)
    benchCoerce # int, empty array..........R1 I3 - [Mo0.145μs vs. Mo0.145μs] 0.00% (±0.00%)
    benchCoerce # int, empty iterable.......R5 I4 - [Mo0.180μs vs. Mo0.180μs] 0.00% (±0.00%)
    benchCoerce # int, non-empty array......R5 I4 - [Mo0.360μs vs. Mo0.360μs] -0.05% (±0.68%)
    benchCoerce # int, non-empty iterable...R2 I4 - [Mo0.535μs vs. Mo0.535μs] +0.03% (±0.46%)
    benchAssert # mixed, empty array........R1 I1 - [Mo0.150μs vs. Mo0.150μs] 0.00% (±0.00%)
    benchAssert # mixed, non-empty array....R2 I4 - [Mo0.325μs vs. Mo0.325μs] 0.00% (±0.76%)
    benchAssert # mixed, large array........R1 I4 - [Mo4.886μs vs. Mo4.815μs] +1.48% (±0.32%)
    benchAssert # int, empty array..........R1 I4 - [Mo0.150μs vs. Mo0.150μs] 0.00% (±0.00%)
    benchAssert # int, non-empty array......R5 I4 - [Mo0.335μs vs. Mo0.340μs] -1.47% (±0.74%)
    benchMatch # mixed, empty array.........R5 I4 - [Mo0.125μs vs. Mo0.125μs] 0.00% (±0.00%)
    benchMatch # mixed, non-empty array.....R1 I1 - [Mo0.280μs vs. Mo0.280μs] 0.00% (±0.00%)
    benchMatch # mixed, large array.........R1 I3 - [Mo4.458μs vs. Mo4.544μs] -1.90% (±0.54%)
    benchMatch # int, empty array...........R5 I4 - [Mo0.125μs vs. Mo0.125μs] 0.00% (±0.00%)
    benchMatch # int, non-empty array.......R1 I4 - [Mo0.290μs vs. Mo0.285μs] +1.75% (±0.00%)

\Psl\Tests\Benchmark\Type\DictTypeBench

    benchCoerce # generic array, empty arra.R1 I2 - [Mo0.155μs vs. Mo0.150μs] +3.33% (±0.00%)
    benchCoerce # generic array, empty iter.R1 I3 - [Mo0.190μs vs. Mo0.190μs] 0.00% (±0.00%)
    benchCoerce # generic array, non-empty .R3 I4 - [Mo0.320μs vs. Mo0.315μs] +1.48% (±0.77%)
    benchCoerce # generic array, non-empty .R1 I4 - [Mo0.390μs vs. Mo0.390μs] 0.00% (±0.00%)
    benchCoerce # generic array, large arra.R1 I2 - [Mo12.696μs vs. Mo12.751μs] -0.43% (±0.51%)
    benchCoerce # generic array, large iter.R1 I0 - [Mo15.458μs vs. Mo15.728μs] -1.72% (±0.53%)
    benchCoerce # int array, empty array....R1 I1 - [Mo0.150μs vs. Mo0.155μs] -3.23% (±0.00%)
    benchCoerce # int array, empty iterable.R1 I4 - [Mo0.190μs vs. Mo0.190μs] 0.00% (±0.00%)
    benchCoerce # int array, non-empty arra.R1 I1 - [Mo0.510μs vs. Mo0.510μs] +0.00% (±0.00%)
    benchCoerce # int array, non-empty iter.R3 I4 - [Mo0.650μs vs. Mo0.645μs] +0.78% (±0.49%)
    benchCoerce # int array, large array....R1 I1 - [Mo10.082μs vs. Mo10.296μs] -2.07% (±0.40%)
    benchCoerce # int array, large iterable.R1 I3 - [Mo13.298μs vs. Mo13.517μs] -1.62% (±0.38%)
    benchCoerce # map, empty array..........R1 I4 - [Mo0.155μs vs. Mo0.155μs] 0.00% (±0.00%)
    benchCoerce # map, empty iterable.......R2 I2 - [Mo0.190μs vs. Mo0.190μs] 0.00% (±0.00%)
    benchCoerce # map, non-empty array......R1 I2 - [Mo0.590μs vs. Mo0.590μs] +0.03% (±0.41%)
    benchCoerce # map, non-empty iterable...R3 I3 - [Mo0.725μs vs. Mo0.720μs] +0.74% (±0.67%)
    benchCoerce # map, large array..........R1 I0 - [Mo10.702μs vs. Mo10.942μs] -2.20% (±0.45%)
    benchCoerce # map, large iterable.......R2 I2 - [Mo13.842μs vs. Mo13.947μs] -0.76% (±0.51%)
    benchAssert # generic array, empty arra.R1 I1 - [Mo0.140μs vs. Mo0.140μs] 0.00% (±0.00%)
    benchAssert # generic array, non-empty .R1 I4 - [Mo0.300μs vs. Mo0.290μs] +3.45% (±0.00%)
    benchAssert # generic array, large arra.R2 I3 - [Mo12.197μs vs. Mo11.986μs] +1.76% (±0.62%)
    benchAssert # int array, empty array....R1 I4 - [Mo0.140μs vs. Mo0.140μs] 0.00% (±0.00%)
    benchAssert # int array, non-empty arra.R5 I4 - [Mo0.460μs vs. Mo0.460μs] 0.00% (±0.53%)
    benchAssert # int array, large array....R5 I4 - [Mo10.717μs vs. Mo11.005μs] -2.62% (±0.56%)
    benchAssert # map, empty array..........R1 I1 - [Mo0.140μs vs. Mo0.140μs] 0.00% (±0.00%)
    benchAssert # map, non-empty array......R4 I4 - [Mo0.565μs vs. Mo0.565μs] +0.03% (±0.56%)
    benchAssert # map, large array..........R1 I2 - [Mo10.271μs vs. Mo10.456μs] -1.76% (±0.24%)
    benchMatch # generic array, empty array.R3 I4 - [Mo0.170μs vs. Mo0.170μs] 0.00% (±0.00%)
    benchMatch # generic array, non-empty a.R3 I3 - [Mo0.315μs vs. Mo0.320μs] -1.51% (±0.77%)
    benchMatch # generic array, large array.R5 I4 - [Mo11.921μs vs. Mo12.060μs] -1.15% (±0.35%)
    benchMatch # int array, empty array.....R1 I3 - [Mo0.170μs vs. Mo0.170μs] 0.00% (±0.00%)
    benchMatch # int array, non-empty array.R1 I3 - [Mo0.490μs vs. Mo0.495μs] -0.98% (±0.50%)
    benchMatch # int array, large array.....R2 I4 - [Mo10.918μs vs. Mo11.049μs] -1.18% (±0.49%)
    benchMatch # map, empty array...........R1 I1 - [Mo0.170μs vs. Mo0.170μs] 0.00% (±0.00%)
    benchMatch # map, non-empty array.......R5 I4 - [Mo0.585μs vs. Mo0.590μs] -0.82% (±0.42%)
    benchMatch # map, large array...........R3 I4 - [Mo10.247μs vs. Mo10.405μs] -1.52% (±0.72%)

\Psl\Tests\Benchmark\Type\NonEmptyStringTypeBench

    benchCoerce # string....................R1 I1 - [Mo0.105μs vs. Mo0.105μs] 0.00% (±0.00%)
    benchCoerce # int.......................R1 I0 - [Mo0.125μs vs. Mo0.125μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (ex.R5 I4 - [Mo0.150μs vs. Mo0.150μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (im.R1 I1 - [Mo0.155μs vs. Mo0.150μs] +3.33% (±0.00%)
    benchAssert.............................R1 I1 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchMatch..............................R1 I3 - [Mo0.105μs vs. Mo0.105μs] 0.00% (±0.00%)

\Psl\Tests\Benchmark\Type\StringTypeBench

    benchCoerce # string....................R2 I4 - [Mo0.090μs vs. Mo0.090μs] 0.00% (±0.00%)
    benchCoerce # int.......................R1 I4 - [Mo0.115μs vs. Mo0.120μs] -4.17% (±0.00%)
    benchCoerce # instanceof Stringable (ex.R1 I1 - [Mo0.140μs vs. Mo0.140μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (im.R3 I3 - [Mo0.140μs vs. Mo0.140μs] 0.00% (±0.00%)
    benchAssert.............................R5 I4 - [Mo0.085μs vs. Mo0.085μs] 0.00% (±0.00%)
    benchMatch..............................R5 I4 - [Mo0.100μs vs. Mo0.095μs] +5.26% (±0.00%)

\Psl\Tests\Benchmark\Type\ArrayKeyTypeBench

    benchCoerce # string....................R2 I4 - [Mo0.095μs vs. Mo0.095μs] 0.00% (±0.00%)
    benchCoerce # int.......................R5 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (ex.R1 I3 - [Mo5.833μs vs. Mo5.729μs] +1.80% (±0.34%)
    benchCoerce # instanceof Stringable (im.R2 I3 - [Mo5.672μs vs. Mo5.802μs] -2.24% (±0.54%)
    benchAssert # string....................R4 I4 - [Mo0.090μs vs. Mo0.095μs] -5.26% (±0.00%)
    benchAssert # int.......................R5 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchMatch # string.....................R5 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchMatch # int........................R5 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)

\Psl\Tests\Benchmark\Type\IntTypeBench

    benchCoerce # int.......................R2 I4 - [Mo0.095μs vs. Mo0.095μs] 0.00% (±0.00%)
    benchCoerce # string....................R1 I2 - [Mo0.165μs vs. Mo0.160μs] +3.12% (±0.00%)
    benchCoerce # float.....................R1 I3 - [Mo0.120μs vs. Mo0.120μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (ex.R1 I4 - [Mo0.205μs vs. Mo0.205μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (im.R1 I4 - [Mo0.205μs vs. Mo0.205μs] 0.00% (±0.00%)
    benchAssert.............................R2 I4 - [Mo0.085μs vs. Mo0.085μs] 0.00% (±0.00%)
    benchMatch..............................R5 I4 - [Mo0.095μs vs. Mo0.095μs] 0.00% (±0.00%)

\Psl\Tests\Benchmark\Type\ShapeTypeBench

    benchCoerce # empty shape, empty array .R4 I3 - [Mo0.335μs vs. Mo0.335μs] 0.00% (±0.74%)
    benchCoerce # empty shape, empty iterab.R1 I3 - [Mo0.315μs vs. Mo0.565μs] -44.23% (±0.00%)
    benchCoerce # empty shape, non-empty ar.R1 I4 - [Mo0.385μs vs. Mo0.370μs] +4.01% (±0.00%)
    benchCoerce # empty shape, non-empty it.R1 I1 - [Mo0.505μs vs. Mo0.772μs] -34.58% (±0.63%)
    benchCoerce # complex shape with option.R1 I4 - [Mo0.682μs vs. Mo0.683μs] -0.16% (±0.55%)
    benchCoerce # complex shape with option.R1 I4 - [Mo1.547μs vs. Mo1.806μs] -14.33% (±0.38%)
    benchCoerce # complex shape with option.R1 I0 - [Mo0.974μs vs. Mo0.993μs] -1.85% (±0.41%)
    benchCoerce # complex shape with option.R3 I4 - [Mo3.072μs vs. Mo3.367μs] -8.77% (±0.58%)
    benchAssert # empty shape, empty array .R1 I3 - [Mo0.130μs vs. Mo0.130μs] 0.00% (±0.00%)
    benchAssert # empty shape, non-empty ar.R1 I0 - [Mo0.230μs vs. Mo0.230μs] 0.00% (±0.00%)
    benchAssert # complex shape with option.R1 I3 - [Mo1.025μs vs. Mo1.027μs] -0.23% (±0.00%)
    benchAssert # complex shape with option.R1 I0 - [Mo2.102μs vs. Mo2.087μs] +0.69% (±0.41%)
    benchMatch # empty shape, empty array v.R1 I4 - [Mo0.160μs vs. Mo0.160μs] 0.00% (±0.00%)
    benchMatch # empty shape, non-empty arr.R4 I4 - [Mo0.260μs vs. Mo0.255μs] +1.96% (±0.00%)
    benchMatch # complex shape with optiona.R4 I4 - [Mo1.058μs vs. Mo1.060μs] -0.25% (±0.55%)
    benchMatch # complex shape with optiona.R2 I4 - [Mo2.135μs vs. Mo2.162μs] -1.28% (±0.23%)
```