### PR TITLE
fix: update filepath for NonNullType

### DIFF
--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -708,7 +708,7 @@ final class Loader
         'Psl\\Type\\Internal\\IterableType' => 'Psl/Type/Internal/IterableType.php',
         'Psl\\Type\\Internal\\MixedType' => 'Psl/Type/Internal/MixedType.php',
         'Psl\\Type\\Internal\\NullType' => 'Psl/Type/Internal/NullType.php',
-        'Psl\\Type\\NonNullType' => 'Psl/Type/Internal/NonNullType.php',
+        'Psl\\Type\\NonNullType' => 'Psl/Type/NonNullType.php',
         'Psl\\Type\\Internal\\NullableType' => 'Psl/Type/Internal/NullableType.php',
         'Psl\\Type\\Internal\\OptionalType' => 'Psl/Type/Internal/OptionalType.php',
         'Psl\\Type\\Internal\\PositiveIntType' => 'Psl/Type/Internal/PositiveIntType.php',


### PR DESCRIPTION
As mentioned in the issue -> https://github.com/azjezz/psl/issues/487 the file has been moved to the global type directory (https://github.com/azjezz/psl/pull/478). But the filepath location was not updated, only the namespace. So now the file could not be loaded which leads into errors.

So i updated also the file location in this pr.