### PR TITLE
fix: remove loading of not existing class Interval from Loader

### DIFF
--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -871,7 +871,6 @@ final class Loader
         'Psl\\DateTime\\Exception\\ParserException' => 'Psl/DateTime/Exception/ParserException.php',
         'Psl\\DateTime\\Exception\\UnderflowException' => 'Psl/DateTime/Exception/UnderflowException.php',
         'Psl\\DateTime\\DateTime' => 'Psl/DateTime/DateTime.php',
-        'Psl\\DateTime\\Duration' => 'Psl/DateTime/Interval.php',
         'Psl\\DateTime\\Timestamp' => 'Psl/DateTime/Timestamp.php',
     ];
 


### PR DESCRIPTION
As mentioned in issue Interval does not existing: https://github.com/azjezz/psl/issues/489

Additional to that i executed the preloading, to check if there are more errors.

![image](https://github.com/user-attachments/assets/9aefb040-f4ae-43b5-b4e2-4ed634ff3d4c)

It looks everything is fixed.
