### PR TITLE
Allow iterable for Vec\concat first argument

### DIFF
--- a/src/Psl/Vec/concat.php
+++ b/src/Psl/Vec/concat.php
@@ -9,12 +9,12 @@ namespace Psl\Vec;
  *
  * @template T
  *
- * @param list<T> $first
+ * @param iterable<T> $first
  * @param iterable<T> ...$rest
  *
  * @return list<T>
  */
-function concat(array $first, iterable ...$rest): array
+function concat(iterable $first, iterable ...$rest): array
 {
     $first = values($first);
     foreach ($rest as $arr) {


### PR DESCRIPTION
I am not sure why `Psl\Vec\concat()` only accepts `array` as the first argument instead of `iterable`. It seems an oversite. All other function from `Psl\Vec` allow it and there is nothing special in the implemenation to not support `iterable`