### PR TITLE
Add missing Option::orElse method

### DIFF
--- a/src/Psl/Option/Option.php
+++ b/src/Psl/Option/Option.php
@@ -194,6 +194,24 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
     }
 
     /**
+     * Returns the option if it contains a value, otherwise calls $closure and returns the result.
+     *
+     * @param (Closure(): Option<T>) $closure
+     *
+     * @param-immediately-invoked-callable $closure
+     *
+     * @return Option<T>
+     */
+    public function orElse(Closure $closure): Option
+    {
+        if ($this->option !== null) {
+            return $this;
+        }
+
+        return $closure();
+    }
+
+    /**
      * Returns none if the option is none, otherwise calls `$predicate` with the wrapped value and returns:
      *  - Option<T>::some() if `$predicate` returns true (where t is the wrapped value), and
      *  - Option<T>::none() if `$predicate` returns false.

--- a/tests/unit/Option/NoneTest.php
+++ b/tests/unit/Option/NoneTest.php
@@ -71,6 +71,14 @@ final class NoneTest extends TestCase
         static::assertFalse(Option\none()->or(Option\some(4))->isNone());
     }
 
+    public function testOrElse(): void
+    {
+        static::assertFalse(Option\none()->orElse(static fn () => Option\none())->isSome());
+        static::assertTrue(Option\none()->orElse(static fn () => Option\some(4))->isSome());
+        static::assertTrue(Option\none()->orElse(static fn () => Option\none())->isNone());
+        static::assertFalse(Option\none()->orElse(static fn () => Option\some(4))->isNone());
+    }
+
     public function testFilter(): void
     {
         $option = Option\none();

--- a/tests/unit/Option/SomeTest.php
+++ b/tests/unit/Option/SomeTest.php
@@ -68,6 +68,14 @@ final class SomeTest extends TestCase
         static::assertFalse(Option\some(2)->or(Option\some(4))->isNone());
     }
 
+    public function testOrElse(): void
+    {
+        static::assertTrue(Option\some(2)->orElse(static fn () => Option\none())->isSome());
+        static::assertTrue(Option\some(2)->orElse(static fn () => Option\some(4))->isSome());
+        static::assertFalse(Option\some(2)->orElse(static fn () => Option\none())->isNone());
+        static::assertFalse(Option\some(2)->orElse(static fn () => Option\some(4))->isNone());
+    }
+
     public function testFilter(): void
     {
         $option = Option\some(2);


### PR DESCRIPTION
The `Option::or()` method states

```
     * @note:   Arguments passed to `Option::or()` are eagerly evaluated;
     *          if you are passing the result of a function call, it is recommended to use `Option::orElse()`, which is lazily evaluated.
```

But there is no `Option::orElse()` method.

Now there is!