### PR TITLE
feat(type): add `int_range` type

### DIFF
--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -348,6 +348,7 @@ final class Loader
         'Psl\\Type\\array_key' => 'Psl/Type/array_key.php',
         'Psl\\Type\\bool' => 'Psl/Type/bool.php',
         'Psl\\Type\\float' => 'Psl/Type/float.php',
+        'Psl\\Type\\int_range' => 'Psl/Type/int_range.php',
         'Psl\\Type\\int' => 'Psl/Type/int.php',
         'Psl\\Type\\intersection' => 'Psl/Type/intersection.php',
         'Psl\\Type\\iterable' => 'Psl/Type/iterable.php',

--- a/src/Psl/Type/Internal/IntRangeType.php
+++ b/src/Psl/Type/Internal/IntRangeType.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Type;
+use Psl\Type\Exception\AssertException;
+use Psl\Type\Exception\CoercionException;
+use Stringable;
+
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
+
+/**
+ * @extends Type\Type<int>
+ *
+ * @internal
+ */
+final readonly class IntRangeType extends Type\Type
+{
+    public function __construct(
+        private int $min,
+        private int $max,
+    ) {
+    }
+
+    /**
+     * @psalm-assert-if-true int $value
+     */
+    #[\Override]
+    public function matches(mixed $value): bool
+    {
+        return is_int($value) && $value >= $this->min && $value <= $this->max;
+    }
+
+    /**
+     * @throws CoercionException
+     */
+    #[\Override]
+    public function coerce(mixed $value): int
+    {
+        $int = $this->coerceToInt($value);
+        if ($int >= $this->min && $int <= $this->max) {
+            return $int;
+        }
+
+        throw CoercionException::withValue($value, $this->toString());
+    }
+
+    /**
+     * @throws CoercionException
+     * @return int<min, max>
+     */
+    private function coerceToInt(mixed $value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_float($value)) {
+            $integer_value = (int) $value;
+            if (((float) $integer_value) === $value) {
+                return $integer_value;
+            }
+        }
+
+        if (is_string($value) || $value instanceof Stringable) {
+            $str = (string) $value;
+            $int = (int) $str;
+            if ($str === ((string) $int)) {
+                return $int;
+            }
+
+            $trimmed = ltrim($str, '0');
+            $int = (int) $trimmed;
+            if ($trimmed === ((string) $int)) {
+                return $int;
+            }
+
+            // Exceptional case "000" -(trim)-> "", but we want to return 0
+            if ('' === $trimmed && '' !== $str) {
+                return 0;
+            }
+        }
+
+        throw CoercionException::withValue($value, $this->toString());
+    }
+
+    /**
+     * @psalm-assert int $value
+     *
+     * @throws AssertException
+     */
+    #[\Override]
+    public function assert(mixed $value): int
+    {
+        if (is_int($value) && $value >= $this->min && $value <= $this->max) {
+            return $value;
+        }
+
+        throw AssertException::withValue($value, $this->toString());
+    }
+
+    #[\Override]
+    public function toString(): string
+    {
+        $min = $this->min === PHP_INT_MIN ? 'min' : ((string) $this->min);
+        $max = $this->max === PHP_INT_MAX ? 'max' : ((string) $this->max);
+
+        return sprintf('int<%s, %s>', $min, $max);
+    }
+}

--- a/src/Psl/Type/README.md
+++ b/src/Psl/Type/README.md
@@ -444,6 +444,21 @@ Type\instance_of(SomeInterface::class)->assert($someImplementation);
 
 ---
 
+#### [int_range](int_range.php)
+
+```hack
+@pure
+Type\int_range(10, 42): TypeInterface<int<10, 42>>
+```
+
+Provides a type that can parse integers with a user defined range.
+
+Can coerce from:
+
+* This type will use the same coercion rules as the [`int()`](#int) type whilst guarding the integer range.
+
+---
+
 #### [int](int.php)
 
 ```hack

--- a/src/Psl/Type/int_range.php
+++ b/src/Psl/Type/int_range.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @return TypeInterface<int>
+ */
+function int_range(int $min, int $max): TypeInterface
+{
+    return new Internal\IntRangeType($min, $max);
+}

--- a/tests/unit/Type/IntRangeTypeTest.php
+++ b/tests/unit/Type/IntRangeTypeTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Type;
+
+use Psl\Math;
+use Psl\Type;
+
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
+
+final class IntRangeTypeTest extends TypeTest
+{
+    public function getType(): Type\TypeInterface
+    {
+        return Type\int_range(Math\INT64_MIN, Math\INT64_MAX);
+    }
+
+    public function getValidCoercions(): iterable
+    {
+        yield [42, 42];
+        yield [-42, -42];
+        yield [0, 0];
+        yield ['0', 0];
+        yield ['42', 42];
+        yield ['-42', -42];
+        yield [$this->stringable('42'), 42];
+        yield [$this->stringable((string) Math\INT64_MAX), Math\INT64_MAX];
+        yield [(string) Math\INT64_MAX, Math\INT64_MAX];
+        yield [Math\INT64_MAX, Math\INT64_MAX];
+        yield ['7', 7];
+        yield ['07', 7];
+        yield ['007', 7];
+        yield ['000', 0];
+        yield [1.0, 1];
+    }
+
+    public function getInvalidCoercions(): iterable
+    {
+        yield [1.23];
+        yield ['1.23'];
+        yield ['1e123'];
+        yield [''];
+        yield [[]];
+        yield [[123]];
+        yield [null];
+        yield [false];
+        yield [$this->stringable('1.23')];
+        yield [$this->stringable('-007')];
+        yield ['-007'];
+        yield ['9223372036854775808'];
+        yield [$this->stringable('9223372036854775808')];
+        yield ['-9223372036854775809'];
+        yield [$this->stringable('-9223372036854775809')];
+        yield ['0xFF'];
+    }
+
+    public function getToStringExamples(): iterable
+    {
+        yield [Type\int_range(5, 10), 'int<5, 10>'];
+        yield [Type\int_range(PHP_INT_MIN, PHP_INT_MAX), 'int<min, max>'];
+        yield [Type\int_range(99, PHP_INT_MAX), 'int<99, max>'];
+        yield [Type\int_range(PHP_INT_MIN, 42), 'int<min, 42>'];
+    }
+
+    public static function outOfBoundsProvider(): iterable
+    {
+        yield [123];
+        yield ['123'];
+        yield [-10];
+        yield ['-10'];
+    }
+
+    /** @dataProvider outOfBoundsProvider */
+    public function testCoerceWithLowerBounds(mixed $value): void
+    {
+        $type = Type\int_range(0, 100);
+        $this->expectException(Type\Exception\CoercionException::class);
+        $this->expectExceptionMessage('int<0, 100>');
+        $type->coerce($value);
+    }
+
+    /** @dataProvider outOfBoundsProvider */
+    public function testMatchesWithLowerBounds(mixed $value): void
+    {
+        $type = Type\int_range(0, 100);
+        static::assertFalse($type->matches($value));
+    }
+
+    /** @dataProvider outOfBoundsProvider */
+    public function testAssertWithLowerBounds(mixed $value): void
+    {
+        $type = Type\int_range(0, 100);
+        $this->expectException(Type\Exception\AssertException::class);
+        $type->assert($value);
+    }
+}


### PR DESCRIPTION
Ref #390 

Unfortunately, Psalm does not appear to support templates in int ranges, i.e. `int<TMin, TMax>`

What's the best thing to do here? reduce the templates to `int` and do something in the psalm plugin?