### PR TITLE
chore(collection): use a more natural JSON serialization for Sets and Maps

### DIFF
--- a/docs/component/collection.md
+++ b/docs/component/collection.md
@@ -28,10 +28,10 @@
 #### `Classes`
 
 - [Map](./../../src/Psl/Collection/Map.php#L25)
-- [MutableMap](./../../src/Psl/Collection/MutableMap.php#L25)
-- [MutableSet](./../../src/Psl/Collection/MutableSet.php#L22)
+- [MutableMap](./../../src/Psl/Collection/MutableMap.php#L26)
+- [MutableSet](./../../src/Psl/Collection/MutableSet.php#L23)
 - [MutableVector](./../../src/Psl/Collection/MutableVector.php#L24)
-- [Set](./../../src/Psl/Collection/Set.php#L23)
+- [Set](./../../src/Psl/Collection/Set.php#L24)
 - [Vector](./../../src/Psl/Collection/Vector.php#L22)
 
 

--- a/src/Psl/Collection/CollectionInterface.php
+++ b/src/Psl/Collection/CollectionInterface.php
@@ -49,14 +49,31 @@ interface CollectionInterface extends Countable, DefaultInterface, IteratorAggre
     public function toArray(): array;
 
     /**
-     * Get an array copy of the current collection.
+     * Prepare the collection for JSON serialization.
      *
-     * @return array<Tk, Tv>
+     * This method is responsible for defining how the collection should be
+     * represented when encoded to JSON using `json_encode()`.
+     *
+     * The returned value must be a valid PHP data type that can be serialized
+     * into JSON. This can be an array, an object, or any other type that accurately represents
+     * the collection's data structure and contents in JSON format.
+     *
+     * Implementations should choose a representation (JSON array `[]` or JSON object `{}`)
+     * that best reflects the nature of the collection.
+     * For example:
+     * - A numerically indexed sequence of elements might be best represented as a JSON array.
+     * - A collection with key-value pairs might be better represented as a JSON object.
+     *
+     * The key goal is to ensure that the serialized JSON accurately reflects the
+     * logical structure and data within the collection.
+     *
+     * @return mixed  A PHP value representing the collection for JSON serialization.
+     *               This value will be passed to `json_encode()` to produce the final JSON output.
      *
      * @psalm-mutation-free
      */
     #[\Override]
-    public function jsonSerialize(): array;
+    public function jsonSerialize(): mixed;
 
     /**
      * Returns a `CollectionInterface` containing the values of the current `CollectionInterface`

--- a/src/Psl/Collection/Map.php
+++ b/src/Psl/Collection/Map.php
@@ -220,16 +220,24 @@ final readonly class Map implements MapInterface
     }
 
     /**
-     * Get an array copy of the current map.
+     * Returns the map's elements as an object.
      *
-     * @return array<Tk, Tv>
+     * This ensures that the map is always serialized as a JSON object ({}) and not a JSON array ([]).
+     *
+     * PHP's `json_encode` serializes empty arrays as `[]`.  Also, arrays with sequential integer keys starting
+     * from 0 are serialized  as JSON arrays too, like `[0 => 'a', 1 => 'b']` becoming `['a', 'b']`.
+     *
+     * By casting to an object, we guarantee that the map will always be a JSON object `{}` when serialized,
+     * even if empty or having sequential integer keys.
+     *
+     * @return object
      *
      * @psalm-mutation-free
      */
     #[\Override]
-    public function jsonSerialize(): array
+    public function jsonSerialize(): object
     {
-        return $this->elements;
+        return (object) $this->elements;
     }
 
     /**

--- a/src/Psl/Collection/MutableMap.php
+++ b/src/Psl/Collection/MutableMap.php
@@ -7,6 +7,7 @@ namespace Psl\Collection;
 use Closure;
 use Psl\Dict;
 use Psl\Iter;
+use stdClass;
 
 use function array_key_exists;
 use function array_key_first;
@@ -220,16 +221,24 @@ final class MutableMap implements MutableMapInterface
     }
 
     /**
-     * Get an array copy of the current map.
+     * Returns the map's elements as an object.
      *
-     * @return array<Tk, Tv>
+     * This ensures that the map is always serialized as a JSON object ({}) and not a JSON array ([]).
+     *
+     * PHP's `json_encode` serializes empty arrays as `[]`.  Also, arrays with sequential integer keys starting
+     * from 0 are serialized  as JSON arrays too, like `[0 => 'a', 1 => 'b']` becoming `['a', 'b']`.
+     *
+     * By casting to an object, we guarantee that the map will always be a JSON object `{}` when serialized,
+     * even if empty or having sequential integer keys.
+     *
+     * @return object
      *
      * @psalm-mutation-free
      */
     #[\Override]
-    public function jsonSerialize(): array
+    public function jsonSerialize(): object
     {
-        return $this->elements;
+        return (object) $this->elements;
     }
 
     /**

--- a/src/Psl/Collection/MutableSet.php
+++ b/src/Psl/Collection/MutableSet.php
@@ -12,6 +12,7 @@ use Psl\Vec;
 use function array_key_exists;
 use function array_key_first;
 use function array_key_last;
+use function array_values;
 use function count;
 
 /**

--- a/src/Psl/Collection/MutableSet.php
+++ b/src/Psl/Collection/MutableSet.php
@@ -194,14 +194,14 @@ final class MutableSet implements MutableSetInterface
     /**
      * Get an array copy of the current `MutableSet`.
      *
-     * @return array<T, T>
+     * @return array<T>
      *
      * @psalm-mutation-free
      */
     #[\Override]
     public function jsonSerialize(): array
     {
-        return $this->elements;
+        return array_values($this->elements);
     }
 
     /**

--- a/src/Psl/Collection/Set.php
+++ b/src/Psl/Collection/Set.php
@@ -195,14 +195,14 @@ final readonly class Set implements SetInterface
     /**
      * Get an array copy of the current `Set`.
      *
-     * @return array<T, T>
+     * @return array<T>
      *
      * @psalm-mutation-free
      */
     #[\Override]
     public function jsonSerialize(): array
     {
-        return $this->elements;
+        return array_values($this->elements);
     }
 
     /**

--- a/src/Psl/Collection/Set.php
+++ b/src/Psl/Collection/Set.php
@@ -13,6 +13,7 @@ use function array_key_exists;
 use function array_key_first;
 use function array_key_last;
 use function array_keys;
+use function array_values;
 use function count;
 
 /**

--- a/tests/unit/Collection/AbstractMapTest.php
+++ b/tests/unit/Collection/AbstractMapTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Psl\Collection;
 use Psl\Collection\MapInterface;
 use Psl\Collection\VectorInterface;
+use Psl\Json;
 use Psl\Str;
 
 abstract class AbstractMapTest extends TestCase
@@ -85,13 +86,25 @@ abstract class AbstractMapTest extends TestCase
             'baz' => 3,
         ]);
 
-        $array = $map->jsonSerialize();
+        $array = (array) $map->jsonSerialize();
 
         static::assertSame([
             'foo' => 1,
             'bar' => 2,
             'baz' => 3,
         ], $array);
+    }
+
+    public function testJsonRepresentation(): void
+    {
+        $assert = function (array $array, string $expected): void {
+            static::assertSame($expected, Json\encode($this->create($array), pretty: false));
+        };
+
+        $assert([], '{}');
+        $assert(['foo' => 'bar'], '{"foo":"bar"}');
+        $assert(['foo' => 'bar', 'baz' => 'qux'], '{"foo":"bar","baz":"qux"}');
+        $assert([1 => 2, 3 => 4], '{"1":2,"3":4}');
     }
 
     public function testKeys(): void

--- a/tests/unit/Collection/MutableSetTest.php
+++ b/tests/unit/Collection/MutableSetTest.php
@@ -161,6 +161,13 @@ final class MutableSetTest extends AbstractSetTest
         static::assertTrue($set->contains('baz'));
     }
 
+    public function testJsonSerialize(): void
+    {
+        $set = $this->createFromList(['foo', 'bar', 'baz', 'qux']);
+
+        static::assertEquals(['foo', 'bar', 'baz', 'qux'], $set->jsonSerialize());
+    }
+
     /**
      * @template T of array-key
      *

--- a/tests/unit/Collection/SetTest.php
+++ b/tests/unit/Collection/SetTest.php
@@ -45,4 +45,11 @@ final class SetTest extends AbstractSetTest
         static::assertTrue($set->contains('bar'));
         static::assertTrue($set->contains('baz'));
     }
+
+    public function testJsonSerialize(): void
+    {
+        $set = $this->createFromList(['foo', 'bar', 'baz', 'qux']);
+
+        static::assertEquals(['foo', 'bar', 'baz', 'qux'], $set->jsonSerialize());
+    }
 }


### PR DESCRIPTION
This adjusts the methods `Set::jsonSerialize()` and `MutableSet::jsonSerialize()` to return list-like arrays that `json_encode()` (with default flags) will encode as a JSON array rather than as a JSON object. This is arguably a more natural representation of a set than the classes' internal representations, which have keys that equal their corresponding values. If nothing else, it's more in line with the serialization done in Hack for the `keyset` type, and it's less redundant.

For example:

```php
$s = new Psl\Collection\Set(['foo', 'bar']);
$serialized = $s->jsonSerialize();

var_export($serialized);
echo PHP_EOL;
echo 'JSON: '.json_encode($serialized);
```

Formerly, this would have output the following:

```
array (
  'foo' => 'foo',
  'bar' => 'bar',
)
JSON: {"foo":"foo","bar":"bar"}
```

But now it will output this:

```
array (
  0 => 'foo',
  1 => 'bar',
)
JSON: ["foo","bar"]
```
