### PR TITLE
refactor: remove redundant `@var` tags from constants

### DIFF
--- a/src/Psl/DateTime/constants.php
+++ b/src/Psl/DateTime/constants.php
@@ -6,119 +6,85 @@ namespace Psl\DateTime;
 
 /**
  * The number of nanoseconds in a microsecond.
- *
- * @var int
  */
 const NANOSECONDS_PER_MICROSECOND = 1000;
 
 /**
  * The number of nanoseconds in a millisecond.
- *
- * @var int
  */
 const NANOSECONDS_PER_MILLISECOND = 1_000_000;
 
 /**
  * The number of nanoseconds in a second.
- *
- * @var int
  */
 const NANOSECONDS_PER_SECOND = 1_000_000_000;
 
 /**
  * The number of microseconds in a millisecond.
- *
- * @var int
  */
 const MICROSECONDS_PER_MILLISECOND = 1000;
 
 /**
  * The number of microseconds in a second.
- *
- * @var int
  */
 const MICROSECONDS_PER_SECOND = 1_000_000;
 
 /**
  * The number of milliseconds in a second.
- *
- * @var int
  */
 const MILLISECONDS_PER_SECOND = 1000;
 
 /**
  * The number of seconds in a minute.
- *
- * @var int
  */
 const SECONDS_PER_MINUTE = 60;
 
 /**
  * The number of seconds in an hour.
- *
- * @var int
  */
 const SECONDS_PER_HOUR = 3600;
 
 /**
  * The number of seconds in a day.
- *
- * @var int
  */
 const SECONDS_PER_DAY = 86_400;
 
 /**
  * The number of seconds in a week.
- *
- * @var int
  */
 const SECONDS_PER_WEEK = 604_800;
 
 /**
  * The number of minutes in an hour.
- *
- * @var int
  */
 const MINUTES_PER_HOUR = 60;
 
 /**
  * The number of minutes in a day.
- *
- * @var int
  */
 const MINUTES_PER_DAY = 1440;
 
 /**
  * The number of minutes in a week.
- *
- * @var int
  */
 const MINUTES_PER_WEEK = 10_080;
 
 /**
  * The number of hours in a day.
- *
- * @var int
  */
 const HOURS_PER_DAY = 24;
 
 /**
  * The number of hours in a week.
- *
- * @var int
  */
 const HOURS_PER_WEEK = 168;
 
 /**
  * The number of days in a week.
- *
- * @var int
  */
 const DAYS_PER_WEEK = 7;
 
 /**
  * The number of months in a year.
- *
- * @var int
  */
 const MONTHS_PER_YEAR = 12;

--- a/src/Psl/Math/constants.php
+++ b/src/Psl/Math/constants.php
@@ -10,7 +10,7 @@ use const NAN as PHP_NAN;
 /**
  * The value of `INFINITY` is `1 / 0` (positive infinity).
  *
- * @var int
+ * @var float
  */
 const INFINITY = INF;
 
@@ -23,133 +23,95 @@ const NAN = PHP_NAN;
 
 /**
  * The base of the natural system of logarithms, or approximately 2.7182818284590452353602875.
- *
- * @var float
  */
 const E = 2.7182818284590452353602875;
 
 /**
  * The ratio of the circumference of a circle to its diameter, or approximately 3.141592653589793238462643.
- *
- * @var float
  */
 const PI = 3.141592653589793238462643;
 
 /**
  * The maximum integer value representable in a 64-bit binary-coded decimal.
- *
- * @var int
  */
 const INT64_MAX = 9223372036854775807;
 
 /**
  * The minimum integer value representable in a 64-bit binary-coded decimal.
- *
- * @var int
  */
 const INT64_MIN = -1 << 63;
 
 /**
  * The maximum integer value representable in a 53-bit binary-coded decimal.
- *
- * @var int
  */
 const INT53_MAX = 9007199254740992;
 
 /**
  * The minimum integer value representable in a 53-bit binary-coded decimal.
- *
- * @var int
  */
 const INT53_MIN = -9007199254740993;
 
 /**
  * The maximum integer value representable in a 32-bit binary-coded decimal.
- *
- * @var int
  */
 const INT32_MAX = 2147483647;
 
 /**
  * The minimum integer value representable in a 32-bit binary-coded decimal.
- *
- * @var int
  */
 const INT32_MIN = -2147483648;
 
 /**
  * The maximum integer value representable in a 16-bit binary-coded decimal.
- *
- * @var int
  */
 const INT16_MAX = 32767;
 
 /**
  * The minimum integer value representable in a 16-bit binary-coded decimal.
- *
- * @var int
  */
 const INT16_MIN = -32768;
 
 /**
  * The maximum integer value representable in a 8-bit binary-coded decimal.
- *
- * @var int
  */
 const INT8_MAX = 127;
 
 /**
  * The minimum integer value representable in a 8-bit binary-coded decimal.
- *
- * @var int
  */
 const INT8_MIN = -128;
 
 /**
  * The maximum unsigned integer value representable in a 32-bit binary-coded decimal.
- *
- * @var int
  */
 const UINT32_MAX = 4294967295;
 
 /**
  * The maximum unsigned integer value representable in a 16-bit binary-coded decimal.
- *
- * @var int
  */
 const UINT16_MAX = 65535;
 
 /**
  * The maximum unsigned integer value representable in a 8-bit binary-coded decimal.
- *
- * @var int
  */
 const UINT8_MAX = 255;
 
 /**
  * The maximum floating point value representable in a 32-bit binary-coded decimal.
- *
- * @var float
  */
 const FLOAT32_MAX = 3.40282347E+38;
 
 /**
  * The minimum floating point value representable in a 32-bit binary-coded decimal.
- *
- * @var float
  */
 const FLOAT32_MIN = -3.40282347E+38;
 
 /**
  * The maximum floating point value representable in a 64-bit binary-coded decimal.
- *
- * @var float
  */
 const FLOAT64_MAX = 1.7976931348623157E+308;
 
 /**
  * The minimum floating point value representable in a 64-bit binary-coded decimal.
- *
- * @var float
  */
 const FLOAT64_MIN = -1.7976931348623157E+308;


### PR DESCRIPTION
This commit removes a large number of `@var` docblocks from constants throughout the `Psl\DateTime` and `Psl\Math` namespaces.

These annotations were often redundant, too wide (e.g., `@var int` for a specific literal value), or in some cases, incorrect. modern static analyzers can infer the precise literal types of these constants directly from their values.