### PR TITLE
Add IS0-8601 and RFC-3339 pattern without microsecond fraction

### DIFF
--- a/src/Psl/DateTime/FormatPattern.php
+++ b/src/Psl/DateTime/FormatPattern.php
@@ -16,6 +16,7 @@ enum FormatPattern: string implements DefaultInterface
 {
     case Rfc2822 = 'EEE, dd MMM yyyy HH:mm:ss Z';
     case Iso8601 = 'yyyy-MM-dd\'T\'HH:mm:ss.SSSXXX';
+    case Iso8601WithoutMicroseconds = 'yyyy-MM-dd\'T\'HH:mm:ssXXX';
     case Http = 'EEE, dd MMM yyyy HH:mm:ss zzz';
     case Cookie = 'EEEE, dd-MMM-yyyy HH:mm:ss zzz';
     case SqlDate = 'yyyy-MM-dd';
@@ -25,6 +26,7 @@ enum FormatPattern: string implements DefaultInterface
     case IsoOrdinalDate = 'yyyy-DDD';
     case JulianDay = 'yyyy DDD';
     case Rfc3339 = 'yyyy-MM-dd\'T\'HH:mm:ss.SSSZZZZZ';
+    case Rfc3339WithoutMicroseconds = 'yyyy-MM-dd\'T\'HH:mm:ssZZZZZ';
     case UnixTimestamp = 'U';
     case SimpleDate = 'dd/MM/yyyy';
     case American = 'MM/dd/yyyy';


### PR DESCRIPTION
In both ISO-8601 and RFC-3339, the microseconds part (decimal fraction) is optional.

* https://www.ietf.org/rfc/rfc3339.txt - See 5.6
* https://www.ionos.com/digitalguide/websites/web-development/iso-8601/ - See basic principles.

In this PR, I introduce 2 more options for these patterns without microseconds.
This makes it interopable with the default PHP date formats (atom, iso-8601 and expanded, DATE_RFC3339 and expanded)

The ISO standard goes even further and makes seconds optional, 2-year digits possible, ... 
That is out of scope for now.