### PR TITLE
feat(Result): introduce `Result::unwrapOr()`

### DIFF
--- a/src/Psl/Result/Failure.php
+++ b/src/Psl/Result/Failure.php
@@ -45,6 +45,20 @@ final readonly class Failure implements ResultInterface
     }
 
     /**
+     * Unwrap the Result if it is succeeded or return $default value.
+     *
+     * @param D $default
+     *
+     * @return T|D
+     *
+     * @template D
+     */
+    public function unwrapOr(mixed $default): mixed
+    {
+        return $default;
+    }
+
+    /**
      * Since this is a failed result wrapper, this always returns the `Throwable` thrown during the operation.
      *
      * @return Te - The `Throwable` thrown during the operation.

--- a/src/Psl/Result/Failure.php
+++ b/src/Psl/Result/Failure.php
@@ -47,11 +47,11 @@ final readonly class Failure implements ResultInterface
     /**
      * Unwrap the Result if it is succeeded or return $default value.
      *
+     * @template D
+     *
      * @param D $default
      *
-     * @return T|D
-     *
-     * @template D
+     * @return D
      */
     public function unwrapOr(mixed $default): mixed
     {

--- a/src/Psl/Result/ResultInterface.php
+++ b/src/Psl/Result/ResultInterface.php
@@ -96,6 +96,17 @@ interface ResultInterface extends Psl\Promise\PromiseInterface
     public function getResult();
 
     /**
+     * Unwrap the Result if it is succeeded or return $default value.
+     *
+     * @param D $default
+     *
+     * @return T|D
+     *
+     * @template D
+     */
+    public function unwrapOr(mixed $default): mixed;
+
+    /**
      * Return the underlying throwable, or fail with a invariant violation exception.
      *
      * - if the operation succeeded: fails with a invariant violation exception.

--- a/src/Psl/Result/ResultInterface.php
+++ b/src/Psl/Result/ResultInterface.php
@@ -98,11 +98,11 @@ interface ResultInterface extends Psl\Promise\PromiseInterface
     /**
      * Unwrap the Result if it is succeeded or return $default value.
      *
+     * @template D 
+     *
      * @param D $default
      *
      * @return T|D
-     *
-     * @template D
      */
     public function unwrapOr(mixed $default): mixed;
 

--- a/src/Psl/Result/ResultInterface.php
+++ b/src/Psl/Result/ResultInterface.php
@@ -98,7 +98,7 @@ interface ResultInterface extends Psl\Promise\PromiseInterface
     /**
      * Unwrap the Result if it is succeeded or return $default value.
      *
-     * @template D 
+     * @template D
      *
      * @param D $default
      *

--- a/src/Psl/Result/Success.php
+++ b/src/Psl/Result/Success.php
@@ -47,11 +47,11 @@ final readonly class Success implements ResultInterface
     /**
      * Unwrap the Result if it is succeeded or return $default value.
      *
+     * @template D
+     *
      * @param D $default
      *
-     * @return T|D
-     *
-     * @template D
+     * @return T
      */
     public function unwrapOr(mixed $default): mixed
     {

--- a/src/Psl/Result/Success.php
+++ b/src/Psl/Result/Success.php
@@ -45,6 +45,20 @@ final readonly class Success implements ResultInterface
     }
 
     /**
+     * Unwrap the Result if it is succeeded or return $default value.
+     *
+     * @param D $default
+     *
+     * @return T|D
+     *
+     * @template D
+     */
+    public function unwrapOr(mixed $default): mixed
+    {
+        return $this->value;
+    }
+
+    /**
      * Since this is a successful result wrapper, this always throws a
      * `Psl\Exception\InvariantViolationException` saying that there was no exception thrown from the operation.
      *

--- a/tests/unit/Result/FailureTest.php
+++ b/tests/unit/Result/FailureTest.php
@@ -33,6 +33,14 @@ final class FailureTest extends TestCase
         $wrapper->getResult();
     }
 
+    public function testUnwrapFailure(): void
+    {
+        $result = new Failure(new Exception());
+        $value = $result->unwrapOr(null);
+
+        static::assertNull($value);
+    }
+
     public function testGetException(): void
     {
         $exception = new Exception('bar');

--- a/tests/unit/Result/SuccessTest.php
+++ b/tests/unit/Result/SuccessTest.php
@@ -31,6 +31,14 @@ final class SuccessTest extends TestCase
         static::assertSame('hello', $wrapper->getResult());
     }
 
+    public function testUnwrap(): void
+    {
+        $result = new Success('foo');
+        $value = $result->unwrapOr(null);
+
+        static::assertSame('foo', $value);
+    }
+
     public function testGetException(): void
     {
         $wrapper = new Success('hello');


### PR DESCRIPTION
I'd like to introduce a function that allows to get inner value from Result if success and allows to bypass throwing an exception from Failure by providing a default value.