### PR TITLE
chore(tests): clean up test suite and fix type annotations

### DIFF
--- a/config/mago.toml
+++ b/config/mago.toml
@@ -2,7 +2,7 @@ php-version = "8.4"
 
 [source]
 paths = ["src", "tests", "examples", "docs"]
-includes = ["vendor/revolt"]
+includes = ["vendor/revolt", "vendor/phpbench"]
 excludes = []
 
 [formatter]
@@ -37,9 +37,8 @@ no-else-clause = { enabled = false }
 
 [analyzer]
 excludes = [
-  # unit tests, and benchmarks are mostly untyped.
+  # unit tests are mostly untyped.
   "tests/unit",
-  "tests/benchmark",
   # those components are not supported by mago.
   "tests/static-analysis/Fun",
   "tests/static-analysis/Option",

--- a/tests/unit/Async/AllTest.php
+++ b/tests/unit/Async/AllTest.php
@@ -72,6 +72,7 @@ final class AllTest extends TestCase
 
     public function testAllAwaitablesAreCompletedAtALaterTime(): void
     {
+        /** @var Psl\Ref<string> */
         $ref = new Psl\Ref('');
 
         try {

--- a/tests/unit/DateTime/DurationTest.php
+++ b/tests/unit/DateTime/DurationTest.php
@@ -37,7 +37,7 @@ final class DurationTest extends TestCase
         static::assertSame(1.0, DateTime\Duration::milliseconds(1)->getTotalMilliseconds());
         static::assertSame(1.0, DateTime\Duration::microseconds(1)->getTotalMicroseconds());
         static::assertSame(1, DateTime\Duration::nanoseconds(1)->getNanoseconds());
-        static::assertSame(0.0, DateTime\Duration::zero(1)->getTotalSeconds());
+        static::assertSame(0.0, DateTime\Duration::zero()->getTotalSeconds());
     }
 
     public static function provideGetTotalHours(): array

--- a/tests/unit/Dict/IntersectByKeyTest.php
+++ b/tests/unit/Dict/IntersectByKeyTest.php
@@ -11,6 +11,14 @@ use Psl\Vec;
 
 final class IntersectByKeyTest extends TestCase
 {
+    /**
+     * @template Tk as array-key
+     * @template Tv
+     *
+     * @param iterable<Tk, Tv> $first
+     * @param iterable<Tk, Tv> $second
+     * @param iterable<Tk, Tv> ...$rest
+     */
     #[DataProvider('provideData')]
     public function testIntersectByKey(array $expected, iterable $first, iterable $second, iterable ...$rest): void
     {

--- a/tests/unit/IO/CopyTest.php
+++ b/tests/unit/IO/CopyTest.php
@@ -73,7 +73,7 @@ final class CopyTest extends TestCase
     public function testCopyTimeout(): void
     {
         $listener = TCP\listen('127.0.0.1', 0);
-        $port = $listener->getLocalAddress()->port;
+        $port = $listener->getLocalAddress()->port ?? 0;
 
         $this->expectException(IO\Exception\TimeoutException::class);
 

--- a/tests/unit/Option/NoneTest.php
+++ b/tests/unit/Option/NoneTest.php
@@ -183,6 +183,12 @@ final class NoneTest extends TestCase
         static::assertTrue($y->zipWith($x, static fn(int $a, int $b): int => $a + $b)->isNone());
     }
 
+    /**
+     * @template X
+     * @template Y
+     *
+     * @param Option\Option<array{X, Y}> $option
+     */
     #[DataProvider('provideTestUnzip')]
     public function testUnzip(Option\Option $option): void
     {

--- a/tests/unit/Option/SomeTest.php
+++ b/tests/unit/Option/SomeTest.php
@@ -188,6 +188,12 @@ final class SomeTest extends TestCase
         static::assertTrue(Option\some(new Fixture\Point(17, 42))->equals($point));
     }
 
+    /**
+     * @template X
+     * @template Y
+     *
+     * @param Option\Option<array{X, Y}> $option
+     */
     #[DataProvider('provideTestUnzip')]
     public function testUnzip(Option\Option $option, mixed $expectedX, mixed $expectedY): void
     {

--- a/tests/unit/Regex/FirstMatchTest.php
+++ b/tests/unit/Regex/FirstMatchTest.php
@@ -13,6 +13,10 @@ use function Psl\Regex\capture_groups;
 
 final class FirstMatchTest extends TestCase
 {
+    /**
+     * @param non-empty-string $pattern
+     * @param TypeInterface<array<array-key, mixed>|null>|null $shape
+     */
     #[DataProvider('provideMatchingData')]
     public function testMatching(
         array $expected,
@@ -24,6 +28,9 @@ final class FirstMatchTest extends TestCase
         static::assertSame($expected, Regex\first_match($subject, $pattern, $shape, $offset));
     }
 
+    /**
+     * @param non-empty-string $pattern
+     */
     #[DataProvider('provideNonMatchingData')]
     public function testNotMatching(string $subject, string $pattern, int $offset = 0): void
     {

--- a/tests/unit/Str/Byte/RangeTest.php
+++ b/tests/unit/Str/Byte/RangeTest.php
@@ -19,7 +19,7 @@ final class RangeTest extends TestCase
     }
 
     /**
-     * @return list<{0: string, 1: string, 2: Range\RangeInterface}>
+     * @return list<array{0: string, 1: string, 2: Range\RangeInterface}>
      */
     public static function provideData(): array
     {

--- a/tests/unit/Str/MetaphoneTest.php
+++ b/tests/unit/Str/MetaphoneTest.php
@@ -10,6 +10,9 @@ use Psl\Str;
 
 final class MetaphoneTest extends TestCase
 {
+    /**
+     * @param non-negative-int $phonemes
+     */
     #[DataProvider('provideData')]
     public function testMetaphone(null|string $expected, string $str, int $phonemes = 0): void
     {

--- a/tests/unit/Str/RangeTest.php
+++ b/tests/unit/Str/RangeTest.php
@@ -19,7 +19,7 @@ final class RangeTest extends TestCase
     }
 
     /**
-     * @return list<{0: string, 1: string, 2: Range\RangeInterface}>
+     * @return list<array{0: string, 1: string, 2: Range\RangeInterface}>
      */
     public static function provideData(): array
     {

--- a/tests/unit/Str/SpliceTest.php
+++ b/tests/unit/Str/SpliceTest.php
@@ -10,6 +10,10 @@ use Psl\Str;
 
 final class SpliceTest extends TestCase
 {
+    /**
+     * @param non-negative-int $offset
+     * @param non-negative-int|null $length
+     */
     #[DataProvider('provideData')]
     public function testSplice(
         string $expected,

--- a/tests/unit/TCP/SocketTest.php
+++ b/tests/unit/TCP/SocketTest.php
@@ -61,7 +61,7 @@ final class SocketTest extends TestCase
     public function testConnectAndCommunicate(): void
     {
         $listener = TCP\listen('127.0.0.1', 0);
-        $port = $listener->getLocalAddress()->port;
+        $port = $listener->getLocalAddress()->port ?? 0;
 
         Async\concurrently([
             'server' => static function () use ($listener): void {
@@ -103,7 +103,7 @@ final class SocketTest extends TestCase
                 $listener->close();
             },
             'client' => static function () use ($address): void {
-                $client = TCP\connect('127.0.0.1', $address->port);
+                $client = TCP\connect('127.0.0.1', $address->port ?? 0);
                 $client->writeAll('ping');
                 $response = $client->readAll();
                 static::assertSame('pong', $response);
@@ -130,7 +130,7 @@ final class SocketTest extends TestCase
     public function testConnectWithTimeout(): void
     {
         $listener = TCP\listen('127.0.0.1', 0);
-        $port = $listener->getLocalAddress()->port;
+        $port = $listener->getLocalAddress()->port ?? 0;
 
         Async\concurrently([
             'server' => static function () use ($listener): void {
@@ -157,7 +157,7 @@ final class SocketTest extends TestCase
     public function testConnectConsumedByConnect(): void
     {
         $listener = TCP\listen('127.0.0.1', 0);
-        $port = $listener->getLocalAddress()->port;
+        $port = $listener->getLocalAddress()->port ?? 0;
 
         $socket = TCP\Socket::createV4();
         $stream = $socket->connect('127.0.0.1', $port);

--- a/tests/unit/TLS/ErrorCaseTest.php
+++ b/tests/unit/TLS/ErrorCaseTest.php
@@ -19,7 +19,7 @@ final class ErrorCaseTest extends TestCase
         $this->expectException(HandshakeFailedException::class);
 
         $listener = TCP\listen('127.0.0.1', 0);
-        $port = $listener->getLocalAddress()->port;
+        $port = $listener->getLocalAddress()->port ?? 0;
 
         Async\concurrently([
             'server' => static function () use ($listener): void {
@@ -45,7 +45,7 @@ final class ErrorCaseTest extends TestCase
         $this->expectExceptionMessage('Stream resource is not available.');
 
         $listener = TCP\listen('127.0.0.1', 0);
-        $port = $listener->getLocalAddress()->port;
+        $port = $listener->getLocalAddress()->port ?? 0;
 
         Async\concurrently([
             'server' => static function () use ($listener): void {
@@ -71,7 +71,7 @@ final class ErrorCaseTest extends TestCase
         $this->expectExceptionMessage('Stream resource is not available.');
 
         $listener = TCP\listen('127.0.0.1', 0);
-        $port = $listener->getLocalAddress()->port;
+        $port = $listener->getLocalAddress()->port ?? 0;
 
         Async\concurrently([
             'server' => static function () use ($listener): void {

--- a/tests/unit/TLS/LazyAcceptorTest.php
+++ b/tests/unit/TLS/LazyAcceptorTest.php
@@ -9,54 +9,14 @@ use Psl\Async;
 use Psl\TCP;
 use Psl\TLS;
 
-use function extension_loaded;
-
 final class LazyAcceptorTest extends TestCase
 {
-    /**
-     * @var array{cert_file: string, key_file: string}|null
-     */
-    private static null|array $certFiles = null;
-
-    public static function setUpBeforeClass(): void
-    {
-        if (!extension_loaded('openssl')) {
-            static::markTestSkipped('OpenSSL extension is required for TLS tests.');
-        }
-
-        $key = openssl_pkey_new([
-            'private_key_bits' => 2048,
-            'private_key_type' => OPENSSL_KEYTYPE_RSA,
-        ]);
-
-        $csr = openssl_csr_new([
-            'commonName' => 'localhost',
-            'organizationName' => 'PSL Test',
-        ], $key);
-
-        $cert = openssl_csr_sign($csr, null, $key, 1);
-
-        $cert_file = tempnam(sys_get_temp_dir(), 'psl_tls_cert_');
-        $key_file = tempnam(sys_get_temp_dir(), 'psl_tls_key_');
-
-        openssl_x509_export_to_file($cert, $cert_file);
-        openssl_pkey_export_to_file($key, $key_file);
-
-        self::$certFiles = ['cert_file' => $cert_file, 'key_file' => $key_file];
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$certFiles) {
-            @unlink(self::$certFiles['cert_file']);
-            @unlink(self::$certFiles['key_file']);
-            self::$certFiles = null;
-        }
-    }
+    private const CERT_FILE = __DIR__ . '/../../fixture/certs/server.crt';
+    private const KEY_FILE = __DIR__ . '/../../fixture/certs/server.key';
 
     public function testLazyAcceptorInspectsClientHelloAndCompletes(): void
     {
-        $cert = TLS\Certificate::create(self::$certFiles['cert_file'], self::$certFiles['key_file']);
+        $cert = TLS\Certificate::create(self::CERT_FILE, self::KEY_FILE);
         $serverConfig = TLS\ServerConfig::create($cert);
 
         $listener = TCP\listen('127.0.0.1', 0);
@@ -97,7 +57,7 @@ final class LazyAcceptorTest extends TestCase
 
     public function testLazyAcceptorWithAlpnProtocols(): void
     {
-        $cert = TLS\Certificate::create(self::$certFiles['cert_file'], self::$certFiles['key_file']);
+        $cert = TLS\Certificate::create(self::CERT_FILE, self::KEY_FILE);
 
         $listener = TCP\listen('127.0.0.1', 0);
         $port = $listener->getLocalAddress()->port;

--- a/tests/unit/Type/Internal/BackedEnumValueTypeTest.php
+++ b/tests/unit/Type/Internal/BackedEnumValueTypeTest.php
@@ -18,7 +18,7 @@ use ReflectionProperty;
 class BackedEnumValueTypeTest extends TestCase
 {
     /**
-     * @return list<array{0: class-string<BackedEnum>, 1: bool}
+     * @return list<array{0: class-string<BackedEnum>, 1: bool}>
      */
     public static function enumDataProvider(): array
     {

--- a/tests/unit/Vec/ReductionsTest.php
+++ b/tests/unit/Vec/ReductionsTest.php
@@ -26,7 +26,7 @@ final class ReductionsTest extends TestCase
     }
 
     /**
-     * @return iterable<array{0: list<int>, 1: iterable<int>, 2: (function(int, int, int): int)}>
+     * @return iterable<array{0: list<int>, 1: iterable<int>, 2: (Closure(int, int, int): int)}>
      */
     public static function provideData(): iterable
     {


### PR DESCRIPTION
- Use pre-generated fixture certificates in LazyAcceptorTest instead of runtime openssl generation
- Fix PHPDoc type annotations (malformed tuple syntax, missing generics, wrong callable syntax)
- Add null-coalescing for nullable port access in TCP/TLS tests
- Fix Duration::zero() call with incorrect argument
- Include vendor/phpbench in mago source paths and re-enable benchmark analysis
