### PR TITLE
revert(option): revert #475

### DIFF
--- a/src/Psl/Option/Option.php
+++ b/src/Psl/Option/Option.php
@@ -73,8 +73,6 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      * Returns true if the option is a some and the value inside of it matches a predicate.
      *
      * @param (Closure(T): bool) $predicate
-     *
-     * @param-immediately-invoked-callable $predicate
      */
     public function isSomeAnd(Closure $predicate): bool
     {
@@ -142,8 +140,6 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      *
      * @param (Closure(): O) $default
      *
-     * @param-immediately-invoked-callable $default
-     *
      * @return T|O
      */
     public function unwrapOrElse(Closure $default): mixed
@@ -201,8 +197,6 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      *
      * @param (Closure(): Option<T>) $closure
      *
-     * @param-immediately-invoked-callable $closure
-     *
      * @return Option<T>
      */
     public function orElse(Closure $closure): Option
@@ -220,8 +214,6 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      *  - Option<T>::none() if `$predicate` returns false.
      *
      * @param (Closure(T): bool) $predicate
-     *
-     * @param-immediately-invoked-callable $predicate
      *
      * @return Option<T>
      */
@@ -259,13 +251,9 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      *                               The closure must accept the option value as its only argument and can return a value.
      *                               Example: `fn($value) => $value + 10`
      *
-     * @param-immediately-invoked-callable $some
-     *
      * @param (Closure(): Ts) $none A closure to be called when the option is none.
      *                              The closure must not accept any arguments and can return a value.
      *                              Example: `fn() => 'Default value'`
-     *
-     * @param-immediately-invoked-callable $none
      *
      * @return Ts The result of calling the appropriate closure.
      */
@@ -282,8 +270,6 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      * Applies a function to a contained value and returns the original `Option<T>`.
      *
      * @param (Closure(T): mixed) $closure
-     *
-     * @param-immediately-invoked-callable $closure
      *
      * @return Option<T>
      */
@@ -303,8 +289,6 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      *
      * @param (Closure(T): Tu) $closure
      *
-     * @param-immediately-invoked-callable $closure
-     *
      * @return Option<Tu>
      */
     public function map(Closure $closure): Option
@@ -323,8 +307,6 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      * @template Tu
      *
      * @param (Closure(T): Option<Tu>) $closure
-     *
-     * @param-immediately-invoked-callable $closure
      *
      * @return Option<Tu>
      */
@@ -349,8 +331,6 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      *
      * @param (Closure(T): Tu) $closure
      *
-     * @param-immediately-invoked-callable $closure
-     *
      * @param Tu $default
      *
      * @return Option<Tu>
@@ -372,11 +352,7 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      *
      * @param (Closure(T): Tu) $closure
      *
-     * @param-immediately-invoked-callable $closure
-     *
      * @param (Closure(): Tu) $default
-     *
-     * @param-immediately-invoked-callable $default
      *
      * @return Option<Tu>
      */
@@ -437,8 +413,6 @@ final readonly class Option implements Comparison\Comparable, Comparison\Equable
      *
      * @param Option<Tu> $other The Option to zip with.
      * @param (Closure(T, Tu): Tr) $closure The closure to apply to the values.
-     *
-     * @param-immediately-invoked-callable $closure
      *
      * @return Option<Tr> The new `Option` containing the result of applying the closure to the values,
      *                    or `None` if either this or the $other `Option is `None`.


### PR DESCRIPTION
Removes `param-immediately-invoked-callable` annotations.

They are indeed immediately called, but only if `Option` is `Some`. Here, PHPStan assumes that the callback is always called, and thinks that any code below `unwrapOrElse` is unreachable:

```php
$option
    ->unwrapOrElse(static fn (): never => throw new NotFoundHttpException());

// Unreachable statement - code above always terminates
// ...
```