### PR TITLE
feat(DateTime) Provide a human-like months substract and add system

### DIFF
--- a/src/Psl/Option/Option.php
+++ b/src/Psl/Option/Option.php
@@ -74,6 +74,7 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      * Returns true if the option is a some and the value inside of it matches a predicate.
      *
      * @param (Closure(T): bool) $predicate
+     *
      * @param-immediately-invoked-callable $predicate
      */
     public function isSomeAnd(Closure $predicate): bool
@@ -141,6 +142,7 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      * @template O
      *
      * @param (Closure(): O) $default
+     *
      * @param-immediately-invoked-callable $default
      *
      * @return T|O
@@ -219,6 +221,7 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      *  - Option<T>::none() if `$predicate` returns false.
      *
      * @param (Closure(T): bool) $predicate
+     *
      * @param-immediately-invoked-callable $predicate
      *
      * @return Option<T>
@@ -256,10 +259,13 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      * @param (Closure(T): Ts) $some A closure to be called when the option is some.
      *                               The closure must accept the option value as its only argument and can return a value.
      *                               Example: `fn($value) => $value + 10`
+     *
      * @param-immediately-invoked-callable $some
+     *
      * @param (Closure(): Ts) $none A closure to be called when the option is none.
      *                              The closure must not accept any arguments and can return a value.
      *                              Example: `fn() => 'Default value'`
+     *
      * @param-immediately-invoked-callable $none
      *
      * @return Ts The result of calling the appropriate closure.
@@ -277,6 +283,7 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      * Applies a function to a contained value and returns the original `Option<T>`.
      *
      * @param (Closure(T): mixed) $closure
+     *
      * @param-immediately-invoked-callable $closure
      *
      * @return Option<T>
@@ -296,6 +303,7 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      * @template Tu
      *
      * @param (Closure(T): Tu) $closure
+     *
      * @param-immediately-invoked-callable $closure
      *
      * @return Option<Tu>
@@ -316,6 +324,7 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      * @template Tu
      *
      * @param (Closure(T): Option<Tu>) $closure
+     *
      * @param-immediately-invoked-callable $closure
      *
      * @return Option<Tu>
@@ -340,7 +349,9 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      * @template Tu
      *
      * @param (Closure(T): Tu) $closure
+     *
      * @param-immediately-invoked-callable $closure
+     *
      * @param Tu $default
      *
      * @return Option<Tu>
@@ -361,8 +372,11 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      * @template Tu
      *
      * @param (Closure(T): Tu) $closure
+     *
      * @param-immediately-invoked-callable $closure
+     *
      * @param (Closure(): Tu) $default
+     *
      * @param-immediately-invoked-callable $default
      *
      * @return Option<Tu>
@@ -424,6 +438,7 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      *
      * @param Option<Tu> $other The Option to zip with.
      * @param (Closure(T, Tu): Tr) $closure The closure to apply to the values.
+     *
      * @param-immediately-invoked-callable $closure
      *
      * @return Option<Tr> The new `Option` containing the result of applying the closure to the values,

--- a/tests/unit/DateTime/DateTimeTest.php
+++ b/tests/unit/DateTime/DateTimeTest.php
@@ -194,6 +194,44 @@ final class DateTimeTest extends TestCase
         static::assertSame(1, $new->getNanoseconds());
     }
 
