### PR TITLE
Add `uuid` type

### DIFF
--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -443,6 +443,7 @@ final class Loader
         'Psl\\Type\\f32' => 'Psl/Type/f32.php',
         'Psl\\Type\\f64' => 'Psl/Type/f64.php',
         'Psl\\Type\\union' => 'Psl/Type/union.php',
+        'Psl\\Type\\uuid' => 'Psl/Type/uuid.php',
         'Psl\\Type\\vec' => 'Psl/Type/vec.php',
         'Psl\\Type\\dict' => 'Psl/Type/dict.php',
         'Psl\\Type\\is_nan' => 'Psl/Type/is_nan.php',

--- a/src/Psl/Type/Internal/UuidType.php
+++ b/src/Psl/Type/Internal/UuidType.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type\Internal;
+
+use Psl\Type;
+use Psl\Type\Exception\AssertException;
+use Psl\Type\Exception\CoercionException;
+use Stringable;
+
+use function is_string;
+use function preg_match;
+
+/**
+ * @extends Type\Type<non-empty-string>
+ *
+ * @internal
+ */
+final readonly class UuidType extends Type\Type
+{
+    /**
+     * @psalm-assert-if-true non-empty-string $value
+     */
+    #[\Override]
+    public function matches(mixed $value): bool
+    {
+        if (!is_string($value) || $value === '') {
+            return false;
+        }
+
+        return (bool) preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', $value);
+    }
+
+    /**
+     * @throws CoercionException
+     *
+     * @return non-empty-string
+     */
+    #[\Override]
+    public function coerce(mixed $value): string
+    {
+        /** @mago-expect analysis:mixed-assignment */
+        $string = $value instanceof Stringable ? (string) $value : $value;
+
+        if ($this->matches($string)) {
+            return $string;
+        }
+
+        throw CoercionException::withValue($value, $this->toString());
+    }
+
+    /**
+     * @throws AssertException
+     *
+     * @return non-empty-string
+     *
+     * @psalm-assert non-empty-string $value
+     */
+    #[\Override]
+    public function assert(mixed $value): string
+    {
+        if ($this->matches($value)) {
+            return $value;
+        }
+
+        throw AssertException::withValue($value, $this->toString());
+    }
+
+    #[\Override]
+    public function toString(): string
+    {
+        return 'uuid';
+    }
+}

--- a/src/Psl/Type/README.md
+++ b/src/Psl/Type/README.md
@@ -1532,6 +1532,22 @@ Can coerce from:
 
 ---
 
+#### [uuid](uuid.php)
+
+```hack
+@pure
+Type\uuid(): TypeInterface<non-empty-string>
+```
+
+Provides a type that can parse a UUID.
+
+Can coerce from:
+
+* `string`
+* `\Stringable`
+
+---
+
 #### [vec](vec.php)
 
 ```hack

--- a/src/Psl/Type/uuid.php
+++ b/src/Psl/Type/uuid.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Type;
+
+/**
+ * @pure
+ *
+ * @mago-expect analysis:impure-static-variable - The $instance is always the same and is considered pure.
+ *
+ * @return TypeInterface<non-empty-string>
+ */
+function uuid(): TypeInterface
+{
+    static $instance = new Internal\UuidType();
+
+    return $instance;
+}

--- a/tests/unit/Type/Internal/UuidTypeTest.php
+++ b/tests/unit/Type/Internal/UuidTypeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Type\Internal;
+
+use Psl\Tests\Unit\Type\TypeTest;
+use Psl\Type;
+
+use const STDIN;
+
+/**
+ * @extends TypeTest<non-empty-string>
+ */
+final class UuidTypeTest extends TypeTest
+{
+    /**
+     * @return Type\Type<non-empty-string>
+     */
+    #[\Override]
+    public function getType(): Type\TypeInterface
+    {
+        return Type\uuid();
+    }
+
+    #[\Override]
+    public function getValidCoercions(): iterable
+    {
+        yield ['2E58B54C-ADE0-41CD-A806-90420571991B', '2E58B54C-ADE0-41CD-A806-90420571991B'];
+        yield [$this->stringable('3E5AF91A-D381-4996-94DB-16DB3B6B20F7'), '3E5AF91A-D381-4996-94DB-16DB3B6B20F7'];
+        yield ['abf9bb28-14c0-48eb-be4f-e7b2b2203c8f', 'abf9bb28-14c0-48eb-be4f-e7b2b2203c8f'];
+        yield [$this->stringable('88b82321-6993-4e94-961f-52e093153fae'), '88b82321-6993-4e94-961f-52e093153fae'];
+    }
+
+    #[\Override]
+    public function getInvalidCoercions(): iterable
+    {
+        yield [''];
+        yield [1.0];
+        yield [1.23];
+        yield [[]];
+        yield [[1]];
+        yield [Type\bool()];
+        yield [null];
+        yield [false];
+        yield [true];
+        yield [STDIN];
+        yield ['kermit'];
+        yield ['88b82321-6993-4e94-961f-52e093153fa'];
+        yield ['E58B54C-ADE0-41CD-A806-90420571991B'];
+    }
+
+    #[\Override]
+    public function getToStringExamples(): iterable
+    {
+        yield [$this->getType(), 'uuid'];
+    }
+
+    public function testItIsAMemoizedType(): void
+    {
+        static::assertSame(Type\non_empty_string(), Type\non_empty_string());
+    }
+}


### PR DESCRIPTION
Simply matches/coerces mixed to non-empty-string and validates against a simple versionless regex.

If versions were an important additional feature, this could be expanded with an optional argument such as `uuid(6)->assert(%value)` (??)