### PR TITLE
refactor(phpunit): resolve test case naming deprecations

### DIFF
--- a/tests/unit/Collection/AbstractMapTestCase.php
+++ b/tests/unit/Collection/AbstractMapTestCase.php
@@ -11,7 +11,7 @@ use Psl\Collection\VectorInterface;
 use Psl\Json;
 use Psl\Str;
 
-abstract class AbstractMapTest extends TestCase
+abstract class AbstractMapTestCase extends TestCase
 {
     /**
      * The Map class being currently tested.

--- a/tests/unit/Collection/AbstractSetTestCase.php
+++ b/tests/unit/Collection/AbstractSetTestCase.php
@@ -9,7 +9,7 @@ use Psl\Collection;
 use Psl\Collection\SetInterface;
 use Psl\Str;
 
-abstract class AbstractSetTest extends TestCase
+abstract class AbstractSetTestCase extends TestCase
 {
     /**
      * The set class used for values, keys .. etc.

--- a/tests/unit/Collection/AbstractVectorTestCase.php
+++ b/tests/unit/Collection/AbstractVectorTestCase.php
@@ -9,7 +9,7 @@ use Psl\Collection;
 use Psl\Collection\VectorInterface;
 use Psl\Str;
 
-abstract class AbstractVectorTest extends TestCase
+abstract class AbstractVectorTestCase extends TestCase
 {
     /**
      * The Vector class used for values, keys .. etc.

--- a/tests/unit/Collection/MapTest.php
+++ b/tests/unit/Collection/MapTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Collection;
 use Psl\Collection\Map;
 use Psl\Collection\Vector;
 
-final class MapTest extends AbstractMapTest
+final class MapTest extends AbstractMapTestCase
 {
     /**
      * @var class-string<Map>

--- a/tests/unit/Collection/MutableMapTest.php
+++ b/tests/unit/Collection/MutableMapTest.php
@@ -9,7 +9,7 @@ use Psl\Collection\Exception;
 use Psl\Collection\MutableMap;
 use Psl\Collection\MutableVector;
 
-final class MutableMapTest extends AbstractMapTest
+final class MutableMapTest extends AbstractMapTestCase
 {
     /**
      * @var class-string<MutableMap>

--- a/tests/unit/Collection/MutableSetTest.php
+++ b/tests/unit/Collection/MutableSetTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Collection;
 use Psl\Collection\Exception;
 use Psl\Collection\MutableSet;
 
-final class MutableSetTest extends AbstractSetTest
+final class MutableSetTest extends AbstractSetTestCase
 {
     /**
      * The Set class used for values, keys .. etc.

--- a/tests/unit/Collection/MutableVectorTest.php
+++ b/tests/unit/Collection/MutableVectorTest.php
@@ -8,7 +8,7 @@ use Psl\Collection;
 use Psl\Collection\Exception;
 use Psl\Collection\MutableVector;
 
-final class MutableVectorTest extends AbstractVectorTest
+final class MutableVectorTest extends AbstractVectorTestCase
 {
     /**
      * The Vector class used for values, keys .. etc.

--- a/tests/unit/Collection/SetTest.php
+++ b/tests/unit/Collection/SetTest.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Unit\Collection;
 
 use Psl\Collection\Set;
 
-final class SetTest extends AbstractSetTest
+final class SetTest extends AbstractSetTestCase
 {
     /**
      * The Set class used for values, keys .. etc.

--- a/tests/unit/Collection/VectorTest.php
+++ b/tests/unit/Collection/VectorTest.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Unit\Collection;
 
 use Psl\Collection\Vector;
 
-final class VectorTest extends AbstractVectorTest
+final class VectorTest extends AbstractVectorTestCase
 {
     /**
      * The Vector class used for values, keys .. etc.

--- a/tests/unit/Comparison/AbstractComparisonTestCase.php
+++ b/tests/unit/Comparison/AbstractComparisonTestCase.php
@@ -10,7 +10,7 @@ use Psl\Comparison\Comparable;
 use Psl\Comparison\Exception\IncomparableException;
 use Psl\Comparison\Order;
 
-abstract class AbstractComparisonTest extends TestCase
+abstract class AbstractComparisonTestCase extends TestCase
 {
     public static function provideComparisonCases(): Generator
     {

--- a/tests/unit/Comparison/CompareTest.php
+++ b/tests/unit/Comparison/CompareTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Comparison;
 use Psl\Comparison;
 use Psl\Comparison\Order;
 
-class CompareTest extends AbstractComparisonTest
+class CompareTest extends AbstractComparisonTestCase
 {
     /**
      * @dataProvider provideComparisonCases

--- a/tests/unit/Comparison/EqualTest.php
+++ b/tests/unit/Comparison/EqualTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Comparison;
 use Psl\Comparison;
 use Psl\Comparison\Order;
 
-class EqualTest extends AbstractComparisonTest
+class EqualTest extends AbstractComparisonTestCase
 {
     /**
      * @dataProvider provideComparisonCases

--- a/tests/unit/Comparison/GreaterOrEqualTest.php
+++ b/tests/unit/Comparison/GreaterOrEqualTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Comparison;
 use Psl\Comparison;
 use Psl\Comparison\Order;
 
-class GreaterOrEqualTest extends AbstractComparisonTest
+class GreaterOrEqualTest extends AbstractComparisonTestCase
 {
     /**
      * @dataProvider provideComparisonCases

--- a/tests/unit/Comparison/GreaterTest.php
+++ b/tests/unit/Comparison/GreaterTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Comparison;
 use Psl\Comparison;
 use Psl\Comparison\Order;
 
-class GreaterTest extends AbstractComparisonTest
+class GreaterTest extends AbstractComparisonTestCase
 {
     /**
      * @dataProvider provideComparisonCases

--- a/tests/unit/Comparison/LessOrEqualTest.php
+++ b/tests/unit/Comparison/LessOrEqualTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Comparison;
 use Psl\Comparison;
 use Psl\Comparison\Order;
 
-class LessOrEqualTest extends AbstractComparisonTest
+class LessOrEqualTest extends AbstractComparisonTestCase
 {
     /**
      * @dataProvider provideComparisonCases

--- a/tests/unit/Comparison/LessTest.php
+++ b/tests/unit/Comparison/LessTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Comparison;
 use Psl\Comparison;
 use Psl\Comparison\Order;
 
-class LessTest extends AbstractComparisonTest
+class LessTest extends AbstractComparisonTestCase
 {
     /**
      * @dataProvider provideComparisonCases

--- a/tests/unit/Comparison/NotEqualTest.php
+++ b/tests/unit/Comparison/NotEqualTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Comparison;
 use Psl\Comparison;
 use Psl\Comparison\Order;
 
-class NotEqualTest extends AbstractComparisonTest
+class NotEqualTest extends AbstractComparisonTestCase
 {
     /**
      * @dataProvider provideComparisonCases

--- a/tests/unit/Comparison/SortTest.php
+++ b/tests/unit/Comparison/SortTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Comparison;
 use Psl\Comparison;
 use Psl\Comparison\Order;
 
-class SortTest extends AbstractComparisonTest
+class SortTest extends AbstractComparisonTestCase
 {
     /**
      * @dataProvider provideComparisonCases

--- a/tests/unit/File/ReadWriteTest.php
+++ b/tests/unit/File/ReadWriteTest.php
@@ -9,9 +9,9 @@ use Psl\File;
 use Psl\Filesystem;
 use Psl\OS;
 use Psl\Str;
-use Psl\Tests\Unit\Filesystem\AbstractFilesystemTest;
+use Psl\Tests\Unit\Filesystem\AbstractFilesystemTestCase;
 
-final class ReadWriteTest extends AbstractFilesystemTest
+final class ReadWriteTest extends AbstractFilesystemTestCase
 {
     protected string $function = 'file';
 

--- a/tests/unit/Filesystem/AbstractFilesystemTestCase.php
+++ b/tests/unit/Filesystem/AbstractFilesystemTestCase.php
@@ -11,7 +11,7 @@ use Psl\OS;
 use Psl\Str;
 use Psl\Type;
 
-abstract class AbstractFilesystemTest extends TestCase
+abstract class AbstractFilesystemTestCase extends TestCase
 {
     protected string $function;
     protected string $cacheDirectory;

--- a/tests/unit/Filesystem/CopyTest.php
+++ b/tests/unit/Filesystem/CopyTest.php
@@ -8,7 +8,7 @@ use Psl\File;
 use Psl\Filesystem;
 use Psl\Str;
 
-final class CopyTest extends AbstractFilesystemTest
+final class CopyTest extends AbstractFilesystemTestCase
 {
     protected string $function = 'copy';
 

--- a/tests/unit/Filesystem/DirectoryTest.php
+++ b/tests/unit/Filesystem/DirectoryTest.php
@@ -9,7 +9,7 @@ use Psl\Filesystem;
 use Psl\Str;
 use Psl\Vec;
 
-final class DirectoryTest extends AbstractFilesystemTest
+final class DirectoryTest extends AbstractFilesystemTestCase
 {
     protected string $function = 'directory';
 

--- a/tests/unit/Filesystem/FileTest.php
+++ b/tests/unit/Filesystem/FileTest.php
@@ -10,7 +10,7 @@ use Psl\Str;
 
 use function time;
 
-final class FileTest extends AbstractFilesystemTest
+final class FileTest extends AbstractFilesystemTestCase
 {
     protected string $function = 'file';
 

--- a/tests/unit/Filesystem/LinkTest.php
+++ b/tests/unit/Filesystem/LinkTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Filesystem;
 use Psl\Filesystem;
 use Psl\Str;
 
-final class LinkTest extends AbstractFilesystemTest
+final class LinkTest extends AbstractFilesystemTestCase
 {
     protected string $function = 'link';
 

--- a/tests/unit/Filesystem/PermissionsTest.php
+++ b/tests/unit/Filesystem/PermissionsTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Filesystem;
 use Psl\Filesystem;
 use Psl\Str;
 
-final class PermissionsTest extends AbstractFilesystemTest
+final class PermissionsTest extends AbstractFilesystemTestCase
 {
     protected string $function = 'permissions';
 

--- a/tests/unit/Type/AlwaysAssertTypeTest.php
+++ b/tests/unit/Type/AlwaysAssertTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class AlwaysAssertTypeTest extends TypeTest
+final class AlwaysAssertTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/ArrayKeyTypeTest.php
+++ b/tests/unit/Type/ArrayKeyTypeTest.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Unit\Type;
 
 use Psl\Type;
 
-final class ArrayKeyTypeTest extends TypeTest
+final class ArrayKeyTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/BoolTypeTest.php
+++ b/tests/unit/Type/BoolTypeTest.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Unit\Type;
 
 use Psl\Type;
 
-final class BoolTypeTest extends TypeTest
+final class BoolTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/ClassStringTypeTest.php
+++ b/tests/unit/Type/ClassStringTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Collection;
 use Psl\Type;
 
-final class ClassStringTypeTest extends TypeTest
+final class ClassStringTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/ConstantNameOfTypeTest.php
+++ b/tests/unit/Type/ConstantNameOfTypeTest.php
@@ -8,7 +8,7 @@ use Override;
 use Psl\Tests\Fixture\ClassWithConstants;
 use Psl\Type;
 
-final class ConstantNameOfTypeTest extends TypeTest
+final class ConstantNameOfTypeTest extends TypeTestCase
 {
     #[Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/ContainerTypeTest.php
+++ b/tests/unit/Type/ContainerTypeTest.php
@@ -12,9 +12,9 @@ use Psl\Vec;
 use RuntimeException;
 
 /**
- * @extends TypeTest<iterable<int, int>>
+ * @extends TypeTestCase<iterable<int, int>>
  */
-final class ContainerTypeTest extends TypeTest
+final class ContainerTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/ConvertedTypeTest.php
+++ b/tests/unit/Type/ConvertedTypeTest.php
@@ -9,7 +9,7 @@ use Psl\Str;
 use Psl\Type;
 use RuntimeException;
 
-final class ConvertedTypeTest extends TypeTest
+final class ConvertedTypeTest extends TypeTestCase
 {
     private const string DATE_FORMAT = 'Y-m-d H:i:s';
 

--- a/tests/unit/Type/DictTypeTest.php
+++ b/tests/unit/Type/DictTypeTest.php
@@ -13,9 +13,9 @@ use Psl\Vec;
 use RuntimeException;
 
 /**
- * @extends TypeTest<array<array-key, mixed>>
+ * @extends TypeTestCase<array<array-key, mixed>>
  */
-final class DictTypeTest extends TypeTest
+final class DictTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/EnumCaseOfTypeTest.php
+++ b/tests/unit/Type/EnumCaseOfTypeTest.php
@@ -9,7 +9,7 @@ use Psl\Tests\Fixture\StringEnum;
 use Psl\Tests\Fixture\UnitEnum;
 use Psl\Type;
 
-final class EnumCaseOfTypeTest extends TypeTest
+final class EnumCaseOfTypeTest extends TypeTestCase
 {
     #[Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/F32TypeTest.php
+++ b/tests/unit/Type/F32TypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class F32TypeTest extends TypeTest
+final class F32TypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/F64TypeTest.php
+++ b/tests/unit/Type/F64TypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class F64TypeTest extends TypeTest
+final class F64TypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/FloatTypeTest.php
+++ b/tests/unit/Type/FloatTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class FloatTypeTest extends TypeTest
+final class FloatTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/I16TypeTest.php
+++ b/tests/unit/Type/I16TypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class I16TypeTest extends TypeTest
+final class I16TypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/I32TypeTest.php
+++ b/tests/unit/Type/I32TypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class I32TypeTest extends TypeTest
+final class I32TypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/I64TypeTest.php
+++ b/tests/unit/Type/I64TypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class I64TypeTest extends TypeTest
+final class I64TypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/I8TypeTest.php
+++ b/tests/unit/Type/I8TypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class I8TypeTest extends TypeTest
+final class I8TypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/InstanceOfTypeTest.php
+++ b/tests/unit/Type/InstanceOfTypeTest.php
@@ -8,7 +8,7 @@ use Psl\Collection;
 use Psl\Collection\CollectionInterface;
 use Psl\Type;
 
-final class InstanceOfTypeTest extends TypeTest
+final class InstanceOfTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/IntRangeTypeTest.php
+++ b/tests/unit/Type/IntRangeTypeTest.php
@@ -10,7 +10,7 @@ use Psl\Type;
 use const PHP_INT_MAX;
 use const PHP_INT_MIN;
 
-final class IntRangeTypeTest extends TypeTest
+final class IntRangeTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/IntTypeTest.php
+++ b/tests/unit/Type/IntTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class IntTypeTest extends TypeTest
+final class IntTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/IntegerBackedEnumTypeTest.php
+++ b/tests/unit/Type/IntegerBackedEnumTypeTest.php
@@ -9,9 +9,9 @@ use Psl\Tests\Fixture\IntegerEnum;
 use Psl\Type;
 
 /**
- * @extends TypeTest<IntegerEnum>
+ * @extends TypeTestCase<IntegerEnum>
  */
-final class IntegerBackedEnumTypeTest extends TypeTest
+final class IntegerBackedEnumTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/IntegerBackedEnumValueTypeTest.php
+++ b/tests/unit/Type/IntegerBackedEnumValueTypeTest.php
@@ -11,9 +11,9 @@ use Psl\Type;
 use const STDIN;
 
 /**
- * @extends TypeTest<value-of<IntegerEnum>>
+ * @extends TypeTestCase<value-of<IntegerEnum>>
  */
-final class IntegerBackedEnumValueTypeTest extends TypeTest
+final class IntegerBackedEnumValueTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/Internal/UuidTypeTest.php
+++ b/tests/unit/Type/Internal/UuidTypeTest.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Psl\Tests\Unit\Type\Internal;
 
-use Psl\Tests\Unit\Type\TypeTest;
+use Psl\Tests\Unit\Type\TypeTestCase;
 use Psl\Type;
 
 use const STDIN;
 
 /**
- * @extends TypeTest<non-empty-string>
+ * @extends TypeTestCase<non-empty-string>
  */
-final class UuidTypeTest extends TypeTest
+final class UuidTypeTest extends TypeTestCase
 {
     /**
      * @return Type\Type<non-empty-string>

--- a/tests/unit/Type/IntersectionTypeTest.php
+++ b/tests/unit/Type/IntersectionTypeTest.php
@@ -9,7 +9,7 @@ use Psl\Collection\CollectionInterface;
 use Psl\Collection\IndexAccessInterface;
 use Psl\Type;
 
-final class IntersectionTypeTest extends TypeTest
+final class IntersectionTypeTest extends TypeTestCase
 {
     public function testIntersectionLeft(): void
     {

--- a/tests/unit/Type/IterableTypeTest.php
+++ b/tests/unit/Type/IterableTypeTest.php
@@ -12,9 +12,9 @@ use Psl\Vec;
 use RuntimeException;
 
 /**
- * @extends TypeTest<iterable<int, int>>
+ * @extends TypeTestCase<iterable<int, int>>
  */
-final class IterableTypeTest extends TypeTest
+final class IterableTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/LiteralScalarBoolTypeTest.php
+++ b/tests/unit/Type/LiteralScalarBoolTypeTest.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Unit\Type;
 
 use Psl\Type;
 
-final class LiteralScalarBoolTypeTest extends TypeTest
+final class LiteralScalarBoolTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/LiteralScalarFloatTypeTest.php
+++ b/tests/unit/Type/LiteralScalarFloatTypeTest.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Unit\Type;
 
 use Psl\Type;
 
-final class LiteralScalarFloatTypeTest extends TypeTest
+final class LiteralScalarFloatTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/LiteralScalarIntTypeTest.php
+++ b/tests/unit/Type/LiteralScalarIntTypeTest.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Unit\Type;
 
 use Psl\Type;
 
-final class LiteralScalarIntTypeTest extends TypeTest
+final class LiteralScalarIntTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/LiteralScalarStringTypeTest.php
+++ b/tests/unit/Type/LiteralScalarStringTypeTest.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Unit\Type;
 
 use Psl\Type;
 
-final class LiteralScalarStringTypeTest extends TypeTest
+final class LiteralScalarStringTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/MapTypeTest.php
+++ b/tests/unit/Type/MapTypeTest.php
@@ -14,9 +14,9 @@ use Psl\Vec;
 use RuntimeException;
 
 /**
- * @extends TypeTest<Collection\MapInterface<array-key, mixed>>
+ * @extends TypeTestCase<Collection\MapInterface<array-key, mixed>>
  */
-final class MapTypeTest extends TypeTest
+final class MapTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/MethodNameOfTypeTest.php
+++ b/tests/unit/Type/MethodNameOfTypeTest.php
@@ -8,7 +8,7 @@ use Override;
 use Psl\Collection;
 use Psl\Type;
 
-final class MethodNameOfTypeTest extends TypeTest
+final class MethodNameOfTypeTest extends TypeTestCase
 {
     #[Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/MixedDictTypeTest.php
+++ b/tests/unit/Type/MixedDictTypeTest.php
@@ -14,7 +14,7 @@ use RuntimeException;
 use SplObjectStorage;
 use stdClass;
 
-final class MixedDictTypeTest extends TypeTest
+final class MixedDictTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/MixedTypeTest.php
+++ b/tests/unit/Type/MixedTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class MixedTypeTest extends TypeTest
+final class MixedTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/MixedVecTypeTest.php
+++ b/tests/unit/Type/MixedVecTypeTest.php
@@ -10,7 +10,7 @@ use Psl\Str;
 use Psl\Type;
 use Psl\Vec;
 
-final class MixedVecTypeTest extends TypeTest
+final class MixedVecTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/MutableMapTypeTest.php
+++ b/tests/unit/Type/MutableMapTypeTest.php
@@ -14,9 +14,9 @@ use Psl\Vec;
 use RuntimeException;
 
 /**
- * @extends TypeTest<MutableMapInterface<array-key, mixed>>
+ * @extends TypeTestCase<MutableMapInterface<array-key, mixed>>
  */
-final class MutableMapTypeTest extends TypeTest
+final class MutableMapTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/MutableSetTypeTest.php
+++ b/tests/unit/Type/MutableSetTypeTest.php
@@ -13,9 +13,9 @@ use Psl\Vec;
 use RuntimeException;
 
 /**
- * @extends TypeTest<MutableSetInterface<array-key>>
+ * @extends TypeTestCase<MutableSetInterface<array-key>>
  */
-final class MutableSetTypeTest extends TypeTest
+final class MutableSetTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/MutableVectorTypeTest.php
+++ b/tests/unit/Type/MutableVectorTypeTest.php
@@ -14,9 +14,9 @@ use Psl\Vec;
 use RuntimeException;
 
 /**
- * @extends TypeTest<MutableVectorInterface<mixed>>
+ * @extends TypeTestCase<MutableVectorInterface<mixed>>
  */
-final class MutableVectorTypeTest extends TypeTest
+final class MutableVectorTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/NonEmptyDictTypeTest.php
+++ b/tests/unit/Type/NonEmptyDictTypeTest.php
@@ -13,9 +13,9 @@ use Psl\Vec;
 use RuntimeException;
 
 /**
- * @extends TypeTest<non-empty-array<array-key, mixed>>
+ * @extends TypeTestCase<non-empty-array<array-key, mixed>>
  */
-final class NonEmptyDictTypeTest extends TypeTest
+final class NonEmptyDictTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/NonEmptyStringTypeTest.php
+++ b/tests/unit/Type/NonEmptyStringTypeTest.php
@@ -7,9 +7,9 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Type;
 
 /**
- * @extends TypeTest<non-empty-string>
+ * @extends TypeTestCase<non-empty-string>
  */
-final class NonEmptyStringTypeTest extends TypeTest
+final class NonEmptyStringTypeTest extends TypeTestCase
 {
     /**
      * @return Type\Type<non-empty-string>

--- a/tests/unit/Type/NonEmptyVecTypeTest.php
+++ b/tests/unit/Type/NonEmptyVecTypeTest.php
@@ -13,9 +13,9 @@ use Psl\Vec;
 use RuntimeException;
 
 /**
- * @extends TypeTest<non-empty-list<mixed>>
+ * @extends TypeTestCase<non-empty-list<mixed>>
  */
-final class NonEmptyVecTypeTest extends TypeTest
+final class NonEmptyVecTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/NonNullTypeTest.php
+++ b/tests/unit/Type/NonNullTypeTest.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Unit\Type;
 
 use Psl\Type;
 
-final class NonNullTypeTest extends TypeTest
+final class NonNullTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/NullTypeTest.php
+++ b/tests/unit/Type/NullTypeTest.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Unit\Type;
 
 use Psl\Type;
 
-final class NullTypeTest extends TypeTest
+final class NullTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/NullableTypeTest.php
+++ b/tests/unit/Type/NullableTypeTest.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Unit\Type;
 
 use Psl\Type;
 
-final class NullableTypeTest extends TypeTest
+final class NullableTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/NumTypeTest.php
+++ b/tests/unit/Type/NumTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class NumTypeTest extends TypeTest
+final class NumTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/NumericStringTypeTest.php
+++ b/tests/unit/Type/NumericStringTypeTest.php
@@ -7,9 +7,9 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Type;
 
 /**
- * @extends TypeTest<numeric-string>
+ * @extends TypeTestCase<numeric-string>
  */
-final class NumericStringTypeTest extends TypeTest
+final class NumericStringTypeTest extends TypeTestCase
 {
     /**
      * @return Type\Type<numeric-string>

--- a/tests/unit/Type/ObjectTypeTest.php
+++ b/tests/unit/Type/ObjectTypeTest.php
@@ -8,7 +8,7 @@ use Psl\Collection;
 use Psl\Collection\CollectionInterface;
 use Psl\Type;
 
-final class ObjectTypeTest extends TypeTest
+final class ObjectTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/PositiveIntTypeTest.php
+++ b/tests/unit/Type/PositiveIntTypeTest.php
@@ -8,9 +8,9 @@ use Psl\Math;
 use Psl\Type;
 
 /**
- * @extends TypeTest<positive-int>
+ * @extends TypeTestCase<positive-int>
  */
-final class PositiveIntTypeTest extends TypeTest
+final class PositiveIntTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/PrivateConstantNameOfTypeTest.php
+++ b/tests/unit/Type/PrivateConstantNameOfTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Tests\Fixture\ClassWithConstants;
 use Psl\Type;
 
-final class PrivateConstantNameOfTypeTest extends TypeTest
+final class PrivateConstantNameOfTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/PrivateMethodNameOfTypeTest.php
+++ b/tests/unit/Type/PrivateMethodNameOfTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Tests\Fixture\ClassWithMethods;
 use Psl\Type;
 
-final class PrivateMethodNameOfTypeTest extends TypeTest
+final class PrivateMethodNameOfTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/PrivatePropertyNameOfTypeTest.php
+++ b/tests/unit/Type/PrivatePropertyNameOfTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Tests\Fixture\ClassWithProperties;
 use Psl\Type;
 
-final class PrivatePropertyNameOfTypeTest extends TypeTest
+final class PrivatePropertyNameOfTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/PropertyNameOfTypeTest.php
+++ b/tests/unit/Type/PropertyNameOfTypeTest.php
@@ -8,7 +8,7 @@ use Override;
 use Psl\Tests\Fixture\ClassWithProperties;
 use Psl\Type;
 
-final class PropertyNameOfTypeTest extends TypeTest
+final class PropertyNameOfTypeTest extends TypeTestCase
 {
     #[Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/ProtectedConstantNameOfTypeTest.php
+++ b/tests/unit/Type/ProtectedConstantNameOfTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Tests\Fixture\ClassWithConstants;
 use Psl\Type;
 
-final class ProtectedConstantNameOfTypeTest extends TypeTest
+final class ProtectedConstantNameOfTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/ProtectedMethodNameOfTypeTest.php
+++ b/tests/unit/Type/ProtectedMethodNameOfTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Tests\Fixture\ClassWithMethods;
 use Psl\Type;
 
-final class ProtectedMethodNameOfTypeTest extends TypeTest
+final class ProtectedMethodNameOfTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/ProtectedPropertyNameOfTypeTest.php
+++ b/tests/unit/Type/ProtectedPropertyNameOfTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Tests\Fixture\ClassWithProperties;
 use Psl\Type;
 
-final class ProtectedPropertyNameOfTypeTest extends TypeTest
+final class ProtectedPropertyNameOfTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/PublicConstantNameOfTypeTest.php
+++ b/tests/unit/Type/PublicConstantNameOfTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Tests\Fixture\ClassWithConstants;
 use Psl\Type;
 
-final class PublicConstantNameOfTypeTest extends TypeTest
+final class PublicConstantNameOfTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/PublicMethodNameOfTypeTest.php
+++ b/tests/unit/Type/PublicMethodNameOfTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Tests\Fixture\ClassWithMethods;
 use Psl\Type;
 
-final class PublicMethodNameOfTypeTest extends TypeTest
+final class PublicMethodNameOfTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/PublicPropertyNameOfTypeTest.php
+++ b/tests/unit/Type/PublicPropertyNameOfTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Tests\Fixture\ClassWithProperties;
 use Psl\Type;
 
-final class PublicPropertyNameOfTypeTest extends TypeTest
+final class PublicPropertyNameOfTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/ResourceTypeTest.php
+++ b/tests/unit/Type/ResourceTypeTest.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Unit\Type;
 
 use Psl\Type;
 
-final class ResourceTypeTest extends TypeTest
+final class ResourceTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/ScalarTypeTest.php
+++ b/tests/unit/Type/ScalarTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class ScalarTypeTest extends TypeTest
+final class ScalarTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/SetTypeTest.php
+++ b/tests/unit/Type/SetTypeTest.php
@@ -13,9 +13,9 @@ use Psl\Vec;
 use RuntimeException;
 
 /**
- * @extends TypeTest<SetInterface<array-key>>
+ * @extends TypeTestCase<SetInterface<array-key>>
  */
-final class SetTypeTest extends TypeTest
+final class SetTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/ShapeAllowUnknownFieldsTypeTest.php
+++ b/tests/unit/Type/ShapeAllowUnknownFieldsTypeTest.php
@@ -9,9 +9,9 @@ use Psl\Iter;
 use Psl\Type;
 
 /**
- * @extends TypeTest<array>
+ * @extends TypeTestCase<array>
  */
-final class ShapeAllowUnknownFieldsTypeTest extends TypeTest
+final class ShapeAllowUnknownFieldsTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/ShapeTypeTest.php
+++ b/tests/unit/Type/ShapeTypeTest.php
@@ -12,9 +12,9 @@ use Psl\Type;
 use RuntimeException;
 
 /**
- * @extends TypeTest<array>
+ * @extends TypeTestCase<array>
  */
-final class ShapeTypeTest extends TypeTest
+final class ShapeTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/StringBackedEnumTypeTest.php
+++ b/tests/unit/Type/StringBackedEnumTypeTest.php
@@ -9,9 +9,9 @@ use Psl\Tests\Fixture\StringEnum;
 use Psl\Type;
 
 /**
- * @extends TypeTest<StringEnum>
+ * @extends TypeTestCase<StringEnum>
  */
-final class StringBackedEnumTypeTest extends TypeTest
+final class StringBackedEnumTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/StringBackedEnumValueTypeTest.php
+++ b/tests/unit/Type/StringBackedEnumValueTypeTest.php
@@ -11,9 +11,9 @@ use Psl\Type;
 use const STDIN;
 
 /**
- * @extends TypeTest<value-of<StringEnum>>
+ * @extends TypeTestCase<value-of<StringEnum>>
  */
-final class StringBackedEnumValueTypeTest extends TypeTest
+final class StringBackedEnumValueTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/StringTypeTest.php
+++ b/tests/unit/Type/StringTypeTest.php
@@ -6,7 +6,7 @@ namespace Psl\Tests\Unit\Type;
 
 use Psl\Type;
 
-final class StringTypeTest extends TypeTest
+final class StringTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/TypeTestCase.php
+++ b/tests/unit/Type/TypeTestCase.php
@@ -15,7 +15,7 @@ use Psl\Vec;
 /**
  * @template T
  */
-abstract class TypeTest extends TestCase
+abstract class TypeTestCase extends TestCase
 {
     /**
      * @return TypeInterface<T>

--- a/tests/unit/Type/U16TypeTest.php
+++ b/tests/unit/Type/U16TypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class U16TypeTest extends TypeTest
+final class U16TypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/U32TypeTest.php
+++ b/tests/unit/Type/U32TypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class U32TypeTest extends TypeTest
+final class U32TypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/U8TypeTest.php
+++ b/tests/unit/Type/U8TypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class U8TypeTest extends TypeTest
+final class U8TypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/UIntTypeTest.php
+++ b/tests/unit/Type/UIntTypeTest.php
@@ -7,7 +7,7 @@ namespace Psl\Tests\Unit\Type;
 use Psl\Math;
 use Psl\Type;
 
-final class UIntTypeTest extends TypeTest
+final class UIntTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/UnionTypeTest.php
+++ b/tests/unit/Type/UnionTypeTest.php
@@ -8,7 +8,7 @@ use Psl\Collection\CollectionInterface;
 use Psl\Collection\IndexAccessInterface;
 use Psl\Type;
 
-final class UnionTypeTest extends TypeTest
+final class UnionTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/UnitEnumTypeTest.php
+++ b/tests/unit/Type/UnitEnumTypeTest.php
@@ -9,9 +9,9 @@ use Psl\Tests\Fixture\UnitEnum;
 use Psl\Type;
 
 /**
- * @extends TypeTest<UnitEnum>
+ * @extends TypeTestCase<UnitEnum>
  */
-final class UnitEnumTypeTest extends TypeTest
+final class UnitEnumTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface

--- a/tests/unit/Type/VecTypeTest.php
+++ b/tests/unit/Type/VecTypeTest.php
@@ -13,9 +13,9 @@ use Psl\Vec;
 use RuntimeException;
 
 /**
- * @extends TypeTest<list<mixed>>
+ * @extends TypeTestCase<list<mixed>>
  */
-final class VecTypeTest extends TypeTest
+final class VecTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getValidCoercions(): iterable

--- a/tests/unit/Type/VectorTypeTest.php
+++ b/tests/unit/Type/VectorTypeTest.php
@@ -14,9 +14,9 @@ use Psl\Vec;
 use RuntimeException;
 
 /**
- * @extends TypeTest<VectorInterface<mixed>>
+ * @extends TypeTestCase<VectorInterface<mixed>>
  */
-final class VectorTypeTest extends TypeTest
+final class VectorTypeTest extends TypeTestCase
 {
     #[\Override]
     public function getType(): Type\TypeInterface


### PR DESCRIPTION
Resolves:

```
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

Warning:       Abstract test case classes with "Test" suffix are deprecated (Psl\Tests\Unit\Collection\AbstractMapTest)
Warning:       Abstract test case classes with "Test" suffix are deprecated (Psl\Tests\Unit\Collection\AbstractSetTest)
Warning:       Abstract test case classes with "Test" suffix are deprecated (Psl\Tests\Unit\Collection\AbstractVectorTest)
Warning:       Abstract test case classes with "Test" suffix are deprecated (Psl\Tests\Unit\Comparison\AbstractComparisonTest)
Warning:       Abstract test case classes with "Test" suffix are deprecated (Psl\Tests\Unit\Filesystem\AbstractFilesystemTest)
Warning:       Abstract test case classes with "Test" suffix are deprecated (Psl\Tests\Unit\Type\TypeTest)
```