+    public function testPlusMonthsEdgeCases(): void
+    {
+        $jan_31th = DateTime::fromParts(Timezone::default(), 2024, Month::January, 31, 14, 0, 0, 0);
+        $febr_29th = $jan_31th->plusMonths(1);
+        static::assertSame([2024, 2, 29], $febr_29th->getDate());
+        static::assertSame([14, 0, 0, 0], $febr_29th->getTime());
+
+        $dec_31th = DateTime::fromParts(Timezone::default(), 2023, Month::December, 31, 14, 0, 0, 0);
+        $march_31th = $dec_31th->plusMonths(3);
+        static::assertSame([2024, 3, 31], $march_31th->getDate());
+        static::assertSame([14, 0, 0, 0], $march_31th->getTime());
+
+        $april_30th = $march_31th->plusMonths(1);
+        static::assertSame([2024, 4, 30], $april_30th->getDate());
+        static::assertSame([14, 0, 0, 0], $april_30th->getTime());
+
+        $april_30th_next_year = $april_30th->plusYears(1);
+        static::assertSame([2025, 4, 30], $april_30th_next_year->getDate());
+        static::assertSame([14, 0, 0, 0], $april_30th_next_year->getTime());
+    }
+
+    public function testPlusMonthOverflows(): void
+    {
+        $jan_31th_2024 = DateTime::fromParts(Timezone::default(), 2024, Month::January, 31, 14, 0, 0, 0);
+        $previous_month = 1;
+        for ($i = 1; $i < 24; $i++) {
+            $res = $jan_31th_2024->plusMonths($i);
+
+            $expected_month = ($previous_month + 1) % 12;
+            $expected_month = $expected_month === 0 ? 12 : $expected_month;
+
+            static::assertSame($res->getDay(), $res->getMonthEnum()->getDaysForYear($res->getYear()));
+            static::assertSame($res->getMonth(), $expected_month);
+
+            $previous_month = $expected_month;
+        }
+    }
+
     public function testMinusMethods(): void
     {
         $datetime = DateTime::fromParts(Timezone::default(), 2024, Month::February, 4, 14, 0, 0, 0);
@@ -218,6 +256,57 @@ final class DateTimeTest extends TestCase
 
         $new = $datetime->minusNanoseconds(1);
         static::assertSame(999999999, $new->getNanoseconds());
+    }
+
+    public function testMinusMonthsEdgeCases(): void
+    {
+        $febr_29th = DateTime::fromParts(Timezone::default(), 2024, Month::February, 29, 14, 0, 0, 0);
+        $jan_29th = $febr_29th->minusMonths(1);
+        static::assertSame([2024, 1, 29], $jan_29th->getDate());
+        static::assertSame([14, 0, 0, 0], $jan_29th->getTime());
+
+        $febr_28th_previous_year = $febr_29th->minusYears(1);
+        static::assertSame([2023, 2, 28], $febr_28th_previous_year->getDate());
+        static::assertSame([14, 0, 0, 0], $febr_28th_previous_year->getTime());
+
+        $febr_29th_previous_leap_year = $febr_29th->minusYears(4);
+        static::assertSame([2020, 2, 29], $febr_29th_previous_leap_year->getDate());
+        static::assertSame([14, 0, 0, 0], $febr_29th_previous_leap_year->getTime());
+
+        $march_31th = DateTime::fromParts(Timezone::default(), 2024, Month::March, 31, 14, 0, 0, 0);
+        $dec_31th = $march_31th->minusMonths(3);
+        static::assertSame([2023, 12, 31], $dec_31th->getDate());
+        static::assertSame([14, 0, 0, 0], $dec_31th->getTime());
+
+        $jan_31th = $march_31th->minusMonths(2);
+        static::assertSame([2024, 1, 31], $jan_31th->getDate());
+        static::assertSame([14, 0, 0, 0], $jan_31th->getTime());
+
+        $may_31th = DateTime::fromParts(Timezone::default(), 2024, Month::May, 31, 14, 0, 0, 0);
+        $april_30th = $may_31th->minusMonths(1);
+        static::assertSame([2024, 4, 30], $april_30th->getDate());
+        static::assertSame([14, 0, 0, 0], $april_30th->getTime());
+
+        $april_30th_previous_year = $april_30th->minusYears(1);
+        static::assertSame([2023, 4, 30], $april_30th_previous_year->getDate());
+        static::assertSame([14, 0, 0, 0], $april_30th_previous_year->getTime());
+    }
+
+    public function testMinusMonthOverflows(): void
+    {
+        $jan_31th_2024 = DateTime::fromParts(Timezone::default(), 2024, Month::January, 31, 14, 0, 0, 0);
+        $previous_month = 1;
+        for ($i = 1; $i < 24; $i++) {
+            $res = $jan_31th_2024->minusMonths($i);
+
+            $expected_month = $previous_month - 1;
+            $expected_month = $expected_month === 0 ? 12 : $expected_month;
+
+            static::assertSame($res->getDay(), $res->getMonthEnum()->getDaysForYear($res->getYear()));
+            static::assertSame($res->getMonth(), $expected_month);
+
+            $previous_month = $expected_month;
+        }
     }
 
     public function testIsLeapYear(): void


### PR DESCRIPTION
As mentioned in 

* https://github.com/azjezz/psl/pull/446#discussion_r1558855675
* https://github.com/azjezz/psl/pull/446#discussion_r1560977706

This PR introduces a way of adding and subsctracting months that is more in line with how you would do it as a human, rather than a computer.


I know you told me a few times:

> The behaviour there is still the same, i personally think it is okay. its not broken. as there is no "standard" way of doing things here, every lib / lang does something that is completely different


However, I hope you consider taking this approach when it's just a "merge" button click away :)