### PR TITLE
Fix PHPDoc return type annotation

### DIFF
--- a/src/Psl/IO/Reader.php
+++ b/src/Psl/IO/Reader.php
@@ -129,8 +129,7 @@ final class Reader implements ReadHandleInterface
     }
 
     /**
-     * @returns string the read data on success,
-     *  or null if the end of file is reached before finding the current line terminator.
+     * @return string|null the read data on success, or null if the end of file is reached before finding the current line terminator.
      *
      * @throws Exception\AlreadyClosedException If the handle has been already closed.
      * @throws Exception\RuntimeException If an error occurred during the operation.


### PR DESCRIPTION
hey there :wave: 

This fixes a typo in the `@return` annotation. It is only a small change, but PHPStorm gathers all annotations from the whole project and puts them in the auto-complete suggestions, which is a bit annoying for this one :sweat_smile: 
