### PR TITLE
fix(type): Positive int has a broken exception path

### DIFF
--- a/src/Psl/Type/Internal/PositiveIntType.php
+++ b/src/Psl/Type/Internal/PositiveIntType.php
@@ -58,10 +58,7 @@ final class PositiveIntType extends Type\Type
                 return $int;
             }
 
-            // Exceptional case "000" -(trim)-> "", but we treat it as 0
-            if ('' === $trimmed && '' !== $str) {
-                CoercionException::withValue($value, $this->toString());
-            }
+            throw CoercionException::withValue($value, $this->toString());
         }
 
         if (is_float($value)) {


### PR DESCRIPTION
Fixes https://github.com/azjezz/psl/issues/411

The check is obsolete.
If the trimmed string does not result in a positive int, an exception can be thrown at that moment.