### PR TITLE
Move nonnull type to public namespace

### DIFF
--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -699,7 +699,7 @@ final class Loader
         'Psl\\Type\\Internal\\IterableType' => 'Psl/Type/Internal/IterableType.php',
         'Psl\\Type\\Internal\\MixedType' => 'Psl/Type/Internal/MixedType.php',
         'Psl\\Type\\Internal\\NullType' => 'Psl/Type/Internal/NullType.php',
-        'Psl\\Type\\Internal\\NonNullType' => 'Psl/Type/Internal/NonNullType.php',
+        'Psl\\Type\\NonNullType' => 'Psl/Type/Internal/NonNullType.php',
         'Psl\\Type\\Internal\\NullableType' => 'Psl/Type/Internal/NullableType.php',
         'Psl\\Type\\Internal\\OptionalType' => 'Psl/Type/Internal/OptionalType.php',
         'Psl\\Type\\Internal\\PositiveIntType' => 'Psl/Type/Internal/PositiveIntType.php',

--- a/src/Psl/Type/NonNullType.php
+++ b/src/Psl/Type/NonNullType.php
@@ -2,18 +2,19 @@
 
 declare(strict_types=1);
 
-namespace Psl\Type\Internal;
+namespace Psl\Type;
 
 use Psl\Type;
 use Psl\Type\Exception\AssertException;
 use Psl\Type\Exception\CoercionException;
 
 /**
+ * This type is not marked as internal, cause the class is being leaked by the nonnull() function.
+ * This is necessary to get coerce and assert narrow down the type without psalm having a TNonNull type.
+ *
  * @ara-extends Type\Type<nonnull>
  *
  * @extends Type\Type<mixed>
- *
- * @internal
  */
 final readonly class NonNullType extends Type\Type
 {

--- a/src/Psl/Type/nonnull.php
+++ b/src/Psl/Type/nonnull.php
@@ -4,21 +4,19 @@ declare(strict_types=1);
 
 namespace Psl\Type;
 
-use Psl\Type\Internal\NonNullType;
-
 /**
  * @psalm-pure
  *
  * @psalm-suppress ImpureStaticVariable - The $instance is always the same and is considered pure.
  *
- * @ara-return TypeInterface<nonnull>
+ * @ara-return NonNullType
  *
  * @return NonNullType
  */
-function nonnull(): TypeInterface
+function nonnull(): NonNullType
 {
-    /** @var Internal\NonNullType $instance */
-    static $instance = new Internal\NonNullType();
+    /** @var NonNullType $instance */
+    static $instance = new NonNullType();
 
     return $instance;
 }


### PR DESCRIPTION
Currently, the hack in the nonnull type results in a psalm issue when it's being used:

![nonnullissue](https://github.com/azjezz/psl/assets/1618158/5b8ea99b-0b3f-499f-939d-2ff5da614d4b)

This PR moves the NonNull type out of the internal namespace to overcome this problem.


