### PR TITLE
Release the handles before changing permissions when copying files

### DIFF
--- a/src/Psl/Filesystem/copy.php
+++ b/src/Psl/Filesystem/copy.php
@@ -34,6 +34,8 @@ function copy(string $source, string $destination, bool $overwrite = false): voi
         throw Exception\NotReadableException::forFile($source);
     }
 
+    $source_handle = null;
+    $destination_handle = null;
     $source_lock = null;
     $destination_lock = null;
     try {
@@ -69,6 +71,9 @@ function copy(string $source, string $destination, bool $overwrite = false): voi
         // @codeCoverageIgnoreEnd
         $source_lock?->release();
         $destination_lock?->release();
+
+        $source_handle?->close();
+        $destination_handle?->close();
     }
 
     // preserve executable permission bits

--- a/src/Psl/Filesystem/copy.php
+++ b/src/Psl/Filesystem/copy.php
@@ -71,7 +71,6 @@ function copy(string $source, string $destination, bool $overwrite = false): voi
         // @codeCoverageIgnoreEnd
         $source_lock?->release();
         $destination_lock?->release();
-
         $source_handle?->close();
         $destination_handle?->close();
     }


### PR DESCRIPTION
When dealing with stream wrappers not closing the handlers can cause issues if `stat` functions are called. At the end of the `copy` function `get_permissions` crashes as checking for file existance fails becuse the hadle is not closed.

Not sure how to write this in a unit test, as setting up a stream wrapper is quite complex.
Generally I think the handles should be closed before caling `change_permissions`, as the job of the `copy` function is at that point done.

@azjezz please let me know what to do regarding the tests, or just merge this PR as is :innocent: