### PR TITLE
Change `Iter\apply` `(Closure(T): void)` `$function` to `(Closure(T): mixed)`

### DIFF
--- a/src/Psl/Iter/apply.php
+++ b/src/Psl/Iter/apply.php
@@ -12,7 +12,7 @@ use Closure;
  * @template  T
  *
  * @param iterable<T> $iterable Iterable to apply on
- * @param (Closure(T): void) $function Apply function
+ * @param (Closure(T): mixed) $function Apply function
  */
 function apply(iterable $iterable, Closure $function): void
 {


### PR DESCRIPTION
If the return type is not going to be used, it does not make sense to enforce it.

For example, there are cases like arrow functions that are incompatible, and force to use longer versions just because of the implicit return, for example:

```php
Psl\Iter\apply(
    $items,
    fn (Item $item) => $q($item)->then($this->processItem(...))
);
```