### PR TITLE
feat: make immutable collections array accessible

### DIFF
--- a/docs/component/collection.md
+++ b/docs/component/collection.md
@@ -12,11 +12,11 @@
 
 #### `Interfaces`
 
-- [AccessibleCollectionInterface](./../../src/Psl/Collection/AccessibleCollectionInterface.php#L20)
+- [AccessibleCollectionInterface](./../../src/Psl/Collection/AccessibleCollectionInterface.php#L22)
 - [CollectionInterface](./../../src/Psl/Collection/CollectionInterface.php#L23)
 - [IndexAccessInterface](./../../src/Psl/Collection/IndexAccessInterface.php#L13)
 - [MapInterface](./../../src/Psl/Collection/MapInterface.php#L15)
-- [MutableAccessibleCollectionInterface](./../../src/Psl/Collection/MutableAccessibleCollectionInterface.php#L23)
+- [MutableAccessibleCollectionInterface](./../../src/Psl/Collection/MutableAccessibleCollectionInterface.php#L22)
 - [MutableCollectionInterface](./../../src/Psl/Collection/MutableCollectionInterface.php#L22)
 - [MutableIndexAccessInterface](./../../src/Psl/Collection/MutableIndexAccessInterface.php#L16)
 - [MutableMapInterface](./../../src/Psl/Collection/MutableMapInterface.php#L16)
@@ -27,11 +27,11 @@
 
 #### `Classes`
 
-- [Map](./../../src/Psl/Collection/Map.php#L25)
+- [Map](./../../src/Psl/Collection/Map.php#L27)
 - [MutableMap](./../../src/Psl/Collection/MutableMap.php#L26)
 - [MutableSet](./../../src/Psl/Collection/MutableSet.php#L23)
 - [MutableVector](./../../src/Psl/Collection/MutableVector.php#L24)
-- [Set](./../../src/Psl/Collection/Set.php#L24)
-- [Vector](./../../src/Psl/Collection/Vector.php#L22)
+- [Set](./../../src/Psl/Collection/Set.php#L26)
+- [Vector](./../../src/Psl/Collection/Vector.php#L24)
 
 

--- a/src/Psl/Collection/AccessibleCollectionInterface.php
+++ b/src/Psl/Collection/AccessibleCollectionInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\Collection;
 
+use ArrayAccess;
 use Closure;
 
 /**
@@ -16,8 +17,9 @@ use Closure;
  *
  * @extends CollectionInterface<Tk, Tv>
  * @extends IndexAccessInterface<Tk, Tv>
+ * @extends ArrayAccess<Tk, Tv>
  */
-interface AccessibleCollectionInterface extends CollectionInterface, IndexAccessInterface
+interface AccessibleCollectionInterface extends CollectionInterface, IndexAccessInterface, ArrayAccess
 {
     /**
      * Returns a `AccessibleCollectionInterface` containing the values of the current

--- a/src/Psl/Collection/Map.php
+++ b/src/Psl/Collection/Map.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Psl\Collection;
 
 use Closure;
+use Error;
+use Psl\Collection\Exception\RuntimeException;
 use Psl\Dict;
 use Psl\Iter;
 
@@ -611,5 +613,76 @@ final readonly class Map implements MapInterface
                     return Map::fromArray($array);
                 },
             );
+    }
+
+    /**
+     * Determines if the specified offset exists in the current map.
+     *
+     * @param mixed $offset An offset to check for.
+     *
+     * @throws Exception\InvalidOffsetException If the offset type is not valid.
+     *
+     * @return bool Returns true if the specified offset exists, false otherwise.
+     *
+     * @psalm-assert array-key $offset
+     *
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function offsetExists(mixed $offset): bool
+    {
+        if (!is_int($offset) && !is_string($offset)) {
+            throw new Exception\InvalidOffsetException(
+                'Invalid map read offset type, expected a string or an integer.',
+            );
+        }
+
+        /** @var Tk $offset - technically, we don't know if the offset is of type Tk, but we can assume it is, as this causes no "harm". */
+        return $this->contains($offset);
+    }
+
+    /**
+     * Returns the value at the specified offset.
+     *
+     * @param mixed $offset The offset to retrieve.
+     *
+     * @throws Exception\InvalidOffsetException If the offset type is not valid.
+     * @throws Exception\OutOfBoundsException If the offset is out-of-bounds.
+     *
+     * @return Tv|null The value at the specified offset, null if the offset does not exist.
+     *
+     * @psalm-mutation-free
+     *
+     * @psalm-assert array-key $offset
+     */
+    #[\Override]
+    public function offsetGet(mixed $offset): mixed
+    {
+        if (!is_int($offset) && !is_string($offset)) {
+            throw new Exception\InvalidOffsetException(
+                'Invalid map read offset type, expected a string or an integer.',
+            );
+        }
+
+        /** @var Tk $offset - technically, we don't know if the offset is of type Tk, but we can assume it is, as this causes no "harm". */
+        return $this->at($offset);
+    }
+
+    /**
+     * @throws Error
+     */
+    #[\Override]
+    public function offsetSet(mixed $offset, mixed $value): never
+    {
+        throw new Error(sprintf('Cannot use object of type %s as array', get_class($this)));
+    }
+
+    /**
+     * @throws Error
+     */
+    #[\Override]
+    public function offsetUnset(mixed $offset): never
+    {
+        throw new Error(sprintf('Cannot use object of type %s as array', get_class($this)));
     }
 }

--- a/src/Psl/Collection/MutableAccessibleCollectionInterface.php
+++ b/src/Psl/Collection/MutableAccessibleCollectionInterface.php
@@ -18,11 +18,9 @@ use Closure;
  * @extends AccessibleCollectionInterface<Tk, Tv>
  * @extends MutableCollectionInterface<Tk, Tv>
  * @extends MutableIndexAccessInterface<Tk, Tv>
- * @extends ArrayAccess<Tk, Tv>
  */
 interface MutableAccessibleCollectionInterface extends
     AccessibleCollectionInterface,
-    ArrayAccess,
     MutableCollectionInterface,
     MutableIndexAccessInterface
 {

--- a/src/Psl/Collection/Set.php
+++ b/src/Psl/Collection/Set.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Psl\Collection;
 
 use Closure;
+use Error;
+use Psl\Collection\Exception\RuntimeException;
 use Psl\Dict;
 use Psl\Iter;
 use Psl\Vec;
@@ -610,5 +612,76 @@ final readonly class Set implements SetInterface
              */
             static fn(array $chunk): Set => static::fromArray($chunk),
         ));
+    }
+
+    /**
+     * Determines if the specified offset exists in the current set.
+     *
+     * @param mixed $offset An offset to check for.
+     *
+     * @throws Exception\InvalidOffsetException If the offset type is not valid.
+     *
+     * @return bool Returns true if the specified offset exists, false otherwise.
+     *
+     * @psalm-mutation-free
+     *
+     * @psalm-assert array-key $offset
+     */
+    #[\Override]
+    public function offsetExists(mixed $offset): bool
+    {
+        if (!is_int($offset) && !is_string($offset)) {
+            throw new Exception\InvalidOffsetException(
+                'Invalid set read offset type, expected a string or an integer.',
+            );
+        }
+
+        /** @var T $offset - technically, we don't know if the offset is of type T, but we can assume it is, as this causes no "harm". */
+        return $this->contains($offset);
+    }
+
+    /**
+     * Returns the value at the specified offset.
+     *
+     * @param mixed $offset The offset to retrieve.
+     *
+     * @throws Exception\InvalidOffsetException If the offset type is not array-key.
+     * @throws Exception\OutOfBoundsException If the offset does not exist.
+     *
+     * @return T The value at the specified offset.
+     *
+     * @psalm-mutation-free
+     *
+     * @psalm-assert array-key $offset
+     */
+    #[\Override]
+    public function offsetGet(mixed $offset): mixed
+    {
+        if (!is_int($offset) && !is_string($offset)) {
+            throw new Exception\InvalidOffsetException(
+                'Invalid set read offset type, expected a string or an integer.',
+            );
+        }
+
+        /** @var T $offset - technically, we don't know if the offset is of type T, but we can assume it is, as this causes no "harm". */
+        return $this->at($offset);
+    }
+
+    /**
+     * @throws Error
+     */
+    #[\Override]
+    public function offsetSet(mixed $offset, mixed $value): never
+    {
+        throw new Error(sprintf('Cannot use object of type %s as array', get_class($this)));
+    }
+
+    /**
+     * @throws Error
+     */
+    #[\Override]
+    public function offsetUnset(mixed $offset): never
+    {
+        throw new Error(sprintf('Cannot use object of type %s as array', get_class($this)));
     }
 }

--- a/src/Psl/Collection/Vector.php
+++ b/src/Psl/Collection/Vector.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Psl\Collection;
 
 use Closure;
+use Error;
+use Psl\Collection\Exception\RuntimeException;
 use Psl\Dict;
 use Psl\Iter;
 use Psl\Vec;
@@ -591,5 +593,70 @@ final readonly class Vector implements VectorInterface
              */
             static fn(array $chunk): Vector => static::fromArray($chunk),
         ));
+    }
+
+    /**
+     * Determines if the specified offset exists in the current vector.
+     *
+     * @param mixed $offset An offset to check for.
+     *
+     * @throws Exception\InvalidOffsetException If the offset type is not a positive integer.
+     *
+     * @return bool Returns true if the specified offset exists, false otherwise.
+     *
+     * @psalm-mutation-free
+     *
+     * @psalm-assert int<0, max> $offset
+     */
+    #[\Override]
+    public function offsetExists(mixed $offset): bool
+    {
+        if (!is_int($offset) || $offset < 0) {
+            throw new Exception\InvalidOffsetException('Invalid vector read offset type, expected a positive integer.');
+        }
+
+        return $this->contains($offset);
+    }
+
+    /**
+     * Returns the value at the specified offset.
+     *
+     * @param mixed $offset The offset to retrieve.
+     *
+     * @throws Exception\InvalidOffsetException If the offset type is not a positive integer.
+     * @throws Exception\OutOfBoundsException If the offset does not exist.
+     *
+     * @return T|null The value at the specified offset, null if the offset does not exist.
+     *
+     * @psalm-mutation-free
+     *
+     * @psalm-assert int<0, max> $offset
+     */
+    #[\Override]
+    public function offsetGet(mixed $offset): mixed
+    {
+        if (!is_int($offset) || $offset < 0) {
+            throw new Exception\InvalidOffsetException('Invalid vector read offset type, expected a positive integer.');
+        }
+
+        return $this->at($offset);
+    }
+
+    /**
+     * @throws Error
+     */
+    #[\Override]
+    public function offsetSet(mixed $offset, mixed $value): never
+    {
+        throw new Error(sprintf('Cannot use object of type %s as array', get_class($this)));
+    }
+
+    /**
+     * @throws Error
+     */
+    #[\Override]
+    public function offsetUnset(mixed $offset): never
+    {
+        throw new Error(sprintf('Cannot use object of type %s as array', get_class($this)));
     }
 }

--- a/tests/unit/Collection/MapTest.php
+++ b/tests/unit/Collection/MapTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\Tests\Unit\Collection;
 
+use Psl\Collection\Exception;
 use Psl\Collection\Map;
 use Psl\Collection\Vector;
 
@@ -30,6 +31,79 @@ final class MapTest extends AbstractMapTest
         static::assertSame('bar', $map->at('foo'));
         static::assertSame('baz', $map->at('bar'));
         static::assertSame('qux', $map->at('baz'));
+    }
+
+    public function testArrayAccess(): void
+    {
+        $map = $this->create([
+            'foo' => '1',
+            'bar' => '2',
+            'baz' => '3',
+        ]);
+
+        static::assertTrue(isset($map['foo']));
+        static::assertSame('1', $map['foo']);
+
+        $this->expectException(Exception\OutOfBoundsException::class);
+        $this->expectExceptionMessage('Key (124) was out-of-bounds.');
+
+        $map[124];
+    }
+
+    public function testOffsetSetThrows(): void
+    {
+        $map = $this->create([
+            'foo' => '1',
+            'bar' => '2',
+            'baz' => '3',
+        ]);
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Cannot use object of type Psl\Collection\Map as array');
+
+        $map['foo'] = 'qux';
+    }
+
+    public function testOffsetIssetThrowsForInvalidOffsetType(): void
+    {
+        $map = $this->create([
+            'foo' => '1',
+            'bar' => '2',
+            'baz' => '3',
+        ]);
+
+        $this->expectException(Exception\InvalidOffsetException::class);
+        $this->expectExceptionMessage('Invalid map read offset type, expected a string or an integer.');
+
+        isset($map[false]);
+    }
+
+    public function testOffsetUnsetThrows(): void
+    {
+        $map = $this->create([
+            'foo' => '1',
+            'bar' => '2',
+            'baz' => '3',
+        ]);
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Cannot use object of type Psl\Collection\Map as array');
+
+        unset($map['foo']);
+    }
+
+    public function testOffsetGetThrowsForInvalidOffsetType(): void
+    {
+        $map = $this->create([
+            'foo' => '1',
+            'bar' => '2',
+            'baz' => '3',
+        ]);
+
+        $this->expectException(Exception\InvalidOffsetException::class);
+        $this->expectExceptionMessage('Invalid map read offset type, expected a string or an integer.');
+
+        $map[false];
     }
 
     /**

--- a/tests/unit/Collection/SetTest.php
+++ b/tests/unit/Collection/SetTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\Tests\Unit\Collection;
 
+use Psl\Collection\Exception;
 use Psl\Collection\Set;
 
 final class SetTest extends AbstractSetTest
@@ -53,5 +54,53 @@ final class SetTest extends AbstractSetTest
         $set = $this->createFromList(['foo', 'bar', 'baz', 'qux']);
 
         static::assertSame(['foo', 'bar', 'baz', 'qux'], $set->jsonSerialize());
+    }
+
+    public function testArrayAccess(): void
+    {
+        $set = $this->createFromList(['foo', 'bar', 'baz']);
+
+        static::assertTrue(isset($set['foo']));
+        static::assertSame('foo', $set['foo']);
+    }
+
+    public function testOffsetSetThrows(): void
+    {
+        $set = $this->createFromList(['foo', 'bar', 'baz']);
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Cannot use object of type Psl\Collection\Set as array');
+
+        $set['qux'] = 'qux';
+    }
+
+    public function testOffsetIssetThrowsForInvalidOffsetType(): void
+    {
+        $set = $this->createFromList(['foo', 'bar', 'baz']);
+
+        $this->expectException(Exception\InvalidOffsetException::class);
+        $this->expectExceptionMessage('Invalid set read offset type, expected a string or an integer.');
+
+        isset($set[false]);
+    }
+
+    public function testOffsetGetThrowsForInvalidOffsetType(): void
+    {
+        $set = $this->createFromList(['foo', 'bar', 'baz']);
+
+        $this->expectException(Exception\InvalidOffsetException::class);
+        $this->expectExceptionMessage('Invalid set read offset type, expected a string or an integer.');
+
+        $set[false];
+    }
+
+    public function testOffsetUnsetThrows(): void
+    {
+        $set = $this->createFromList(['foo', 'bar', 'baz']);
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Cannot use object of type Psl\Collection\Set as array');
+
+        unset($set['foo']);
     }
 }

--- a/tests/unit/Collection/VectorTest.php
+++ b/tests/unit/Collection/VectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\Tests\Unit\Collection;
 
+use Psl\Collection\Exception;
 use Psl\Collection\Vector;
 
 final class VectorTest extends AbstractVectorTest
@@ -19,6 +20,79 @@ final class VectorTest extends AbstractVectorTest
     {
         $vector = Vector::fromItems([1, 2, 3]);
         static::assertSame([1, 2, 3], $vector->toArray());
+    }
+
+    public function testArrayAccess(): void
+    {
+        $vector = $this->create([
+            'foo',
+            'bar',
+            'baz',
+        ]);
+
+        static::assertTrue(isset($vector[0]));
+        static::assertSame('foo', $vector[0]);
+
+        $this->expectException(Exception\OutOfBoundsException::class);
+        $this->expectExceptionMessage('Key (3) was out-of-bounds.');
+
+        $vector[3];
+    }
+
+    public function testOffsetSetThrows(): void
+    {
+        $map = $this->create([
+            'foo',
+            'bar',
+            'baz',
+        ]);
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Cannot use object of type Psl\Collection\Vector as array');
+
+        $map[0] = 'qux';
+    }
+
+    public function testOffsetUnsetThrows(): void
+    {
+        $map = $this->create([
+            'foo',
+            'bar',
+            'baz',
+        ]);
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Cannot use object of type Psl\Collection\Vector as array');
+
+        unset($map[0]);
+    }
+
+    public function testOffsetIssetThrowsForInvalidOffsetType(): void
+    {
+        $vector = $this->create([
+            'foo',
+            'bar',
+            'baz',
+        ]);
+
+        $this->expectException(Exception\InvalidOffsetException::class);
+        $this->expectExceptionMessage('Invalid vector read offset type, expected a positive integer.');
+
+        isset($vector[false]);
+    }
+
+    public function testOffsetGetThrowsForInvalidOffsetType(): void
+    {
+        $vector = $this->create([
+            'foo',
+            'bar',
+            'baz',
+        ]);
+
+        $this->expectException(Exception\InvalidOffsetException::class);
+        $this->expectExceptionMessage('Invalid vector read offset type, expected a positive integer.');
+
+        $vector[false];
     }
 
     /**


### PR DESCRIPTION
This PR adds support of array accessing to the immutable `Psl\Collection` objects.

It does this by hoisting the `ArrayAcess` interface from the `MutableAccessibleCollectionInterface` to the `AccessibleCollectionInterface` contract.

To ensure the immutability of the collections, the immutable versions will still throw an `Error` when setting or unsetting elements via array access.