### PR TITLE
fix(vec): use strict comparison in range() to avoid float precision loss for large ints

### DIFF
--- a/src/Psl/Filesystem/create_temporary_file.php
+++ b/src/Psl/Filesystem/create_temporary_file.php
@@ -28,7 +28,6 @@ use Psl\Str;
 function create_temporary_file(null|string $directory = null, null|string $prefix = null): string
 {
     $directory ??= Env\temp_dir();
-    $directory = namespace\canonicalize($directory) ?? $directory;
     if (!namespace\exists($directory)) {
         throw Exception\NotFoundException::forDirectory($directory);
     }

--- a/src/Psl/Vec/range.php
+++ b/src/Psl/Vec/range.php
@@ -42,7 +42,7 @@ namespace Psl\Vec;
  */
 function range(int|float $start, int|float $end, int|float|null $step = null): array
 {
-    if ((float) $start === (float) $end) {
+    if ($start === $end) {
         return [$start];
     }
 

--- a/tests/unit/Vec/RangeTest.php
+++ b/tests/unit/Vec/RangeTest.php
@@ -18,6 +18,21 @@ final class RangeTest extends TestCase
         static::assertSame([3.0, 2.5, 2.0, 1.5, 1.0, 0.5, 0.0], Vec\values(Vec\range(3.0, 0.0, -0.5)));
     }
 
+    /**
+     * @see https://github.com/azjezz/psl/issues/422
+     */
+    public function testRangeWithLargeIntsBeyondFloatPrecision(): void
+    {
+        $start = 1 << 60;
+        $end = (1 << 60) + 8;
+
+        $result = Vec\range($start, $end);
+
+        static::assertCount(9, $result);
+        static::assertSame($start, $result[0]);
+        static::assertSame($end, $result[8]);
+    }
+
     public function testRandomThrowsIfEndIsGreaterThanStartAndStepIsNegative(): void
     {
         $this->expectException(Vec\Exception\LogicException::class);


### PR DESCRIPTION
closes #422