### PR TITLE
feat(type): Notnull type optimizations

### DIFF
--- a/docs/component/type.md
+++ b/docs/component/type.md
@@ -40,7 +40,7 @@
 - [non_empty_dict](./../../src/Psl/Type/non_empty_dict.php#L18)
 - [non_empty_string](./../../src/Psl/Type/non_empty_string.php#L14)
 - [non_empty_vec](./../../src/Psl/Type/non_empty_vec.php#L16)
-- [nonnull](./../../src/Psl/Type/nonnull.php#L16)
+- [nonnull](./../../src/Psl/Type/nonnull.php#L18)
 - [null](./../../src/Psl/Type/null.php#L14)
 - [nullable](./../../src/Psl/Type/nullable.php#L16)
 - [num](./../../src/Psl/Type/num.php#L14)

--- a/src/Psl/Type/Internal/NonNullType.php
+++ b/src/Psl/Type/Internal/NonNullType.php
@@ -18,9 +18,15 @@ use Psl\Type\Exception\CoercionException;
 final readonly class NonNullType extends Type\Type
 {
     /**
-     * @psalm-assert-if-true mixed $value
+     * @template T of mixed
+     *
+     * @param T|null $value
+     *
+     * @psalm-assert-if-true T $value
      *
      * @ara-assert-if-true nonnull $value
+     *
+     * @return ($value is null ? false : true)
      */
     public function matches(mixed $value): bool
     {
@@ -28,9 +34,13 @@ final readonly class NonNullType extends Type\Type
     }
 
     /**
+     * @template T of mixed
+     *
+     * @param T|null $value
+     *
      * @ara-return nonnull
      *
-     * @return mixed
+     * @return ($value is null ? never : T)
      */
     public function coerce(mixed $value): mixed
     {
@@ -42,13 +52,17 @@ final readonly class NonNullType extends Type\Type
     }
 
     /**
+     * @template T
+     *
+     * @param T|null $value
+     *
      * @ara-assert nonnull $value
      *
-     * @psalm-assert mixed $value
+     * @psalm-assert T $value
      *
      * @ara-return nonnull
      *
-     * @return mixed
+     * @return ($value is null ? never : T)
      */
     public function assert(mixed $value): mixed
     {

--- a/src/Psl/Type/nonnull.php
+++ b/src/Psl/Type/nonnull.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Type;
 
+use Psl\Type\Internal\NonNullType;
+
 /**
  * @psalm-pure
  *
@@ -11,7 +13,7 @@ namespace Psl\Type;
  *
  * @ara-return TypeInterface<nonnull>
  *
- * @return TypeInterface<mixed>
+ * @return NonNullType
  */
 function nonnull(): TypeInterface
 {

--- a/tests/static-analysis/Type/nonnull.php
+++ b/tests/static-analysis/Type/nonnull.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\StaticAnalysis\Type;
+
+use Psl\Type;
+
+/**
+ * @throws Type\Exception\AssertException
+ */
+function returns_non_null_assertion(?string $state): string
+{
+    return Type\nonnull()->assert($state);
+}
+
+/**
+ * @throws Type\Exception\AssertException
+ */
+function returns_non_null_assertion_asserted(?string $state): string
+{
+    Type\nonnull()->assert($state);
+
+    return $state;
+}
+
+/**
+ * @throws Type\Exception\CoercionException
+ */
+function returns_non_null_coercion(?string $state): string
+{
+    return Type\nonnull()->coerce($state);
+}
+
+/**
+ * @return true
+ */
+function returns_truthy_match(string $state): bool
+{
+    return Type\nonnull()->matches($state);
+}
+
+/**
+ * @return false
+ */
+function returns_falsy_match(null $state = null): bool
+{
+    return Type\nonnull()->matches($state);
+}
+
+/**
+ * @throws Type\Exception\CoercionException
+ *
+ * Wrapping it in container types still leeds to mixed (including null) return type.
+ * This won't be solvable until psalm supports a TNotNull type.
+ *
+ * @return array<'mightBeNull', mixed>
+ */
+function returns_mixed_in_shape(mixed $data): array
+{
+    return Type\shape([
+        'mightBeNull' => Type\nonnull(),
+    ])->coerce($data);
+}


### PR DESCRIPTION
Fixes https://github.com/azjezz/psl/issues/357

There is still one situation, where you use `nonnull()` inside a `shape()`.
In this situation, the type will resolve to mixed (inluding null).
This can only be solved once psalm has a `TNonNull` type.

Thanks @devnix !