### PR TITLE
fix: change duration to load the correct class in loader

### DIFF
--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -871,7 +871,7 @@ final class Loader
         'Psl\\DateTime\\Exception\\ParserException' => 'Psl/DateTime/Exception/ParserException.php',
         'Psl\\DateTime\\Exception\\UnderflowException' => 'Psl/DateTime/Exception/UnderflowException.php',
         'Psl\\DateTime\\DateTime' => 'Psl/DateTime/DateTime.php',
-        'Psl\\DateTime\\Duration' => 'Psl/DateTime/Interval.php',
+        'Psl\\DateTime\\Duration' => 'Psl/DateTime/Duration.php',
         'Psl\\DateTime\\Timestamp' => 'Psl/DateTime/Timestamp.php',
     ];
 


### PR DESCRIPTION
Loader was fixed as mentioned in https://github.com/azjezz/psl/issues/489.

Additional to that i test to load the preload.php, and don't get any other issues.

![image](https://github.com/user-attachments/assets/7f2d620d-3f89-4300-9346-a1a47b391bdc)


To check if i got before errors, i run the command without the changes.
```
➜  psl git:(next) php src/preload.php
PHP Warning:  require_once(/dev/psl/src/Psl/DateTime/Interval.php): Failed to open stream: No such file or directory in /dev/psl/src/Psl/Internal/Loader.php on line 943

Warning: require_once(/dev/psl/src/Psl/DateTime/Interval.php): Failed to open stream: No such file or directory in /dev/psl/src/Psl/Internal/Loader.php on line 943
PHP Fatal error:  Uncaught Error: Failed opening required '/dev/psl/src/Psl/DateTime/Interval.php' (include_path='.:/opt/homebrew/Cellar/php/8.3.11/share/php/pear') in /dev/psl/src/Psl/Internal/Loader.php:943
Stack trace:
#0 /dev/psl/src/Psl/Internal/Loader.php(954): Psl\Internal\Loader::load('Psl/DateTime/In...')
#1 [internal function]: Psl\Internal\Loader::Psl\Internal\{closure}('Psl\\DateTime\\Du...')
#2 /dev/psl/src/Psl/Internal/Loader.php(1011): class_exists('Psl\\DateTime\\Du...')
#3 /dev/psl/src/Psl/Internal/Loader.php(936): Psl\Internal\Loader::loadClasses()
#4 /dev/psl/src/Psl/Internal/Loader.php(960): Psl\Internal\Loader::Psl\Internal\{closure}()
#5 /dev/psl/src/Psl/Internal/Loader.php(932): Psl\Internal\Loader::autoload(Object(Closure))
#6 /dev/psl/src/preload.php(9): Psl\Internal\Loader::preload()
#7 {main}
  thrown in /dev/psl/src/Psl/Internal/Loader.php on line 943

Fatal error: Uncaught Error: Failed opening required '/dev/psl/src/Psl/DateTime/Interval.php' (include_path='.:/opt/homebrew/Cellar/php/8.3.11/share/php/pear') in /dev/psl/src/Psl/Internal/Loader.php:943
Stack trace:
#0 /dev/psl/src/Psl/Internal/Loader.php(954): Psl\Internal\Loader::load('Psl/DateTime/In...')
#1 [internal function]: Psl\Internal\Loader::Psl\Internal\{closure}('Psl\\DateTime\\Du...')
#2 /dev/psl/src/Psl/Internal/Loader.php(1011): class_exists('Psl\\DateTime\\Du...')
#3 /dev/psl/src/Psl/Internal/Loader.php(936): Psl\Internal\Loader::loadClasses()
#4 /dev/psl/src/Psl/Internal/Loader.php(960): Psl\Internal\Loader::Psl\Internal\{closure}()
#5 /dev/psl/src/Psl/Internal/Loader.php(932): Psl\Internal\Loader::autoload(Object(Closure))
#6 /dev/psl/src/preload.php(9): Psl\Internal\Loader::preload()
#7 {main}
  thrown in /dev/psl/src/Psl/Internal/Loader.php on line 943
```