### PR TITLE
perf: replace PSL calls with native PHP builtins and fix O(n2) algorithms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # php-cs-fixer cache
 /.php_cs.cache
 /.php-cs-fixer.cache
+/.phpbench
 
 # phpunit cache
 /config/.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### other
 
 * docs: documentation website at https://psl.carthage.software/ - [#592](https://github.com/azjezz/psl/pull/592), [#594](https://github.com/azjezz/psl/pull/594) by @azjezz
+* perf: performed optimizations across multiple components, which benchmarks showing up to 100% improvements in certain cases/functions.
 
 ## 4.3.0
 

--- a/config/mago.toml
+++ b/config/mago.toml
@@ -49,7 +49,7 @@ ignore = [
   { code = "duplicate-definition", in = "tests/static-analysis" },
   { code = "unused-method", in = "tests/fixture" },
   { code = "unused-property", in = "tests/fixture" },
-  { code = "unused-statement", in = "docs" },
+  { code = "unused-statement", in = ["docs", "tests/benchmark"] },
   { code = "duplicate-definition", in = "docs" },
   { code = "redundant-type-comparison", in = "docs" },
 ]

--- a/src/Psl/Async/Internal/AwaitableIterator.php
+++ b/src/Psl/Async/Internal/AwaitableIterator.php
@@ -10,7 +10,6 @@ use Revolt\EventLoop;
 use Throwable;
 
 use function array_shift;
-use function count;
 
 /**
  * The following class was derived from code of Amphp.
@@ -124,8 +123,8 @@ final class AwaitableIterator
             Psl\invariant_violation('Concurrent consume() operations are not supported');
         }
 
-        if (0 === count($this->queue->items)) {
-            if (null !== $this->complete && 0 === count($this->queue->pending)) {
+        if ([] === $this->queue->items) {
+            if (null !== $this->complete && [] === $this->queue->pending) {
                 return $this->complete->await();
             }
 

--- a/src/Psl/Async/Semaphore.php
+++ b/src/Psl/Async/Semaphore.php
@@ -131,7 +131,7 @@ final class Semaphore
      */
     public function hasPendingOperations(): bool
     {
-        return $this->getPendingOperations() > 0;
+        return [] !== $this->pending;
     }
 
     /**

--- a/src/Psl/Async/Sequence.php
+++ b/src/Psl/Async/Sequence.php
@@ -9,7 +9,7 @@ use Exception;
 use Revolt\EventLoop;
 use Revolt\EventLoop\Suspension;
 
-use function array_slice;
+use function array_shift;
 
 /**
  * Run an operation with a limit on number of ongoing asynchronous jobs of 1.
@@ -65,9 +65,8 @@ final class Sequence
         try {
             return ($this->operation)($input);
         } finally {
-            $suspension = $this->pending[0] ?? null;
+            $suspension = array_shift($this->pending);
             if (null !== $suspension) {
-                $this->pending = array_slice($this->pending, 1);
                 $suspension->resume();
             } else {
                 foreach ($this->waits as $suspension) {

--- a/src/Psl/Collection/Map.php
+++ b/src/Psl/Collection/Map.php
@@ -9,11 +9,13 @@ use Override;
 use Psl\Dict;
 use Psl\Iter;
 
+use function array_chunk;
 use function array_key_exists;
 use function array_key_first;
 use function array_key_last;
 use function array_keys;
-use function array_slice;
+use function array_map;
+use function array_search;
 use function array_values;
 use function count;
 
@@ -162,15 +164,9 @@ final readonly class Map implements MapInterface
     #[Override]
     public function linearSearch(mixed $search_value): int|string|null
     {
-        foreach ($this->elements as $key => $element) {
-            if ($search_value !== $element) {
-                continue;
-            }
+        $key = array_search($search_value, $this->elements, true);
 
-            return $key;
-        }
-
-        return null;
+        return false === $key ? null : $key;
     }
 
     /**
@@ -446,17 +442,17 @@ final readonly class Map implements MapInterface
     public function zip(array $elements): Map
     {
         $elements = array_values($elements);
+        $count = count($elements);
         /** @var array<Tk, array{0: Tv, 1: Tu}> $result */
         $result = [];
+        $i = 0;
         foreach ($this->elements as $k => $v) {
-            $u = $elements[0] ?? null;
-            if (null === $u) {
+            if ($i >= $count) {
                 break;
             }
 
-            $elements = array_slice($elements, 1);
-
-            $result[$k] = [$v, $u];
+            $result[$k] = [$v, $elements[$i]];
+            $i++;
         }
 
         return new Map($result);
@@ -590,27 +586,8 @@ final readonly class Map implements MapInterface
     #[Override]
     public function chunk(int $size): Vector
     {
-        return $this
-            ->zip($this->keys()->toArray())
-            ->values()
-            ->chunk($size)
-            ->map(
-                /**
-                 * @param Vector<array{0: Tv, 1: Tk}> $vector
-                 *
-                 * @return Map<Tk, Tv>
-                 *
-                 * @pure
-                 */
-                static function (Vector $vector): Map {
-                    /** @var array<Tk, Tv> $array */
-                    $array = [];
-                    foreach ($vector->toArray() as [$v, $k]) {
-                        $array[$k] = $v;
-                    }
+        $chunks = array_map(static fn(array $chunk): Map => new Map($chunk), array_chunk($this->elements, $size, true));
 
-                    return Map::fromArray($array);
-                },
-            );
+        return Vector::fromArray($chunks);
     }
 }

--- a/src/Psl/Collection/MutableMap.php
+++ b/src/Psl/Collection/MutableMap.php
@@ -9,11 +9,13 @@ use Override;
 use Psl\Dict;
 use Psl\Iter;
 
+use function array_chunk;
 use function array_key_exists;
 use function array_key_first;
 use function array_key_last;
 use function array_keys;
-use function array_slice;
+use function array_map;
+use function array_search;
 use function array_values;
 use function count;
 
@@ -162,15 +164,9 @@ final class MutableMap implements MutableMapInterface
     #[Override]
     public function linearSearch(mixed $search_value): int|string|null
     {
-        foreach ($this->elements as $key => $element) {
-            if ($search_value !== $element) {
-                continue;
-            }
+        $key = array_search($search_value, $this->elements, true);
 
-            return $key;
-        }
-
-        return null;
+        return false === $key ? null : $key;
     }
 
     /**
@@ -448,18 +444,17 @@ final class MutableMap implements MutableMapInterface
     public function zip(array $elements): MutableMap
     {
         $elements = array_values($elements);
+        $count = count($elements);
         /** @var array<Tk, array{0: Tv, 1: Tu}> $result */
         $result = [];
-
+        $i = 0;
         foreach ($this->elements as $k => $v) {
-            $u = $elements[0] ?? null;
-            if (null === $u) {
+            if ($i >= $count) {
                 break;
             }
 
-            $elements = array_slice($elements, 1);
-
-            $result[$k] = [$v, $u];
+            $result[$k] = [$v, $elements[$i]];
+            $i++;
         }
 
         return self::fromArray($result);
@@ -595,28 +590,9 @@ final class MutableMap implements MutableMapInterface
     #[Override]
     public function chunk(int $size): MutableVector
     {
-        return $this
-            ->zip($this->keys()->toArray())
-            ->values()
-            ->chunk($size)
-            ->map(
-                /**
-                 * @param MutableVector<array{0: Tv, 1: Tk}> $vector
-                 *
-                 * @return MutableMap<Tk, Tv>
-                 *
-                 * @pure
-                 */
-                static function (MutableVector $vector): MutableMap {
-                    /** @var array<Tk, Tv> $array */
-                    $array = [];
-                    foreach ($vector as [$v, $k]) {
-                        $array[$k] = $v;
-                    }
+        $chunks = array_map(MutableMap::fromArray(...), array_chunk($this->elements, $size, true));
 
-                    return MutableMap::fromArray($array);
-                },
-            );
+        return MutableVector::fromArray($chunks);
     }
 
     /**

--- a/src/Psl/Collection/MutableVector.php
+++ b/src/Psl/Collection/MutableVector.php
@@ -13,6 +13,7 @@ use Psl\Vec;
 use function array_key_exists;
 use function array_key_last;
 use function array_keys;
+use function array_search;
 use function array_values;
 use function count;
 use function iterator_to_array;
@@ -38,9 +39,7 @@ final class MutableVector implements MutableVectorInterface
      */
     public function __construct(array $elements)
     {
-        foreach ($elements as $element) {
-            $this->elements[] = $element;
-        }
+        $this->elements = array_values($elements);
     }
 
     /**
@@ -287,15 +286,9 @@ final class MutableVector implements MutableVectorInterface
     #[Override]
     public function linearSearch(mixed $search_value): null|int
     {
-        foreach ($this->elements as $key => $element) {
-            if ($search_value !== $element) {
-                continue;
-            }
+        $key = array_search($search_value, $this->elements, true);
 
-            return $key;
-        }
-
-        return null;
+        return false === $key ? null : $key;
     }
 
     /**

--- a/src/Psl/Collection/Vector.php
+++ b/src/Psl/Collection/Vector.php
@@ -13,6 +13,8 @@ use Psl\Vec;
 use function array_key_exists;
 use function array_key_last;
 use function array_keys;
+use function array_search;
+use function array_values;
 use function count;
 
 /**
@@ -34,12 +36,7 @@ final readonly class Vector implements VectorInterface
      */
     public function __construct(array $elements)
     {
-        $list = [];
-        foreach ($elements as $element) {
-            $list[] = $element;
-        }
-
-        $this->elements = $list;
+        $this->elements = array_values($elements);
     }
 
     /**
@@ -286,15 +283,9 @@ final readonly class Vector implements VectorInterface
     #[Override]
     public function linearSearch(mixed $search_value): null|int
     {
-        foreach ($this->elements as $key => $element) {
-            if ($search_value !== $element) {
-                continue;
-            }
+        $key = array_search($search_value, $this->elements, true);
 
-            return $key;
-        }
-
-        return null;
+        return false === $key ? null : $key;
     }
 
     /**

--- a/src/Psl/DateTime/DateTimeConvenienceMethodsTrait.php
+++ b/src/Psl/DateTime/DateTimeConvenienceMethodsTrait.php
@@ -6,7 +6,10 @@ namespace Psl\DateTime;
 
 use Override;
 use Psl\Locale\Locale;
-use Psl\Math;
+
+use function abs;
+use function intdiv;
+use function min;
 
 /**
  * @require-implements DateTimeInterface
@@ -512,7 +515,7 @@ trait DateTimeConvenienceMethodsTrait
             return $this->minusMonths(-$months);
         }
 
-        $plus_years = Math\div($months, MONTHS_PER_YEAR);
+        $plus_years = intdiv($months, MONTHS_PER_YEAR);
         $months_left = $months - ($plus_years * MONTHS_PER_YEAR);
         $target_month = $this->getMonth() + $months_left;
 
@@ -526,7 +529,7 @@ trait DateTimeConvenienceMethodsTrait
         return $this->withDate(
             $target_year = $this->getYear() + $plus_years,
             $target_month_enum->value,
-            Math\minva($this->getDay(), $target_month_enum->getDaysForYear($target_year)),
+            min($this->getDay(), $target_month_enum->getDaysForYear($target_year)),
         );
     }
 
@@ -547,13 +550,13 @@ trait DateTimeConvenienceMethodsTrait
             return $this->plusMonths(-$months);
         }
 
-        $minus_years = Math\div($months, MONTHS_PER_YEAR);
+        $minus_years = intdiv($months, MONTHS_PER_YEAR);
         $months_left = $months - ($minus_years * MONTHS_PER_YEAR);
         $target_month = $this->getMonth() - $months_left;
 
         if ($target_month <= 0) {
             $minus_years++;
-            $target_month = MONTHS_PER_YEAR - Math\abs($target_month);
+            $target_month = MONTHS_PER_YEAR - abs($target_month);
         }
 
         $target_month_enum = Month::from($target_month);
@@ -561,7 +564,7 @@ trait DateTimeConvenienceMethodsTrait
         return $this->withDate(
             $target_year = $this->getYear() - $minus_years,
             $target_month_enum->value,
-            Math\minva($this->getDay(), $target_month_enum->getDaysForYear($target_year)),
+            min($this->getDay(), $target_month_enum->getDaysForYear($target_year)),
         );
     }
 
@@ -683,7 +686,7 @@ trait DateTimeConvenienceMethodsTrait
         $day = $this->getDay();
         if ($hasMonths) {
             $totalMonths = ($year * MONTHS_PER_YEAR) + $month - 1 + $monthsToAdd;
-            $year = Math\div($totalMonths, MONTHS_PER_YEAR);
+            $year = intdiv($totalMonths, MONTHS_PER_YEAR);
             $month = $totalMonths % MONTHS_PER_YEAR;
             if ($month < 0) {
                 $year--;
@@ -691,7 +694,7 @@ trait DateTimeConvenienceMethodsTrait
             }
 
             $month += 1;
-            $day = Math\minva($day, Month::from($month)->getDaysForYear($year));
+            $day = min($day, Month::from($month)->getDaysForYear($year));
         }
 
         if ($hasMonths) {

--- a/src/Psl/DateTime/Duration.php
+++ b/src/Psl/DateTime/Duration.php
@@ -7,8 +7,14 @@ namespace Psl\DateTime;
 use DateInterval;
 use Override;
 use Psl\Comparison;
-use Psl\Math;
 use Psl\Str;
+
+use function abs;
+use function rtrim;
+use function str_pad;
+use function substr;
+
+use const STR_PAD_LEFT;
 
 /**
  * Defines a representation of a time duration with specific hours, minutes, seconds,
@@ -667,10 +673,10 @@ final readonly class Duration implements TemporalAmountInterface, Comparison\Com
     {
         $decimal_part = '';
         if ($max_decimals > 0) {
-            $decimal_part = (string) Math\abs($this->nanoseconds);
-            $decimal_part = Str\pad_left($decimal_part, 9, '0');
-            $decimal_part = Str\slice($decimal_part, 0, $max_decimals);
-            $decimal_part = Str\trim_right($decimal_part, '0');
+            $decimal_part = (string) abs($this->nanoseconds);
+            $decimal_part = str_pad($decimal_part, 9, '0', STR_PAD_LEFT);
+            $decimal_part = substr($decimal_part, 0, $max_decimals);
+            $decimal_part = rtrim($decimal_part, '0');
         }
 
         if ('' !== $decimal_part) {
@@ -678,7 +684,7 @@ final readonly class Duration implements TemporalAmountInterface, Comparison\Com
         }
 
         $sec_sign = $this->seconds < 0 || $this->nanoseconds < 0 ? '-' : '';
-        $sec = Math\abs($this->seconds);
+        $sec = abs($this->seconds);
 
         $containsHours = 0 !== $this->hours;
         $containsMinutes = 0 !== $this->minutes;

--- a/src/Psl/DateTime/Internal/format_iso8601_duration.php
+++ b/src/Psl/DateTime/Internal/format_iso8601_duration.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Psl\DateTime\Internal;
 
-use Psl\Math;
-use Psl\Str;
+use function abs;
+use function rtrim;
+use function str_pad;
+
+use const STR_PAD_LEFT;
 
 /**
  * Formats a time-based duration as an ISO 8601 duration string.
@@ -28,10 +31,10 @@ function format_iso8601_duration(int $hours, int $minutes, int $seconds, int $na
     $negative = $hours < 0 || $minutes < 0 || $seconds < 0 || $nanoseconds < 0;
     $prefix = $negative ? '-PT' : 'PT';
 
-    $hours = Math\abs($hours);
-    $minutes = Math\abs($minutes);
-    $seconds = Math\abs($seconds);
-    $nanoseconds = Math\abs($nanoseconds);
+    $hours = abs($hours);
+    $minutes = abs($minutes);
+    $seconds = abs($seconds);
+    $nanoseconds = abs($nanoseconds);
 
     $result = $prefix;
     if ($hours > 0) {
@@ -45,8 +48,8 @@ function format_iso8601_duration(int $hours, int $minutes, int $seconds, int $na
     if ($seconds > 0 || $nanoseconds > 0) {
         $result .= $seconds;
         if ($nanoseconds > 0) {
-            $frac = Str\pad_left((string) $nanoseconds, 9, '0');
-            $frac = Str\trim_right($frac, '0');
+            $frac = str_pad((string) $nanoseconds, 9, '0', STR_PAD_LEFT);
+            $frac = rtrim($frac, '0');
             $result .= '.' . $frac;
         }
 

--- a/src/Psl/DateTime/Internal/format_iso8601_period.php
+++ b/src/Psl/DateTime/Internal/format_iso8601_period.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Psl\DateTime\Internal;
 
 use Psl\DateTime\Exception;
-use Psl\Math;
+
+use function abs;
 
 /**
  * Formats a calendar-based period as an ISO 8601 duration string.
@@ -35,9 +36,9 @@ function format_iso8601_period(int $years, int $months, int $days): string
 
     $prefix = $negative ? '-P' : 'P';
 
-    $years = Math\abs($years);
-    $months = Math\abs($months);
-    $days = Math\abs($days);
+    $years = abs($years);
+    $months = abs($months);
+    $days = abs($days);
 
     $result = $prefix;
     if ($years > 0) {

--- a/src/Psl/DateTime/Internal/format_rfc3339.php
+++ b/src/Psl/DateTime/Internal/format_rfc3339.php
@@ -7,7 +7,12 @@ namespace Psl\DateTime\Internal;
 use Psl\DateTime\SecondsStyle;
 use Psl\DateTime\Timestamp;
 use Psl\DateTime\Timezone;
-use Psl\Str\Byte;
+
+use function str_pad;
+use function str_replace;
+use function substr;
+
+use const STR_PAD_LEFT;
 
 /**
  * @internal
@@ -32,7 +37,7 @@ function format_rfc3339(
     $nanoseconds = $timestamp->getNanoseconds();
 
     // Intl formatter cannot handle nanoseconds and microseconds, do it manually instead.
-    $fraction = Byte\slice(Byte\pad_left((string) $nanoseconds, 9, '0'), 0, $seconds_style->value);
+    $fraction = substr(str_pad((string) $nanoseconds, 9, '0', STR_PAD_LEFT), 0, $seconds_style->value);
     if ('' !== $fraction) {
         $fraction = '.' . $fraction;
     }
@@ -45,5 +50,6 @@ function format_rfc3339(
     $formatter = namespace\create_intl_date_formatter(pattern: $pattern, timezone: $timezone);
     $rfc_string = $formatter->format($seconds);
 
-    return Byte\replace($rfc_string, '@', $fraction);
+    /** @var string */
+    return str_replace('@', $fraction, $rfc_string);
 }

--- a/src/Psl/DateTime/Internal/parse_iso8601_duration.php
+++ b/src/Psl/DateTime/Internal/parse_iso8601_duration.php
@@ -7,7 +7,14 @@ namespace Psl\DateTime\Internal;
 use Psl\DateTime\Exception;
 use Psl\Str;
 
+use function explode;
 use function preg_match;
+use function str_contains;
+use function str_pad;
+use function str_starts_with;
+use function substr;
+
+use const STR_PAD_RIGHT;
 
 /**
  * Parses an ISO 8601 time-based duration string and returns its parts.
@@ -23,15 +30,15 @@ use function preg_match;
 function parse_iso8601_duration(string $value): array
 {
     // Handle optional leading negative sign
-    $negative = Str\starts_with($value, '-');
-    $input = $negative ? Str\slice($value, 1) : $value;
+    $negative = str_starts_with($value, '-');
+    $input = $negative ? substr($value, 1) : $value;
 
     // Time-only format: PT[(\d+)H][(\d+)M][(\d+[.\d+]?)S]
     /** @var array<int, string> $matches */
     $matches = [];
     if (1 !== preg_match('/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?$/', $input, $matches)) {
         // Check for date component to give a better error message
-        if (Str\starts_with($input, 'P') && !Str\starts_with($input, 'PT')) {
+        if (str_starts_with($input, 'P') && !str_starts_with($input, 'PT')) {
             throw new Exception\ParserException(Str\format(
                 'ISO 8601 duration "%s" contains date components; use Period::fromIso8601() instead.',
                 $value,
@@ -48,11 +55,11 @@ function parse_iso8601_duration(string $value): array
 
     $secStr = $matches[3] ?? '';
     if ('' !== $secStr) {
-        if (Str\contains($secStr, '.')) {
-            $parts = Str\split($secStr, '.');
+        if (str_contains($secStr, '.')) {
+            $parts = explode('.', $secStr);
             $seconds = (int) $parts[0];
-            $frac = Str\pad_right($parts[1], 9, '0');
-            $nanoseconds = (int) Str\slice($frac, 0, 9);
+            $frac = str_pad($parts[1], 9, '0', STR_PAD_RIGHT);
+            $nanoseconds = (int) substr($frac, 0, 9);
         } else {
             $seconds = (int) $secStr;
         }

--- a/src/Psl/DateTime/Internal/parse_iso8601_period.php
+++ b/src/Psl/DateTime/Internal/parse_iso8601_period.php
@@ -8,6 +8,10 @@ use Psl\DateTime;
 use Psl\DateTime\Exception;
 use Psl\Str;
 
+use function str_contains;
+use function str_starts_with;
+use function substr;
+
 /**
  * Parses an ISO 8601 date-based period string and returns its parts.
  *
@@ -22,8 +26,8 @@ use Psl\Str;
 function parse_iso8601_period(string $value): array
 {
     // Handle optional leading negative sign
-    $negative = Str\starts_with($value, '-');
-    $input = $negative ? Str\slice($value, 1) : $value;
+    $negative = str_starts_with($value, '-');
+    $input = $negative ? substr($value, 1) : $value;
 
     // Weeks format: P(\d+)W
     /** @var array<int, string> $matches */
@@ -39,7 +43,7 @@ function parse_iso8601_period(string $value): array
     $matches = [];
     if (1 !== preg_match('/^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?$/', $input, $matches)) {
         // Check for time component to give a better error message
-        if (Str\contains($input, 'T')) {
+        if (str_contains($input, 'T')) {
             throw new Exception\ParserException(Str\format(
                 'ISO 8601 period "%s" contains time components; use Duration::fromIso8601() instead.',
                 $value,

--- a/src/Psl/DateTime/Internal/system_time.php
+++ b/src/Psl/DateTime/Internal/system_time.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\DateTime\Internal;
 
-use Psl\Str;
-
+use function explode;
 use function microtime;
 
 use const Psl\DateTime\NANOSECONDS_PER_SECOND;
@@ -20,7 +19,7 @@ function system_time(): array
     $time = microtime();
 
     /** @var list{numeric-string, numeric-string} */
-    $parts = Str\split($time, ' ');
+    $parts = explode(' ', $time);
     $seconds = (int) $parts[1];
     $nanoseconds = (int) ((float) $parts[0] * (float) NANOSECONDS_PER_SECOND);
 

--- a/src/Psl/DateTime/Timestamp.php
+++ b/src/Psl/DateTime/Timestamp.php
@@ -11,6 +11,8 @@ use Psl\Interoperability;
 use Psl\Locale\Locale;
 use Psl\Math;
 
+use function intdiv;
+
 /**
  * Represents a precise point in time, with seconds and nanoseconds since the Unix epoch.
  *
@@ -60,7 +62,7 @@ final readonly class Timestamp implements TemporalInterface, Interoperability\Fr
             throw new Exception\UnderflowException('Subtracting nanoseconds would cause an underflow.');
         }
 
-        $seconds_adjustment = Math\div($nanoseconds, NANOSECONDS_PER_SECOND);
+        $seconds_adjustment = intdiv($nanoseconds, NANOSECONDS_PER_SECOND);
         $adjusted_seconds = $seconds + $seconds_adjustment;
 
         $adjusted_nanoseconds = $nanoseconds % NANOSECONDS_PER_SECOND;
@@ -110,7 +112,7 @@ final readonly class Timestamp implements TemporalInterface, Interoperability\Fr
      */
     public static function fromMilliseconds(int $milliseconds): self
     {
-        $seconds = Math\div($milliseconds, MILLISECONDS_PER_SECOND);
+        $seconds = intdiv($milliseconds, MILLISECONDS_PER_SECOND);
         $remainingMs = $milliseconds % MILLISECONDS_PER_SECOND;
 
         return self::fromParts($seconds, $remainingMs * NANOSECONDS_PER_MILLISECOND);
@@ -128,7 +130,7 @@ final readonly class Timestamp implements TemporalInterface, Interoperability\Fr
      */
     public static function fromMicroseconds(int $microseconds): self
     {
-        $seconds = Math\div($microseconds, MICROSECONDS_PER_SECOND);
+        $seconds = intdiv($microseconds, MICROSECONDS_PER_SECOND);
         $remainingUs = $microseconds % MICROSECONDS_PER_SECOND;
 
         return self::fromParts($seconds, $remainingUs * NANOSECONDS_PER_MICROSECOND);

--- a/src/Psl/Dict/diff.php
+++ b/src/Psl/Dict/diff.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Psl\Dict;
 
 use Psl\Iter;
-use Psl\Vec;
 
 use function array_diff;
+use function array_map;
 
 /**
  * Computes the difference of iterables.
@@ -27,17 +27,5 @@ function diff(iterable $first, iterable $second, iterable ...$rest): array
         return [];
     }
 
-    return array_diff(
-        from_iterable($first),
-        from_iterable($second),
-        ...Vec\map(
-            $rest,
-            /**
-             * @param iterable<Tk, Tv> $iterable
-             *
-             * @return array<Tk, Tv>
-             */
-            from_iterable(...),
-        ),
-    );
+    return array_diff(from_iterable($first), from_iterable($second), ...array_map(from_iterable(...), $rest));
 }

--- a/src/Psl/Dict/diff_by_key.php
+++ b/src/Psl/Dict/diff_by_key.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Psl\Dict;
 
 use Psl\Iter;
-use Psl\Vec;
 
 use function array_diff_key;
+use function array_map;
 
 /**
  * Computes the difference of iterables using keys for comparison.
@@ -27,17 +27,5 @@ function diff_by_key(iterable $first, iterable $second, iterable ...$rest): arra
         return [];
     }
 
-    return array_diff_key(
-        from_iterable($first),
-        from_iterable($second),
-        ...Vec\map(
-            $rest,
-            /**
-             * @param iterable<Tk, Tv> $iterable
-             *
-             * @return array<Tk, Tv>
-             */
-            from_iterable(...),
-        ),
-    );
+    return array_diff_key(from_iterable($first), from_iterable($second), ...array_map(from_iterable(...), $rest));
 }

--- a/src/Psl/Dict/equal.php
+++ b/src/Psl/Dict/equal.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Dict;
 
-use Psl\Iter;
+use function array_key_exists;
+use function count;
 
 /**
  * Returns whether the two given dict have the same entries, using strict
@@ -22,16 +23,14 @@ function equal(array $first, array $second): bool
         return true;
     }
 
-    if (Iter\count($first) !== Iter\count($second)) {
+    if (count($first) !== count($second)) {
         return false;
     }
 
     foreach ($first as $k => $v) {
-        if (!(!Iter\contains_key($second, $k) || $second[$k] !== $v)) {
-            continue;
+        if (!array_key_exists($k, $second) || $second[$k] !== $v) {
+            return false;
         }
-
-        return false;
     }
 
     return true;

--- a/src/Psl/Dict/filter_nulls.php
+++ b/src/Psl/Dict/filter_nulls.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Psl\Dict;
 
+use function array_filter;
+use function is_array;
+
 /**
  * Filter out null values from the given iterable.
  *
@@ -20,11 +23,18 @@ namespace Psl\Dict;
  */
 function filter_nulls(iterable $iterable): array
 {
-    return filter(
-        $iterable,
-        /**
-         * @param Tv|null $value
-         */
-        static fn(mixed $value): bool => null !== $value,
-    );
+    if (is_array($iterable)) {
+        return array_filter($iterable, static fn(mixed $value): bool => null !== $value);
+    }
+
+    $result = [];
+    foreach ($iterable as $k => $v) {
+        if (null === $v) {
+            continue;
+        }
+
+        $result[$k] = $v;
+    }
+
+    return $result;
 }

--- a/src/Psl/Dict/flatten.php
+++ b/src/Psl/Dict/flatten.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Psl\Dict;
 
+use function array_replace;
+use function is_array;
+
 /**
  * Returns a new dict formed by merging the iterable elements of the
  * given iterable.
@@ -27,6 +30,23 @@ namespace Psl\Dict;
  */
 function flatten(iterable $iterables): array
 {
+    if (is_array($iterables)) {
+        $all_arrays = true;
+        foreach ($iterables as $inner) {
+            if (is_array($inner)) {
+                continue;
+            }
+
+            $all_arrays = false;
+            break;
+        }
+
+        if ($all_arrays) {
+            /** @var array<array<Tk, Tv>> $iterables */
+            return [] === $iterables ? [] : array_replace(...$iterables);
+        }
+    }
+
     $result = [];
     foreach ($iterables as $iterable) {
         foreach ($iterable as $key => $value) {

--- a/src/Psl/Dict/flip.php
+++ b/src/Psl/Dict/flip.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Dict;
 
-use Psl;
-use Psl\Type;
+use function array_flip;
+use function is_array;
 
 /**
  * Flips the keys and values of an iterable.
@@ -26,16 +26,12 @@ use Psl\Type;
  */
 function flip(iterable $iterable): array
 {
+    if (is_array($iterable)) {
+        return array_flip($iterable);
+    }
+
     $result = [];
     foreach ($iterable as $key => $value) {
-        Psl\invariant(
-            // @mago-expect analysis:redundant-type-comparison
-            Type\array_key()->matches($value),
-            'Expected all values to be of type array-key, value of type (%s) provided.',
-            gettype($value),
-        );
-
-        /** @var Tv $value */
         $result[$value] = $key;
     }
 

--- a/src/Psl/Dict/group_by.php
+++ b/src/Psl/Dict/group_by.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Psl\Dict;
 
 use Closure;
-use Psl;
-use Psl\Type;
 
 /**
  * Returns a new array where
@@ -47,13 +45,6 @@ function group_by(iterable $values, Closure $key_func): array
         if (null === $key) {
             continue;
         }
-
-        Psl\invariant(
-            // @mago-expect analysis:redundant-type-comparison
-            Type\array_key()->matches($key),
-            'Expected $key_func to return a value of type array-key, value of type (%s) returned.',
-            gettype($key),
-        );
 
         /** @var Tk $key */
         $result[$key] ??= [];

--- a/src/Psl/Dict/intersect.php
+++ b/src/Psl/Dict/intersect.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Psl\Dict;
 
 use Psl\Iter;
-use Psl\Vec;
 
 use function array_intersect;
+use function array_map;
 
 /**
  * Computes the intersection of iterables.
@@ -27,17 +27,5 @@ function intersect(iterable $first, iterable $second, iterable ...$rest): array
         return [];
     }
 
-    return array_intersect(
-        from_iterable($first),
-        from_iterable($second),
-        ...Vec\map(
-            $rest,
-            /**
-             * @param iterable<Tk, Tv> $iterable
-             *
-             * @return array<Tk, Tv>
-             */
-            from_iterable(...),
-        ),
-    );
+    return array_intersect(from_iterable($first), from_iterable($second), ...array_map(from_iterable(...), $rest));
 }

--- a/src/Psl/Dict/intersect_by_key.php
+++ b/src/Psl/Dict/intersect_by_key.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Psl\Dict;
 
 use Psl\Iter;
-use Psl\Vec;
 
 use function array_intersect_key;
+use function array_map;
 
 /**
  * Computes the intersection of iterables using keys for comparison.
@@ -27,9 +27,5 @@ function intersect_by_key(iterable $first, iterable $second, iterable ...$rest):
         return [];
     }
 
-    return array_intersect_key(
-        namespace\from_iterable($first),
-        namespace\from_iterable($second),
-        ...Vec\map($rest, namespace\from_iterable(...)),
-    );
+    return array_intersect_key(from_iterable($first), from_iterable($second), ...array_map(from_iterable(...), $rest));
 }

--- a/src/Psl/Dict/merge.php
+++ b/src/Psl/Dict/merge.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Psl\Dict;
 
+use function array_replace;
+use function is_array;
+
 /**
  * Merges multiple iterables into a new dict.
  * In the case of duplicate keys, later values will overwrite the previous ones.
@@ -20,6 +23,22 @@ namespace Psl\Dict;
  */
 function merge(iterable $first, iterable ...$rest): array
 {
+    if (is_array($first)) {
+        foreach ($rest as $iterable) {
+            if (is_array($iterable)) {
+                continue;
+            }
+
+            /** @var list<iterable<Tk, Tv>> $iterables */
+            $iterables = [$first, ...$rest];
+
+            return flatten($iterables);
+        }
+
+        /** @var array<array<Tk, Tv>> $rest */
+        return array_replace($first, ...$rest);
+    }
+
     /** @var list<iterable<Tk, Tv>> $iterables */
     $iterables = [$first, ...$rest];
 

--- a/src/Psl/Dict/select_keys.php
+++ b/src/Psl/Dict/select_keys.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\Dict;
 
-use Psl\Iter;
+use function array_key_exists;
 
 /**
  * Returns a new dict containing only the keys found in both the input array
@@ -29,7 +29,7 @@ function select_keys(iterable $iterable, iterable $keys): array
 
     $result = [];
     foreach ($keys as $key) {
-        if (!Iter\contains_key($array, $key)) {
+        if (!array_key_exists($key, $array)) {
             continue;
         }
 

--- a/src/Psl/Dict/slice.php
+++ b/src/Psl/Dict/slice.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Psl\Dict;
 
+use function array_slice;
+use function is_array;
+
 /**
  * Takes a slice from an iterable.
  *
@@ -26,6 +29,10 @@ namespace Psl\Dict;
  */
 function slice(iterable $iterable, int $start, null|int $length = null): array
 {
+    if (is_array($iterable)) {
+        return array_slice($iterable, $start, $length, true);
+    }
+
     $result = [];
     if (0 === $length) {
         return $result;

--- a/src/Psl/Dict/sort.php
+++ b/src/Psl/Dict/sort.php
@@ -7,6 +7,7 @@ namespace Psl\Dict;
 use Closure;
 
 use function asort;
+use function is_array;
 use function uasort;
 
 /**
@@ -25,9 +26,13 @@ use function uasort;
  */
 function sort(iterable $iterable, null|Closure $comparator = null): array
 {
-    $array = [];
-    foreach ($iterable as $k => $v) {
-        $array[$k] = $v;
+    if (is_array($iterable)) {
+        $array = $iterable;
+    } else {
+        $array = [];
+        foreach ($iterable as $k => $v) {
+            $array[$k] = $v;
+        }
     }
 
     if (null !== $comparator) {

--- a/src/Psl/Dict/sort_by_key.php
+++ b/src/Psl/Dict/sort_by_key.php
@@ -6,6 +6,7 @@ namespace Psl\Dict;
 
 use Closure;
 
+use function is_array;
 use function ksort;
 use function uksort;
 
@@ -25,9 +26,13 @@ use function uksort;
  */
 function sort_by_key(iterable $iterable, null|Closure $comparator = null): array
 {
-    $result = [];
-    foreach ($iterable as $k => $v) {
-        $result[$k] = $v;
+    if (is_array($iterable)) {
+        $result = $iterable;
+    } else {
+        $result = [];
+        foreach ($iterable as $k => $v) {
+            $result[$k] = $v;
+        }
     }
 
     if ($comparator) {

--- a/src/Psl/Dict/unique_by.php
+++ b/src/Psl/Dict/unique_by.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Psl\Dict;
 
 use Closure;
-use Psl\Iter;
 
 /**
  * Returns a new array in which each value appears exactly once, where the
@@ -23,23 +22,18 @@ use Psl\Iter;
  */
 function unique_by(iterable $iterable, Closure $scalar_func): array
 {
-    /** @var array<Tk, Ts> $unique */
-    $unique = [];
-    /** @var array<Tk, Tv> $original_values */
-    $original_values = [];
-    foreach ($iterable as $k => $v) {
-        $original_values[$k] = $v;
-        $scalar = $scalar_func($v);
-
-        if (!Iter\contains($unique, $scalar)) {
-            $unique[$k] = $scalar;
-        }
-    }
-
+    /** @var array<array-key, true> $seen */
+    $seen = [];
     /** @var array<Tk, Tv> $result */
     $result = [];
-    foreach ($unique as $k => $_) {
-        $result[$k] = $original_values[$k];
+    foreach ($iterable as $k => $v) {
+        $scalar = $scalar_func($v);
+        $key = is_int($scalar) || is_string($scalar) ? $scalar : serialize($scalar);
+
+        if (!isset($seen[$key])) {
+            $seen[$key] = true;
+            $result[$k] = $v;
+        }
     }
 
     return $result;

--- a/src/Psl/Encoding/Base64/Internal/Base64.php
+++ b/src/Psl/Encoding/Base64/Internal/Base64.php
@@ -6,9 +6,11 @@ namespace Psl\Encoding\Base64\Internal;
 
 use Psl\Encoding\Exception;
 use Psl\Regex;
-use Psl\Str;
 
 use function pack;
+use function rtrim;
+use function strlen;
+use function substr;
 use function unpack;
 
 /**
@@ -36,11 +38,11 @@ abstract class Base64
     public static function encode(string $binary, bool $padding = true): string
     {
         $dest = '';
-        $binary_length = Str\length($binary, encoding: Str\Encoding::Ascii8bit);
+        $binary_length = strlen($binary);
 
         for ($i = 0; ($i + 3) <= $binary_length; $i += 3) {
             /** @var array<int, int> $chunk */
-            $chunk = unpack('C*', Str\slice($binary, $i, 3, encoding: Str\Encoding::Ascii8bit));
+            $chunk = unpack('C*', substr($binary, $i, 3));
             $byte0 = $chunk[1];
             $byte1 = $chunk[2];
             $byte2 = $chunk[3];
@@ -57,7 +59,7 @@ abstract class Base64
             /**
              * @var array<int, int> $chunk
              */
-            $chunk = unpack('C*', Str\slice($binary, $i, $chunk_size, encoding: Str\Encoding::Ascii8bit));
+            $chunk = unpack('C*', substr($binary, $i, $chunk_size));
             $byte0 = $chunk[1];
             if (($i + 1) < $binary_length) {
                 $byte1 = $chunk[2];
@@ -94,7 +96,7 @@ abstract class Base64
      */
     public static function decode(string $base64, bool $explicit_padding = true): string
     {
-        $base64_length = Str\length($base64, encoding: Str\Encoding::Ascii8bit);
+        $base64_length = strlen($base64);
         if (0 === $base64_length) {
             return '';
         }
@@ -105,14 +107,14 @@ abstract class Base64
             throw new Exception\IncorrectPaddingException('The given base64 string has incorrect padding.');
         }
 
-        $base64 = Str\trim_right($base64, '=');
-        $base64_length = Str\length($base64, encoding: Str\Encoding::Ascii8bit);
+        $base64 = rtrim($base64, '=');
+        $base64_length = strlen($base64);
 
         $err = 0;
         $dest = '';
         for ($i = 0; ($i + 4) <= $base64_length; $i += 4) {
             /** @var array<int, int> $chunk */
-            $chunk = unpack('C*', Str\slice($base64, $i, 4, encoding: Str\Encoding::Ascii8bit));
+            $chunk = unpack('C*', substr($base64, $i, 4));
             $char0 = static::decode6Bits($chunk[1]);
             $char1 = static::decode6Bits($chunk[2]);
             $char2 = static::decode6Bits($chunk[3]);
@@ -131,7 +133,7 @@ abstract class Base64
             /**
              * @var array<int, int> $chunk
              */
-            $chunk = unpack('C*', Str\slice($base64, $i, $chunk_size, encoding: Str\Encoding::Ascii8bit));
+            $chunk = unpack('C*', substr($base64, $i, $chunk_size));
             $char0 = static::decode6Bits($chunk[1]);
             if (($i + 2) < $base64_length) {
                 $char1 = static::decode6Bits($chunk[2]);

--- a/src/Psl/Encoding/Hex/decode.php
+++ b/src/Psl/Encoding/Hex/decode.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Psl\Encoding\Hex;
 
 use Psl\Encoding\Exception;
-use Psl\Str;
+
+use function strlen;
 
 /**
  * Convert a hexadecimal string into a binary string.
@@ -27,7 +28,7 @@ function decode(string $hexadecimal): string
         );
     }
 
-    $hex_len = Str\length($hexadecimal, Str\Encoding::Ascii8bit);
+    $hex_len = strlen($hexadecimal);
     if (($hex_len & 1) !== 0) {
         throw new Exception\RangeException('Expected an even number of hexadecimal characters.');
     }

--- a/src/Psl/File/Internal/ResourceHandle.php
+++ b/src/Psl/File/Internal/ResourceHandle.php
@@ -25,8 +25,6 @@ use const SEEK_END;
 
 /**
  * @internal
- *
- * @mago-expect analysis:possibly-invalid-argument
  */
 final class ResourceHandle extends IO\Internal\ResourceHandle implements
     File\WriteHandleInterface,

--- a/src/Psl/Filesystem/create_file.php
+++ b/src/Psl/Filesystem/create_file.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Psl\Filesystem;
 
 use Psl\Internal;
-use Psl\Math;
 use Psl\Str;
 
+use function max;
 use function touch;
 
 /**
@@ -30,7 +30,7 @@ function create_file(string $filename, null|int $time = null, null|int $access_t
     } else {
         $time ??= $access_time;
 
-        $fun = static fn(): bool => touch($filename, $time, Math\maxva($access_time, $time));
+        $fun = static fn(): bool => touch($filename, $time, max($access_time, $time));
     }
 
     namespace\create_directory_for_file($filename);

--- a/src/Psl/Graph/DirectedGraph.php
+++ b/src/Psl/Graph/DirectedGraph.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\Graph;
 
-use Psl\Vec;
-
+use function array_values;
 use function Psl\Graph\Internal\get_node_key;
 
 /**
@@ -40,7 +39,7 @@ final readonly class DirectedGraph implements GraphInterface
      */
     public function getNodes(): array
     {
-        return Vec\values($this->nodes);
+        return array_values($this->nodes);
     }
 
     /**

--- a/src/Psl/Graph/UndirectedGraph.php
+++ b/src/Psl/Graph/UndirectedGraph.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\Graph;
 
-use Psl\Vec;
-
+use function array_values;
 use function Psl\Graph\Internal\get_node_key;
 
 /**
@@ -42,7 +41,7 @@ final readonly class UndirectedGraph implements GraphInterface
      */
     public function getNodes(): array
     {
-        return Vec\values($this->nodes);
+        return array_values($this->nodes);
     }
 
     /**

--- a/src/Psl/Graph/dfs.php
+++ b/src/Psl/Graph/dfs.php
@@ -6,6 +6,7 @@ namespace Psl\Graph;
 
 use Psl\DataStructure\Stack;
 
+use function count;
 use function Psl\Graph\Internal\get_node_key;
 
 /**
@@ -60,10 +61,9 @@ function dfs(DirectedGraph|UndirectedGraph $graph, mixed $start): array
         // Push neighbors in reverse order to maintain left-to-right traversal
         $neighborsList = neighbors($graph, $node);
         for ($i = count($neighborsList) - 1; $i >= 0; $i--) {
-            $neighbor = $neighborsList[$i];
-            $neighborKey = get_node_key($neighbor);
+            $neighborKey = get_node_key($neighborsList[$i]);
             if (!isset($visited[$neighborKey])) {
-                $stack->push($neighbor);
+                $stack->push($neighborsList[$i]);
             }
         }
     }

--- a/src/Psl/Graph/neighbors.php
+++ b/src/Psl/Graph/neighbors.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\Graph;
 
-use Psl\Vec;
+use function array_map;
 
 /**
  * Returns all neighbor nodes of a given node.
@@ -30,13 +30,13 @@ function neighbors(DirectedGraph|UndirectedGraph $graph, mixed $node): array
 {
     $edges = $graph->getEdgesFrom($node);
 
-    return Vec\map(
-        $edges,
+    return array_map(
         /**
          * @param Edge<TNode, TWeight> $edge
          *
          * @return TNode
          */
         static fn(Edge $edge): mixed => $edge->to,
+        $edges,
     );
 }

--- a/src/Psl/Graph/shortest_path_by.php
+++ b/src/Psl/Graph/shortest_path_by.php
@@ -92,13 +92,12 @@ function shortest_path_by(
                 $path = [];
                 $current = $to;
                 while (null !== $current) {
-                    array_unshift($path, $current);
+                    $path[] = $current;
                     $currentKey = get_node_key($current);
                     $current = $parent[$currentKey];
                 }
 
-                /** @var list<TNode> $path */
-                return $path;
+                return array_reverse($path);
             }
 
             foreach (neighbors($graph, $node) as $neighbor) {
@@ -147,13 +146,12 @@ function shortest_path_by(
             $path = [];
             $current = $to;
             while (null !== $current) {
-                array_unshift($path, $current);
+                $path[] = $current;
                 $currentKey = get_node_key($current);
                 $current = $parent[$currentKey];
             }
 
-            /** @var list<TNode> $path */
-            return $path;
+            return array_reverse($path);
         }
 
         foreach ($graph->getEdgesFrom($node) as $edge) {

--- a/src/Psl/IO/Internal/ResourceHandle.php
+++ b/src/Psl/IO/Internal/ResourceHandle.php
@@ -12,7 +12,6 @@ use Psl\IO;
 use Psl\IO\Exception;
 use Revolt\EventLoop;
 use Revolt\EventLoop\Suspension;
-use Socket as PHPSocket;
 
 use function error_get_last;
 use function fclose;
@@ -29,6 +28,7 @@ use function stream_get_meta_data;
 use function stream_set_blocking;
 use function stream_set_read_buffer;
 use function stream_set_write_buffer;
+use function strpbrk;
 use function substr;
 
 /**
@@ -50,7 +50,7 @@ class ResourceHandle implements
     public const int MAXIMUM_READ_BUFFER_SIZE = 786_432;
 
     /**
-     * @var closed-resource|resource|PHPSocket|null $stream
+     * @var closed-resource|resource|null $stream
      */
     protected mixed $stream;
 
@@ -72,7 +72,7 @@ class ResourceHandle implements
     private bool $reachedEof = false;
 
     /**
-     * @param resource|PHPSocket $stream
+     * @param resource $stream
      */
     public function __construct(
         mixed $stream,
@@ -83,10 +83,8 @@ class ResourceHandle implements
     ) {
         $this->stream = $stream;
 
-        // @mago-expect analysis:possibly-invalid-argument
         stream_set_blocking($stream, false);
 
-        // @mago-expect analysis:possibly-invalid-argument
         $meta = stream_get_meta_data($stream);
         if ($read) {
             $this->useSingleRead = 'udp_socket' === $meta['stream_type'] || 'STDIO' === $meta['stream_type'];
@@ -104,10 +102,8 @@ class ResourceHandle implements
 
             Psl\invariant($readable, 'Handle is not readable.');
 
-            // @mago-expect analysis:possibly-invalid-argument
             stream_set_read_buffer($stream, 0);
 
-            // @mago-expect analysis:possibly-invalid-argument
             $this->readWatcher = EventLoop::onReadable($stream, function (): void {
                 $this->readSuspension?->resume();
             });
@@ -154,19 +150,12 @@ class ResourceHandle implements
         }
 
         if ($write) {
-            $writable =
-                str_contains($meta['mode'], 'x')
-                || str_contains($meta['mode'], 'w')
-                || str_contains($meta['mode'], 'c')
-                || str_contains($meta['mode'], 'a')
-                || str_contains($meta['mode'], '+');
+            $writable = false !== strpbrk($meta['mode'], 'xwca+');
 
             Psl\invariant($writable, 'Handle is not writeable.');
 
-            // @mago-expect analysis:possibly-invalid-argument
             stream_set_write_buffer($stream, 0);
 
-            // @mago-expect analysis:possibly-invalid-argument
             $this->writeWatcher = EventLoop::onWritable($stream, function (): void {
                 $this->writeSuspension?->resume();
             });
@@ -265,7 +254,7 @@ class ResourceHandle implements
             throw new Exception\RuntimeException($error['message'] ?? 'unknown error.');
         }
 
-        return max($result, 0);
+        return $result;
     }
 
     /**
@@ -303,7 +292,7 @@ class ResourceHandle implements
             throw new Exception\RuntimeException($error['message'] ?? 'unknown error.');
         }
 
-        return max($result, 0);
+        return $result;
     }
 
     /**

--- a/src/Psl/IO/MemoryHandle.php
+++ b/src/Psl/IO/MemoryHandle.php
@@ -6,11 +6,12 @@ namespace Psl\IO;
 
 use Override;
 use Psl\DateTime\Duration;
-use Psl\Math;
 
 use function str_repeat;
 use function strlen;
 use function substr;
+
+use const PHP_INT_MAX;
 
 final class MemoryHandle implements WriteHandleInterface, ReadHandleInterface, SeekHandleInterface, CloseHandleInterface
 {
@@ -59,7 +60,7 @@ final class MemoryHandle implements WriteHandleInterface, ReadHandleInterface, S
         $this->assertHandleIsOpen();
 
         if (null === $max_bytes) {
-            $max_bytes = Math\INT64_MAX;
+            $max_bytes = PHP_INT_MAX;
         }
 
         $length = strlen($this->buffer);
@@ -132,16 +133,23 @@ final class MemoryHandle implements WriteHandleInterface, ReadHandleInterface, S
     {
         $this->assertHandleIsOpen();
         $length = strlen($this->buffer);
-        if ($length < $this->offset) {
-            $this->buffer .= str_repeat("\0", $this->offset - $length);
-            $length = $this->offset;
+        $bytes_length = strlen($bytes);
+
+        if ($this->offset >= $length) {
+            // Fast-path: appending at or past end of buffer
+            if ($this->offset > $length) {
+                $this->buffer .= str_repeat("\0", $this->offset - $length);
+            }
+
+            $this->buffer .= $bytes;
+            $this->offset += $bytes_length;
+            return $bytes_length;
         }
 
-        $bytes_length = strlen($bytes);
+        // Overwrite in the middle of the buffer
         $new = substr($this->buffer, 0, $this->offset) . $bytes;
-        if ($this->offset < $length) {
-            $offset = $this->offset + $bytes_length;
-            $offset = $offset > $length ? $length : $offset;
+        $offset = $this->offset + $bytes_length;
+        if ($offset < $length) {
             $new .= substr($this->buffer, $offset);
         }
 

--- a/src/Psl/IO/ReadHandleConvenienceMethodsTrait.php
+++ b/src/Psl/IO/ReadHandleConvenienceMethodsTrait.php
@@ -50,18 +50,18 @@ trait ReadHandleConvenienceMethodsTrait
             return $data;
         }
 
-        /** @var Psl\Ref<string> $data_ref */
-        $data_ref = new Psl\Ref('');
+        /** @var string $data */
+        $data = '';
         $timer = new Psl\Async\OptionalIncrementalTimeout(
             $timeout,
             /**
              * @throws Exception\TimeoutException
              */
-            static function () use ($data_ref): void {
+            static function () use (&$data): void {
                 // @codeCoverageIgnoreStart
                 throw new Exception\TimeoutException(Str\format(
                     'Reached timeout before %s data could be read.',
-                    '' === $data_ref->value ? 'any' : 'all',
+                    '' === $data ? 'any' : 'all',
                 ));
                 // @codeCoverageIgnoreEnd
             },
@@ -71,13 +71,13 @@ trait ReadHandleConvenienceMethodsTrait
             /** @var positive-int|null $chunk_size */
             $chunk_size = $to_read;
             $chunk = $this->read($chunk_size, $timer->getRemaining());
-            $data_ref->value .= $chunk;
+            $data .= $chunk;
             if (null !== $to_read) {
                 $to_read -= strlen($chunk);
             }
         } while ((null === $to_read || $to_read > 0) && !$this->reachedEndOfDataSource());
 
-        return $data_ref->value;
+        return $data;
     }
 
     /**

--- a/src/Psl/IO/WriteHandleConvenienceMethodsTrait.php
+++ b/src/Psl/IO/WriteHandleConvenienceMethodsTrait.php
@@ -45,25 +45,23 @@ trait WriteHandleConvenienceMethodsTrait
                 $bytes = substr($bytes, $written);
             } while (0 !== $written && '' !== $bytes);
         } else {
-            /**
-             * @var Psl\Ref<int> $written_ref
-             */
-            $written_ref = new Psl\Ref(0);
+            /** @var int $written */
+            $written = 0;
 
-            $timer = new Psl\Async\OptionalIncrementalTimeout($timeout, static function () use ($written_ref): void {
+            $timer = new Psl\Async\OptionalIncrementalTimeout($timeout, static function () use (&$written): void {
                 // @codeCoverageIgnoreStart
                 throw new Exception\TimeoutException(Str\format(
                     'Reached timeout before %s data could be written.',
-                    0 === $written_ref->value ? 'any' : 'all',
+                    0 === $written ? 'any' : 'all',
                 ));
                 // @codeCoverageIgnoreEnd
             });
 
             do {
-                $written_ref->value = $this->write($bytes, $timer->getRemaining());
+                $written = $this->write($bytes, $timer->getRemaining());
 
-                $bytes = substr($bytes, $written_ref->value);
-            } while (0 !== $written_ref->value && '' !== $bytes);
+                $bytes = substr($bytes, $written);
+            } while (0 !== $written && '' !== $bytes);
         }
 
         if ('' !== $bytes) {

--- a/src/Psl/Iter/contains.php
+++ b/src/Psl/Iter/contains.php
@@ -15,12 +15,14 @@ namespace Psl\Iter;
  */
 function contains(iterable $iterable, mixed $value): bool
 {
-    foreach ($iterable as $v) {
-        if ($value !== $v) {
-            continue;
-        }
+    if (is_array($iterable)) {
+        return in_array($value, $iterable, true);
+    }
 
-        return true;
+    foreach ($iterable as $v) {
+        if ($value === $v) {
+            return true;
+        }
     }
 
     return false;

--- a/src/Psl/Iter/contains_key.php
+++ b/src/Psl/Iter/contains_key.php
@@ -15,12 +15,14 @@ namespace Psl\Iter;
  */
 function contains_key(iterable $iterable, mixed $key): bool
 {
-    foreach ($iterable as $k => $_v) {
-        if ($key !== $k) {
-            continue;
-        }
+    if (is_array($iterable) && (is_int($key) || is_string($key))) {
+        return array_key_exists($key, $iterable);
+    }
 
-        return true;
+    foreach ($iterable as $k => $_v) {
+        if ($key === $k) {
+            return true;
+        }
     }
 
     return false;

--- a/src/Psl/Iter/first_key.php
+++ b/src/Psl/Iter/first_key.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Psl\Iter;
 
+use function array_key_first;
+use function is_array;
+
 /**
  * Returns the first key of an iterable, if the iterable is empty, null will be returned.
  *
@@ -18,6 +21,10 @@ namespace Psl\Iter;
  */
 function first_key(iterable $iterable): mixed
 {
+    if (is_array($iterable)) {
+        return array_key_first($iterable);
+    }
+
     foreach ($iterable as $k => $_) {
         return $k;
     }

--- a/src/Psl/Iter/is_empty.php
+++ b/src/Psl/Iter/is_empty.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Iter;
 
+use function is_array;
+
 /**
  * Returns true if the given iterable is empty.
  *
@@ -17,5 +19,9 @@ namespace Psl\Iter;
  */
 function is_empty(iterable $iterable): bool
 {
+    if (is_array($iterable)) {
+        return [] === $iterable;
+    }
+
     return 0 === namespace\count($iterable);
 }

--- a/src/Psl/Iter/last.php
+++ b/src/Psl/Iter/last.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Psl\Iter;
 
+use function array_key_last;
+use function is_array;
+
 /**
  * Returns the last element of an iterable, if the iterable is empty, null will be returned.
  *
@@ -15,6 +18,14 @@ namespace Psl\Iter;
  */
 function last(iterable $iterable): mixed
 {
+    if (is_array($iterable)) {
+        if ([] === $iterable) {
+            return null;
+        }
+
+        return $iterable[array_key_last($iterable)];
+    }
+
     $last = null;
     foreach ($iterable as $v) {
         $last = $v;

--- a/src/Psl/Iter/last_key.php
+++ b/src/Psl/Iter/last_key.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Psl\Iter;
 
+use function array_key_last;
+use function is_array;
+
 /**
  * Returns the last key of an iterable, if the iterable is empty, null will be returned.
  *
@@ -16,6 +19,10 @@ namespace Psl\Iter;
  */
 function last_key(iterable $iterable): mixed
 {
+    if (is_array($iterable)) {
+        return array_key_last($iterable);
+    }
+
     $last = null;
     foreach ($iterable as $k => $_) {
         $last = $k;

--- a/src/Psl/Iter/random.php
+++ b/src/Psl/Iter/random.php
@@ -28,7 +28,7 @@ function random(iterable $iterable): mixed
         throw new Exception\InvalidArgumentException('Expected a non-empty iterable.');
     }
 
-    $size = namespace\count($values);
+    $size = \count($values);
 
     if (1 === $size) {
         return $values[0];

--- a/src/Psl/Json/encode.php
+++ b/src/Psl/Json/encode.php
@@ -33,14 +33,9 @@ function encode(mixed $value, bool $pretty = false, int $flags = 0): string
     }
 
     try {
-        $json = json_encode($value, $flags);
+        /** @var non-empty-string */
+        return json_encode($value, $flags);
     } catch (JsonException $e) {
         throw new Exception\EncodeException(Str\format('%s.', $e->getMessage()), (int) $e->getCode(), $e);
     }
-
-    if (false === $json) {
-        throw new Exception\EncodeException('Unexpected error occurred while encoding JSON.');
-    }
-
-    return $json;
 }

--- a/src/Psl/Math/max.php
+++ b/src/Psl/Math/max.php
@@ -18,14 +18,9 @@ namespace Psl\Math;
  */
 function max(array $numbers): null|int|float
 {
-    $max = null;
-    foreach ($numbers as $number) {
-        if (!(null === $max || $number > $max)) {
-            continue;
-        }
-
-        $max = $number;
+    if ([] === $numbers) {
+        return null;
     }
 
-    return $max;
+    return \max($numbers);
 }

--- a/src/Psl/Math/min.php
+++ b/src/Psl/Math/min.php
@@ -18,14 +18,9 @@ namespace Psl\Math;
  */
 function min(array $numbers): null|float|int
 {
-    $min = null;
-    foreach ($numbers as $number) {
-        if (!(null === $min || $number < $min)) {
-            continue;
-        }
-
-        $min = $number;
+    if ([] === $numbers) {
+        return null;
     }
 
-    return $min;
+    return \min($numbers);
 }

--- a/src/Psl/Math/sum.php
+++ b/src/Psl/Math/sum.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Math;
 
+use function array_sum;
+
 /**
  * Returns the sum of all the given numbers.
  *
@@ -13,10 +15,5 @@ namespace Psl\Math;
  */
 function sum(array $numbers): int
 {
-    $result = 0;
-    foreach ($numbers as $number) {
-        $result += $number;
-    }
-
-    return $result;
+    return (int) array_sum($numbers);
 }

--- a/src/Psl/Math/sum_floats.php
+++ b/src/Psl/Math/sum_floats.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Math;
 
+use function array_sum;
+
 /**
  * Returns the sum of all the given numbers.
  *
@@ -13,10 +15,5 @@ namespace Psl\Math;
  */
 function sum_floats(array $numbers): float
 {
-    $result = 0.0;
-    foreach ($numbers as $number) {
-        $result += (float) $number;
-    }
-
-    return $result;
+    return (float) array_sum($numbers);
 }

--- a/src/Psl/Network/Address.php
+++ b/src/Psl/Network/Address.php
@@ -89,11 +89,10 @@ final readonly class Address
      */
     public function toString(): string
     {
-        $address = "{$this->scheme->value}://{$this->host}";
         if (null === $this->port) {
-            return $address;
+            return "{$this->scheme->value}://{$this->host}";
         }
 
-        return "{$address}:{$this->port}";
+        return "{$this->scheme->value}://{$this->host}:{$this->port}";
     }
 }

--- a/src/Psl/SecureRandom/bytes.php
+++ b/src/Psl/SecureRandom/bytes.php
@@ -6,8 +6,8 @@ namespace Psl\SecureRandom;
 
 use Exception as PHPException;
 use Psl\Str;
-use Psl\Type;
 
+use function is_string;
 use function random_bytes;
 
 /**
@@ -30,7 +30,7 @@ function bytes(int $length): string
         // @codeCoverageIgnoreStart
     } catch (PHPException $e) {
         $code = $e->getCode();
-        if (Type\string()->matches($code)) {
+        if (is_string($code)) {
             $code = Str\to_int($code) ?? 0;
         }
 

--- a/src/Psl/Shell/execute.php
+++ b/src/Psl/Shell/execute.php
@@ -9,6 +9,7 @@ use Psl\Process;
 use Psl\Str;
 
 use function pack;
+use function strlen;
 
 /**
  * Execute an external program.
@@ -74,11 +75,11 @@ function execute(
     if (ErrorOutputBehavior::Packed === $error_output_behavior) {
         $result = '';
         if ('' !== $output->stdout) {
-            $result .= pack('C1N1', 1, Str\Byte\length($output->stdout)) . $output->stdout;
+            $result .= pack('C1N1', 1, strlen($output->stdout)) . $output->stdout;
         }
 
         if ('' !== $output->stderr) {
-            $result .= pack('C1N1', 2, Str\Byte\length($output->stderr)) . $output->stderr;
+            $result .= pack('C1N1', 2, strlen($output->stderr)) . $output->stderr;
         }
 
         return $result;

--- a/src/Psl/Shell/stream_unpack.php
+++ b/src/Psl/Shell/stream_unpack.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Psl\Shell;
 
 use Generator;
-use Psl\Str;
 
+use function strlen;
+use function substr;
 use function unpack as byte_unpack;
 
 /**
@@ -30,11 +31,11 @@ use function unpack as byte_unpack;
 function stream_unpack(string $content): Generator
 {
     while ('' !== $content) {
-        if (Str\Byte\length($content) < 5) {
+        if (strlen($content) < 5) {
             throw new Exception\InvalidArgumentException('$content contains an invalid header value.');
         }
 
-        $headers = byte_unpack('C1type/N1size', Str\Byte\slice($content, 0, 5));
+        $headers = byte_unpack('C1type/N1size', substr($content, 0, 5));
         if (false === $headers) {
             throw new Exception\InvalidArgumentException('$content contains an invalid header value.');
         }
@@ -44,12 +45,12 @@ function stream_unpack(string $content): Generator
         /** @var int<0, max> $size */
         $size = (int) $headers['size'];
 
-        if ($size > (Str\Byte\length($content) - 5)) {
+        if ($size > (strlen($content) - 5)) {
             throw new Exception\InvalidArgumentException('$content contains an invalid header value.');
         }
 
-        $chunk = Str\Byte\slice($content, 5, $size);
-        $content = Str\Byte\slice($content, $size + 5);
+        $chunk = substr($content, 5, $size);
+        $content = substr($content, $size + 5);
 
         if (1 === $type || 2 === $type) {
             yield $type => $chunk;

--- a/src/Psl/Str/Byte/replace_every.php
+++ b/src/Psl/Str/Byte/replace_every.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Str\Byte;
 
+use function array_keys;
+use function array_values;
 use function str_replace;
 
 /**
@@ -16,12 +18,5 @@ use function str_replace;
  */
 function replace_every(string $haystack, array $replacements): string
 {
-    $search = [];
-    $replace = [];
-    foreach ($replacements as $k => $v) {
-        $search[] = $k;
-        $replace[] = $v;
-    }
-
-    return str_replace($search, $replace, $haystack);
+    return str_replace(array_keys($replacements), array_values($replacements), $haystack);
 }

--- a/src/Psl/Str/Byte/replace_every_ci.php
+++ b/src/Psl/Str/Byte/replace_every_ci.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Str\Byte;
 
+use function array_keys;
+use function array_values;
 use function str_ireplace;
 
 /**
@@ -16,14 +18,5 @@ use function str_ireplace;
  */
 function replace_every_ci(string $haystack, array $replacements): string
 {
-    /** @var list<string> $search */
-    $search = [];
-    /** @var list<string> $replace */
-    $replace = [];
-    foreach ($replacements as $k => $v) {
-        $search[] = $k;
-        $replace[] = $v;
-    }
-
-    return str_ireplace($search, $replace, $haystack);
+    return str_ireplace(array_keys($replacements), array_values($replacements), $haystack);
 }

--- a/src/Psl/Str/capitalize.php
+++ b/src/Psl/Str/capitalize.php
@@ -32,8 +32,5 @@ function capitalize(string $string, Encoding $encoding = Encoding::Utf8): string
         return '';
     }
 
-    return concat(
-        uppercase(slice($string, 0, 1, $encoding), $encoding),
-        slice($string, 1, length($string, $encoding), $encoding),
-    );
+    return concat(uppercase(slice($string, 0, 1, $encoding), $encoding), slice($string, 1, null, $encoding));
 }

--- a/src/Psl/Str/contains.php
+++ b/src/Psl/Str/contains.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Str;
 
+use function str_contains;
+
 /**
  * Returns whether the 'haystack' string contains the 'needle' string.
  *
@@ -40,6 +42,10 @@ function contains(string $haystack, string $needle, int $offset = 0, Encoding $e
 {
     if ('' === $needle) {
         return Internal\validate_offset($offset, length($haystack, $encoding), true);
+    }
+
+    if (0 === $offset && ($encoding === Encoding::Ascii || $encoding === Encoding::Utf8)) {
+        return str_contains($haystack, $needle);
     }
 
     return null !== search($haystack, $needle, $offset, $encoding);

--- a/src/Psl/Str/ends_with.php
+++ b/src/Psl/Str/ends_with.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Str;
 
+use function str_ends_with;
+
 /**
  * Returns whether the string ends with the given suffix.
  *
@@ -34,6 +36,14 @@ namespace Psl\Str;
  */
 function ends_with(string $string, string $suffix, Encoding $encoding = Encoding::Utf8): bool
 {
+    if ('' === $suffix) {
+        return false;
+    }
+
+    if ($encoding === Encoding::Ascii || $encoding === Encoding::Utf8) {
+        return str_ends_with($string, $suffix);
+    }
+
     if ($suffix === $string) {
         return true;
     }

--- a/src/Psl/Str/pad_left.php
+++ b/src/Psl/Str/pad_left.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Psl\Str;
 
+use function str_pad;
+
+use const STR_PAD_LEFT;
+
 /**
  * Returns the string padded to the total length by appending the `$pad_string`
  * to the left.
@@ -37,6 +41,19 @@ function pad_left(
     string $pad_string = ' ',
     Encoding $encoding = Encoding::Utf8,
 ): string {
+    if ($encoding === Encoding::Ascii || $encoding === Encoding::Utf8) {
+        if (Byte\length($pad_string) === length($pad_string, $encoding)) {
+            // All characters in pad_string are single-byte, str_pad is safe
+            return str_pad(
+                $string,
+                Byte\length($string) + $total_length - length($string, $encoding),
+                $pad_string,
+                STR_PAD_LEFT,
+            );
+        }
+    }
+
+    $pad_length = length($pad_string, $encoding);
     do {
         $length = length($string, $encoding);
         $remaining = $total_length - $length;
@@ -44,8 +61,9 @@ function pad_left(
             return $string;
         }
 
-        if ($remaining <= length($pad_string, $encoding)) {
+        if ($remaining <= $pad_length) {
             $pad_string = slice($pad_string, 0, $remaining, $encoding);
+            $pad_length = $remaining;
         }
 
         $string = $pad_string . $string;

--- a/src/Psl/Str/pad_right.php
+++ b/src/Psl/Str/pad_right.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Psl\Str;
 
+use function str_pad;
+
+use const STR_PAD_RIGHT;
+
 /**
  * Returns the string padded to the total length by appending the `$pad_string`
  * to the right.
@@ -37,6 +41,19 @@ function pad_right(
     string $pad_string = ' ',
     Encoding $encoding = Encoding::Utf8,
 ): string {
+    if ($encoding === Encoding::Ascii || $encoding === Encoding::Utf8) {
+        if (Byte\length($pad_string) === length($pad_string, $encoding)) {
+            // All characters in pad_string are single-byte, str_pad is safe
+            return str_pad(
+                $string,
+                Byte\length($string) + $total_length - length($string, $encoding),
+                $pad_string,
+                STR_PAD_RIGHT,
+            );
+        }
+    }
+
+    $pad_length = length($pad_string, $encoding);
     do {
         $length = length($string, $encoding);
         $remaining = $total_length - $length;
@@ -44,8 +61,9 @@ function pad_right(
             return $string;
         }
 
-        if ($remaining <= length($pad_string, $encoding)) {
+        if ($remaining <= $pad_length) {
             $pad_string = slice($pad_string, 0, $remaining, $encoding);
+            $pad_length = $remaining;
         }
 
         $string .= $pad_string;

--- a/src/Psl/Str/replace.php
+++ b/src/Psl/Str/replace.php
@@ -14,7 +14,15 @@ use function str_replace;
  */
 function replace(string $haystack, string $needle, string $replacement, Encoding $encoding = Encoding::Utf8): string
 {
-    if ('' === $needle || null === search($haystack, $needle, 0, $encoding)) {
+    if ('' === $needle) {
+        return $haystack;
+    }
+
+    if ($encoding === Encoding::Ascii || $encoding === Encoding::Utf8) {
+        return str_replace($needle, $replacement, $haystack);
+    }
+
+    if (null === search($haystack, $needle, 0, $encoding)) {
         return $haystack;
     }
 

--- a/src/Psl/Str/replace_every.php
+++ b/src/Psl/Str/replace_every.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Psl\Str;
 
+use function array_keys;
+use function array_values;
+use function str_replace;
+
 /**
  * Returns the '$haystack' string with all occurrences of the keys of
  * `$replacements` replaced by the corresponding values.
@@ -14,6 +18,10 @@ namespace Psl\Str;
  */
 function replace_every(string $haystack, array $replacements, Encoding $encoding = Encoding::Utf8): string
 {
+    if ($encoding === Encoding::Ascii || $encoding === Encoding::Utf8) {
+        return str_replace(array_keys($replacements), array_values($replacements), $haystack);
+    }
+
     foreach ($replacements as $needle => $replacement) {
         $haystack = replace($haystack, $needle, $replacement, $encoding);
     }

--- a/src/Psl/Str/replace_every_ci.php
+++ b/src/Psl/Str/replace_every_ci.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Psl\Str;
 
+use function array_keys;
+use function array_values;
+use function str_ireplace;
+
 /**
  * Returns the 'haystack' string with all occurrences of the keys of
  * `$replacements` replaced by the corresponding values (case-insensitive).
@@ -14,8 +18,12 @@ namespace Psl\Str;
  */
 function replace_every_ci(string $haystack, array $replacements, Encoding $encoding = Encoding::Utf8): string
 {
+    if ($encoding === Encoding::Ascii || $encoding === Encoding::Utf8) {
+        return str_ireplace(array_keys($replacements), array_values($replacements), $haystack);
+    }
+
     foreach ($replacements as $needle => $replacement) {
-        if ('' === $needle || null === search_ci($haystack, $needle, 0, $encoding)) {
+        if ('' === $needle) {
             continue;
         }
 

--- a/src/Psl/Str/split.php
+++ b/src/Psl/Str/split.php
@@ -42,15 +42,15 @@ function split(string $string, string $delimiter, null|int $limit = null, Encodi
 
     $tail = $string;
     $chunks = [];
+    $delimiter_length = length($delimiter, $encoding);
 
     /**
      * $offset is within bounded.
      */
     $position = search($tail, $delimiter, 0, $encoding);
     while (1 < $limit && null !== $position) {
-        $result = slice($tail, 0, $position, $encoding);
-        $chunks[] = $result;
-        $tail = slice($tail, length($result, $encoding) + length($delimiter, $encoding), null, $encoding);
+        $chunks[] = slice($tail, 0, $position, $encoding);
+        $tail = slice($tail, $position + $delimiter_length, null, $encoding);
 
         $limit--;
         /**

--- a/src/Psl/Str/starts_with.php
+++ b/src/Psl/Str/starts_with.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Str;
 
+use function str_starts_with;
+
 /**
  * Returns whether the string starts with the given prefix.
  *
@@ -11,5 +13,13 @@ namespace Psl\Str;
  */
 function starts_with(string $string, string $prefix, Encoding $encoding = Encoding::Utf8): bool
 {
+    if ('' === $prefix) {
+        return false;
+    }
+
+    if ($encoding === Encoding::Ascii || $encoding === Encoding::Utf8) {
+        return str_starts_with($string, $prefix);
+    }
+
     return 0 === search($string, $prefix, 0, $encoding);
 }

--- a/src/Psl/Terminal/Buffer.php
+++ b/src/Psl/Terminal/Buffer.php
@@ -10,6 +10,8 @@ use Psl\Ansi\Screen;
 use Psl\IO;
 use Psl\Str;
 
+use function array_fill;
+
 /**
  * A 2D grid of {@see Cell} objects representing the terminal screen.
  *
@@ -103,10 +105,10 @@ final class Buffer
      */
     public function fill(Cell $cell): void
     {
+        /** @var array<non-negative-int, Cell> $row */
+        $row = array_fill(0, $this->width, $cell);
         for ($y = 0; $y < $this->height; $y++) {
-            for ($x = 0; $x < $this->width; $x++) {
-                $this->cells[$y][$x] = $cell;
-            }
+            $this->cells[$y] = $row;
         }
     }
 
@@ -213,19 +215,11 @@ final class Buffer
     private static function createGrid(int $width, int $height): array
     {
         $empty = new Cell();
-        /** @var array<non-negative-int, array<non-negative-int, Cell>> $grid */
-        $grid = [];
-        for ($y = 0; $y < $height; $y++) {
-            /** @var array<non-negative-int, Cell> $row */
-            $row = [];
-            for ($x = 0; $x < $width; $x++) {
-                $row[] = $empty;
-            }
+        /** @var array<non-negative-int, Cell> $row */
+        $row = array_fill(0, $width, $empty);
 
-            $grid[] = $row;
-        }
-
-        return $grid;
+        /** @var array<non-negative-int, array<non-negative-int, Cell>> */
+        return array_fill(0, $height, $row);
     }
 
     /**
@@ -238,13 +232,7 @@ final class Buffer
         /** @var array<non-negative-int, array<non-negative-int, Cell>> $copy */
         $copy = [];
         for ($y = 0; $y < $height; $y++) {
-            /** @var array<non-negative-int, Cell> $row */
-            $row = [];
-            for ($x = 0; $x < $width; $x++) {
-                $row[] = $source[$y][$x];
-            }
-
-            $copy[] = $row;
+            $copy[] = $source[$y];
         }
 
         return $copy;

--- a/src/Psl/Terminal/Internal/CsiKeyMap.php
+++ b/src/Psl/Terminal/Internal/CsiKeyMap.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Psl\Terminal\Internal;
 
-use Psl\Str;
 use Psl\Terminal\Event;
+
+use function explode;
+use function str_contains;
 
 /**
  * Maps CSI escape sequences to key events.
@@ -34,7 +36,7 @@ final class CsiKeyMap
         }
 
         // Kitty keyboard protocol: \e[codepoint u (no modifier)
-        if ($final === 'u' && !Str\Byte\contains($params, ';')) {
+        if ($final === 'u' && !str_contains($params, ';')) {
             return self::mapKittyKey((int) $params, 1);
         }
 
@@ -81,7 +83,7 @@ final class CsiKeyMap
         }
 
         // Modified tilde keys: e.g., "5;5" for Ctrl+PageUp
-        $parts = Str\Byte\split($params, ';');
+        $parts = explode(';', $params);
         if (count($parts) !== 2) {
             return null;
         }
@@ -116,7 +118,7 @@ final class CsiKeyMap
 
     private static function mapModified(string $params, string $final): null|Event\Key
     {
-        $parts = Str\Byte\split($params, ';');
+        $parts = explode(';', $params);
         if (count($parts) !== 2) {
             return null;
         }

--- a/src/Psl/Terminal/Internal/EventParser.php
+++ b/src/Psl/Terminal/Internal/EventParser.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Psl\Terminal\Internal;
 
-use Psl\Str;
 use Psl\Terminal\Event;
+
+use function explode;
+use function str_starts_with;
+use function strlen;
+use function strpos;
+use function substr;
 
 /**
  * Parses raw stdin bytes into terminal Event objects.
@@ -22,6 +27,8 @@ final class EventParser
 
     private const string PASTE_START = "\e[200~";
     private const string PASTE_END = "\e[201~";
+    private const int PASTE_START_LEN = 6;
+    private const int PASTE_END_LEN = 6;
 
     /**
      * Flush any pending incomplete sequences as final events.
@@ -77,16 +84,13 @@ final class EventParser
             return $this->parsePasteContent();
         }
 
-        if (Str\Byte\starts_with($this->buffer, self::PASTE_START)) {
-            $this->buffer = Str\Byte\slice($this->buffer, Str\Byte\length(self::PASTE_START));
+        if (str_starts_with($this->buffer, self::PASTE_START)) {
+            $this->buffer = substr($this->buffer, self::PASTE_START_LEN);
             $this->inPaste = true;
             return null;
         }
 
-        if (
-            Str\Byte\length(self::PASTE_START) > Str\Byte\length($this->buffer)
-            && Str\Byte\starts_with(self::PASTE_START, $this->buffer)
-        ) {
+        if (self::PASTE_START_LEN > strlen($this->buffer) && str_starts_with(self::PASTE_START, $this->buffer)) {
             return false;
         }
 
@@ -99,15 +103,15 @@ final class EventParser
 
     private function parsePasteContent(): Event\Paste|null|false
     {
-        $endPos = Str\Byte\search($this->buffer, self::PASTE_END);
-        if ($endPos === null) {
+        $endPos = strpos($this->buffer, self::PASTE_END);
+        if ($endPos === false) {
             $this->pasteBuffer .= $this->buffer;
             $this->buffer = '';
             return false;
         }
 
-        $this->pasteBuffer .= Str\Byte\slice($this->buffer, 0, $endPos);
-        $this->buffer = Str\Byte\slice($this->buffer, $endPos + Str\Byte\length(self::PASTE_END));
+        $this->pasteBuffer .= substr($this->buffer, 0, $endPos);
+        $this->buffer = substr($this->buffer, $endPos + self::PASTE_END_LEN);
         $result = new Event\Paste($this->pasteBuffer);
         $this->pasteBuffer = '';
         $this->inPaste = false;
@@ -117,7 +121,7 @@ final class EventParser
     private function parseSingleByte(): null|Event\Key
     {
         $byte = $this->buffer[0];
-        $this->buffer = Str\Byte\slice($this->buffer, 1);
+        $this->buffer = substr($this->buffer, 1);
         $ord = ord($byte);
 
         return match (true) {
@@ -148,13 +152,13 @@ final class EventParser
             default => 0,
         };
 
-        if (Str\Byte\length($this->buffer) < $needed) {
+        if (strlen($this->buffer) < $needed) {
             $this->buffer = $firstByte . $this->buffer;
             return null;
         }
 
-        $char = $firstByte . Str\Byte\slice($this->buffer, 0, $needed);
-        $this->buffer = Str\Byte\slice($this->buffer, $needed);
+        $char = $firstByte . substr($this->buffer, 0, $needed);
+        $this->buffer = substr($this->buffer, $needed);
 
         return Event\Key::char($char);
     }
@@ -164,7 +168,7 @@ final class EventParser
      */
     private function parseEscapeSequence(): Event\Key|Event\Mouse|Event\Resize|Event\Focus|null|false
     {
-        if (Str\Byte\length($this->buffer) < 2) {
+        if (strlen($this->buffer) < 2) {
             return false;
         }
 
@@ -175,11 +179,11 @@ final class EventParser
         }
 
         if (ord($second) >= 0x20 && ord($second) <= 0x7E) {
-            $this->buffer = Str\Byte\slice($this->buffer, 2);
+            $this->buffer = substr($this->buffer, 2);
             return Event\Key::named('alt+' . $second);
         }
 
-        $this->buffer = Str\Byte\slice($this->buffer, 1);
+        $this->buffer = substr($this->buffer, 1);
         return Event\Key::named('escape');
     }
 
@@ -188,7 +192,7 @@ final class EventParser
      */
     private function parseCsiSequence(): Event\Key|Event\Mouse|Event\Resize|Event\Focus|null|false
     {
-        $len = Str\Byte\length($this->buffer);
+        $len = strlen($this->buffer);
 
         for ($i = 2; $i < $len; $i++) {
             $c = $this->buffer[$i];
@@ -200,8 +204,8 @@ final class EventParser
             if ($c >= 'A' && $c <= 'Z' || $c === '~' || $c >= 'a' && $c <= 'z') {
                 /** @var non-negative-int $paramLen */
                 $paramLen = $i - 2;
-                $params = Str\Byte\slice($this->buffer, 2, $paramLen);
-                $this->buffer = Str\Byte\slice($this->buffer, $i + 1);
+                $params = substr($this->buffer, 2, $paramLen);
+                $this->buffer = substr($this->buffer, $i + 1);
 
                 if ($params === '' && $c === 'I') {
                     return new Event\Focus(true);
@@ -233,7 +237,7 @@ final class EventParser
      */
     private static function parseInBandResize(string $params): null|Event\Resize
     {
-        $parts = Str\Byte\split($params, ';');
+        $parts = explode(';', $params);
         if (count($parts) < 3 || $parts[0] !== '48') {
             return null;
         }
@@ -252,16 +256,16 @@ final class EventParser
      */
     private function parseSgrMouse(): Event\Mouse|null|false
     {
-        $len = Str\Byte\length($this->buffer);
+        $len = strlen($this->buffer);
 
         for ($i = 3; $i < $len; $i++) {
             $c = $this->buffer[$i];
             if ($c === 'M' || $c === 'm') {
                 /** @var non-negative-int $paramLen */
                 $paramLen = $i - 3;
-                $params = Str\Byte\slice($this->buffer, 3, $paramLen);
+                $params = substr($this->buffer, 3, $paramLen);
                 $isRelease = $c === 'm';
-                $this->buffer = Str\Byte\slice($this->buffer, $i + 1);
+                $this->buffer = substr($this->buffer, $i + 1);
 
                 return SgrMouseParser::parse($params, $isRelease);
             }

--- a/src/Psl/Terminal/Internal/SgrMouseParser.php
+++ b/src/Psl/Terminal/Internal/SgrMouseParser.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Psl\Terminal\Internal;
 
-use Psl\Iter;
-use Psl\Str;
 use Psl\Terminal\Event;
+
+use function count;
+use function explode;
 
 /**
  * Parses SGR mouse protocol parameters into Mouse events.
@@ -19,8 +20,8 @@ final class SgrMouseParser
 
     public static function parse(string $params, bool $isRelease): null|Event\Mouse
     {
-        $parts = Str\Byte\split($params, ';');
-        if (Iter\count($parts) !== 3) {
+        $parts = explode(';', $params);
+        if (count($parts) !== 3) {
             return null;
         }
 

--- a/src/Psl/Terminal/Internal/TerminalSize.php
+++ b/src/Psl/Terminal/Internal/TerminalSize.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Psl\Terminal\Internal;
 
-use Psl\Iter;
 use Psl\Process;
 use Psl\Shell;
 use Psl\Str;
+
+use function count;
 
 use const PHP_OS_FAMILY;
 
@@ -73,7 +74,7 @@ final class TerminalSize
 
             if ($output->status->isSuccessful()) {
                 $parts = Str\split(Str\trim($output->stdout), ' ');
-                if (Iter\count($parts) === 2) {
+                if (count($parts) === 2) {
                     $rows = (int) $parts[0];
                     $cols = (int) $parts[1];
                     if ($rows > 0 && $cols > 0) {
@@ -121,7 +122,7 @@ final class TerminalSize
             ]);
 
             $parts = Str\split(Str\trim($output), ' ');
-            if (Iter\count($parts) === 2) {
+            if (count($parts) === 2) {
                 $cols = (int) $parts[0];
                 $rows = (int) $parts[1];
                 if ($cols > 0 && $rows > 0) {

--- a/src/Psl/Terminal/Layout/Internal/solve.php
+++ b/src/Psl/Terminal/Layout/Internal/solve.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Psl\Terminal\Layout\Internal;
 
-use Psl\Iter;
 use Psl\Math;
 use Psl\Terminal\Layout\Constraint;
 use Psl\Terminal\Rect;
-use Psl\Vec;
+
+use function array_fill;
+use function array_map;
+use function array_sum;
+use function count;
 
 /**
  * Solve layout constraints along a single axis.
@@ -27,13 +30,13 @@ function solve(Rect $rect, array $constraints, bool $vertical): array
         return [];
     }
 
-    $count = Iter\count($constraints);
+    $count = count($constraints);
     /** @var list<int> $sizes */
-    $sizes = Vec\fill($count, 0);
-    $rawSizes = Vec\map($constraints, static fn(Constraint $constraint): int => resolve_constraint(
+    $sizes = array_fill(0, $count, 0);
+    $rawSizes = array_map(static fn(Constraint $constraint): int => resolve_constraint(
         $constraint,
         $totalSpace,
-    ));
+    ), $constraints);
 
     $fixedTotal = 0;
     $fillCount = 0;
@@ -61,7 +64,7 @@ function solve(Rect $rect, array $constraints, bool $vertical): array
         $sizes[$i] = $size;
     }
 
-    $totalAllocated = Math\sum($sizes);
+    $totalAllocated = (int) array_sum($sizes);
     if ($totalAllocated > $totalSpace) {
         $excess = $totalAllocated - $totalSpace;
         $shrinkableTotal = $totalAllocated;

--- a/src/Psl/Tree/at_index.php
+++ b/src/Psl/Tree/at_index.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\Tree;
 
-use Psl\Vec;
+use function array_slice;
 
 /**
  * Gets the value at the specified index path (list of child indices).
@@ -53,5 +53,5 @@ function at_index(NodeInterface $node, array $index_path): mixed
     }
 
     /** @var T */
-    return at_index($node, Vec\slice($index_path, 1));
+    return at_index($node, array_slice($index_path, 1));
 }

--- a/src/Psl/Tree/depth.php
+++ b/src/Psl/Tree/depth.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Psl\Tree;
 
-use Psl\Math;
+use function max;
 
 /**
  * Returns the maximum depth of the tree.
@@ -44,5 +44,5 @@ function depth(NodeInterface $tree): int
         $child_depths[] = depth($child);
     }
 
-    return 1 + Math\max($child_depths);
+    return 1 + max($child_depths);
 }

--- a/src/Psl/Type/Internal/ContainerType.php
+++ b/src/Psl/Type/Internal/ContainerType.php
@@ -35,6 +35,26 @@ final readonly class ContainerType extends Type\Type
     ) {}
 
     /**
+     * @psalm-assert-if-true iterable<Tk, Tv> $value
+     */
+    #[Override]
+    public function matches(mixed $value): bool
+    {
+        if (!is_iterable($value)) {
+            return false;
+        }
+
+        // @mago-expect analysis:mixed-assignment,mixed-assignment
+        foreach ($value as $k => $v) {
+            if (!$this->key_type->matches($k) || !$this->value_type->matches($v)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * @throws CoercionException
      *
      * @return iterable<Tk, Tv>

--- a/src/Psl/Type/Internal/DictType.php
+++ b/src/Psl/Type/Internal/DictType.php
@@ -10,6 +10,7 @@ use Psl\Type\Exception\AssertException;
 use Psl\Type\Exception\CoercionException;
 use Throwable;
 
+use function array_all;
 use function is_array;
 use function is_iterable;
 
@@ -33,6 +34,19 @@ final readonly class DictType extends Type\Type
         private readonly Type\TypeInterface $key_type,
         private readonly Type\TypeInterface $value_type,
     ) {}
+
+    /**
+     * @psalm-assert-if-true array<Tk, Tv> $value
+     */
+    #[Override]
+    public function matches(mixed $value): bool
+    {
+        if (!is_array($value)) {
+            return false;
+        }
+
+        return array_all($value, fn($v, $k) => $this->key_type->matches($k) && $this->value_type->matches($v));
+    }
 
     /**
      * @throws CoercionException

--- a/src/Psl/Type/Internal/MapType.php
+++ b/src/Psl/Type/Internal/MapType.php
@@ -33,9 +33,29 @@ final readonly class MapType extends Type\Type
      * @param Type\TypeInterface<Tv> $value_type
      */
     public function __construct(
-        private readonly Type\TypeInterface $key_type,
-        private readonly Type\TypeInterface $value_type,
+        private Type\TypeInterface $key_type,
+        private Type\TypeInterface $value_type,
     ) {}
+
+    /**
+     * @psalm-assert-if-true Collection\MapInterface<Tk, Tv> $value
+     */
+    #[Override]
+    public function matches(mixed $value): bool
+    {
+        if (!is_object($value) || !$value instanceof Collection\MapInterface) {
+            return false;
+        }
+
+        // @mago-expect analysis:mixed-assignment
+        foreach ($value as $k => $v) {
+            if (!$this->key_type->matches($k) || !$this->value_type->matches($v)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /**
      * @throws CoercionException

--- a/src/Psl/Type/Internal/MutableMapType.php
+++ b/src/Psl/Type/Internal/MutableMapType.php
@@ -33,9 +33,29 @@ final readonly class MutableMapType extends Type\Type
      * @param Type\TypeInterface<Tv> $value_type
      */
     public function __construct(
-        private readonly Type\TypeInterface $key_type,
-        private readonly Type\TypeInterface $value_type,
+        private Type\TypeInterface $key_type,
+        private Type\TypeInterface $value_type,
     ) {}
+
+    /**
+     * @psalm-assert-if-true Collection\MutableMapInterface<Tk, Tv> $value
+     */
+    #[Override]
+    public function matches(mixed $value): bool
+    {
+        if (!is_object($value) || !$value instanceof Collection\MutableMapInterface) {
+            return false;
+        }
+
+        // @mago-expect analysis:mixed-assignment
+        foreach ($value as $k => $v) {
+            if (!$this->key_type->matches($k) || !$this->value_type->matches($v)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /**
      * @throws CoercionException

--- a/src/Psl/Type/Internal/MutableVectorType.php
+++ b/src/Psl/Type/Internal/MutableVectorType.php
@@ -34,6 +34,26 @@ final readonly class MutableVectorType extends Type\Type
     ) {}
 
     /**
+     * @psalm-assert-if-true Collection\MutableVectorInterface<T> $value
+     */
+    #[Override]
+    public function matches(mixed $value): bool
+    {
+        if (!is_object($value) || !$value instanceof Collection\MutableVectorInterface) {
+            return false;
+        }
+
+        // @mago-expect analysis:mixed-assignment
+        foreach ($value as $v) {
+            if (!$this->value_type->matches($v)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * @throws CoercionException
      *
      * @return Collection\MutableVectorInterface<T>

--- a/src/Psl/Type/Internal/ShapeType.php
+++ b/src/Psl/Type/Internal/ShapeType.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Psl\Type\Internal;
 
 use Override;
-use Psl\Iter;
 use Psl\Type;
 use Psl\Type\Exception\AssertException;
 use Psl\Type\Exception\CoercionException;
@@ -26,6 +25,8 @@ use function is_iterable;
  * @template Tv
  *
  * @extends Type\Type<array<Tk, Tv>>
+ *
+ * @mago-expect lint:kan-defect
  */
 final readonly class ShapeType extends Type\Type
 {
@@ -47,6 +48,41 @@ final readonly class ShapeType extends Type\Type
             $elements_types,
             static fn(Type\TypeInterface $element): bool => !$element->isOptional(),
         );
+    }
+
+    /**
+     * @psalm-assert-if-true array<Tk, Tv> $value
+     */
+    #[Override]
+    public function matches(mixed $value): bool
+    {
+        if (!is_array($value)) {
+            return false;
+        }
+
+        foreach ($this->elements_types as $element => $type) {
+            if (array_key_exists($element, $value)) {
+                if (!$type->matches($value[$element])) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (!$type->isOptional()) {
+                return false;
+            }
+        }
+
+        if (!$this->allow_unknown_fields) {
+            foreach ($value as $k => $_v) {
+                if (!array_key_exists($k, $this->elements_types)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -134,7 +170,7 @@ final readonly class ShapeType extends Type\Type
         try {
             foreach ($this->elements_types as $element => $type) {
                 $element_value_found = false;
-                if (Iter\contains_key($array, $element)) {
+                if (array_key_exists($element, $array)) {
                     $element_value_found = true;
                     $result[$element] = $type->coerce($array[$element]);
 
@@ -161,7 +197,7 @@ final readonly class ShapeType extends Type\Type
 
         if ($this->allow_unknown_fields) {
             foreach ($array as $k => $v) {
-                if (Iter\contains_key($result, $k)) {
+                if (array_key_exists($k, $result)) {
                     continue;
                 }
 
@@ -193,7 +229,7 @@ final readonly class ShapeType extends Type\Type
         try {
             foreach ($this->elements_types as $element => $type) {
                 $element_value_found = false;
-                if (Iter\contains_key($value, $element)) {
+                if (array_key_exists($element, $value)) {
                     $element_value_found = true;
                     $result[$element] = $type->assert($value[$element]);
 
@@ -222,7 +258,7 @@ final readonly class ShapeType extends Type\Type
          * @var Tv $v
          */
         foreach ($value as $k => $v) {
-            if (Iter\contains_key($result, $k)) {
+            if (array_key_exists($k, $result)) {
                 continue;
             }
 

--- a/src/Psl/Type/Internal/VectorType.php
+++ b/src/Psl/Type/Internal/VectorType.php
@@ -30,8 +30,28 @@ final readonly class VectorType extends Type\Type
      * @param Type\TypeInterface<T> $value_type
      */
     public function __construct(
-        private readonly Type\TypeInterface $value_type,
+        private Type\TypeInterface $value_type,
     ) {}
+
+    /**
+     * @psalm-assert-if-true Collection\VectorInterface<T> $value
+     */
+    #[Override]
+    public function matches(mixed $value): bool
+    {
+        if (!is_object($value) || !$value instanceof Collection\VectorInterface) {
+            return false;
+        }
+
+        // @mago-expect analysis:mixed-assignment
+        foreach ($value as $v) {
+            if (!$this->value_type->matches($v)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /**
      * @throws CoercionException

--- a/src/Psl/Vec/chunk.php
+++ b/src/Psl/Vec/chunk.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Psl\Vec;
 
+use function array_chunk;
+use function is_array;
+
 /**
  * Returns a list containing the original list split into chunks of the given
  * size.
@@ -20,18 +23,24 @@ namespace Psl\Vec;
  */
 function chunk(iterable $iterable, int $size): array
 {
-    $result = [];
-    $ii = 0;
-    $chunk_number = -1;
-    foreach ($iterable as $value) {
-        if (($ii % $size) === 0) {
-            $result[] = [];
-            $chunk_number++;
-        }
-
-        $result[$chunk_number][] = $value;
-        $ii++;
+    if (is_array($iterable)) {
+        return array_chunk($iterable, $size);
     }
 
-    return values($result);
+    $result = [];
+    $chunk = [];
+    $ii = 0;
+    foreach ($iterable as $value) {
+        $chunk[] = $value;
+        if ((++$ii % $size) === 0) {
+            $result[] = $chunk;
+            $chunk = [];
+        }
+    }
+
+    if ($chunk !== []) {
+        $result[] = $chunk;
+    }
+
+    return $result;
 }

--- a/src/Psl/Vec/chunk_with_keys.php
+++ b/src/Psl/Vec/chunk_with_keys.php
@@ -35,5 +35,6 @@ function chunk_with_keys(iterable $iterable, int $size): array
         $ii++;
     }
 
-    return values($result);
+    /** @var list<array<Tk, Tv>> */
+    return $result;
 }

--- a/src/Psl/Vec/concat.php
+++ b/src/Psl/Vec/concat.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Psl\Vec;
 
+use function array_merge;
+use function array_values;
+use function is_array;
+
 /**
  * Returns a new list formed by concatenating the given lists together.
  *
@@ -16,10 +20,18 @@ namespace Psl\Vec;
  */
 function concat(iterable $first, iterable ...$rest): array
 {
+    if (is_array($first) && $rest === []) {
+        return array_values($first);
+    }
+
     $first = values($first);
     foreach ($rest as $arr) {
-        foreach ($arr as $value) {
-            $first[] = $value;
+        if (is_array($arr)) {
+            $first = array_merge($first, array_values($arr));
+        } else {
+            foreach ($arr as $value) {
+                $first[] = $value;
+            }
         }
     }
 

--- a/src/Psl/Vec/fill.php
+++ b/src/Psl/Vec/fill.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Vec;
 
+use function array_fill;
+
 /**
  * Returns a new vec of size `$size` where all the values are `$value`.
  *
@@ -20,10 +22,5 @@ namespace Psl\Vec;
  */
 function fill(int $size, mixed $value): array
 {
-    $result = [];
-    for ($i = 0; $i < $size; $i++) {
-        $result[] = $value;
-    }
-
-    return $result;
+    return array_fill(0, $size, $value);
 }

--- a/src/Psl/Vec/filter_nulls.php
+++ b/src/Psl/Vec/filter_nulls.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Psl\Vec;
 
+use function array_filter;
+use function array_values;
+use function is_array;
+
 /**
  * Filter out null values from the given iterable.
  *
@@ -19,11 +23,18 @@ namespace Psl\Vec;
  */
 function filter_nulls(iterable $iterable): array
 {
-    return filter(
-        $iterable,
-        /**
-         * @param T|null $value
-         */
-        static fn(mixed $value): bool => null !== $value,
-    );
+    if (is_array($iterable)) {
+        return array_values(array_filter($iterable, static fn(mixed $value): bool => null !== $value));
+    }
+
+    $result = [];
+    foreach ($iterable as $v) {
+        if (null === $v) {
+            continue;
+        }
+
+        $result[] = $v;
+    }
+
+    return $result;
 }

--- a/src/Psl/Vec/flatten.php
+++ b/src/Psl/Vec/flatten.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Psl\Vec;
 
+use function array_merge;
+use function array_values;
+use function is_array;
+
 /**
  * Returns a new list formed by flattening a list of lists into a single list.
  *
@@ -26,6 +30,23 @@ namespace Psl\Vec;
  */
 function flatten(iterable $iterables): array
 {
+    if (is_array($iterables)) {
+        $all_arrays = true;
+        foreach ($iterables as $inner) {
+            if (is_array($inner)) {
+                continue;
+            }
+
+            $all_arrays = false;
+            break;
+        }
+
+        if ($all_arrays) {
+            /** @var array<array<T>> $iterables */
+            return [] === $iterables ? [] : array_values(array_merge(...$iterables));
+        }
+    }
+
     $result = [];
     foreach ($iterables as $iterable) {
         foreach ($iterable as $value) {

--- a/src/Psl/Vec/map.php
+++ b/src/Psl/Vec/map.php
@@ -29,11 +29,16 @@ use function is_array;
  * @param (Closure(Tv): T) $function
  *
  * @return ($iterable is non-empty-array|non-empty-list ? non-empty-list<T> : list<T>)
+ *
+ * @mago-expect analysis:impossible-type-comparison,impossible-condition - false positive.
  */
 function map(iterable $iterable, Closure $function): array
 {
     if (is_array($iterable)) {
-        return array_values(array_map($function, $iterable));
+        // array_map preserves keys, so if input is a list, output is a list
+        return array_is_list($iterable)
+            ? array_map($function, $iterable)
+            : array_values(array_map($function, $iterable));
     }
 
     $result = [];

--- a/src/Psl/Vec/reverse.php
+++ b/src/Psl/Vec/reverse.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Psl\Vec;
 
-use Psl\Iter;
+use function array_reverse;
+use function array_values;
+use function is_array;
 
 /**
  * Reverse the given iterable.
@@ -21,16 +23,11 @@ use Psl\Iter;
  */
 function reverse(iterable $iterable): array
 {
+    if (is_array($iterable)) {
+        return array_reverse(array_values($iterable));
+    }
+
     $values = namespace\values($iterable);
-    if ([] === $values) {
-        return [];
-    }
 
-    $size = Iter\count($values);
-    $result = [];
-    for ($i = $size - 1; $i >= 0; $i--) {
-        $result[] = $values[$i];
-    }
-
-    return $result;
+    return array_reverse($values);
 }

--- a/src/Psl/Vec/slice.php
+++ b/src/Psl/Vec/slice.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Psl\Vec;
 
+use function array_slice;
+use function array_values;
+use function is_array;
+
 /**
  * Takes a slice from an iterable.
  *
@@ -25,6 +29,10 @@ namespace Psl\Vec;
  */
 function slice(iterable $iterable, int $start, null|int $length = null): array
 {
+    if (is_array($iterable)) {
+        return array_values(array_slice($iterable, $start, $length));
+    }
+
     $result = [];
     if (0 === $length) {
         return $result;

--- a/src/Psl/Vec/unique_by.php
+++ b/src/Psl/Vec/unique_by.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Psl\Vec;
 
 use Closure;
-use Psl\Iter;
 
 /**
  * Returns a new array in which each value appears exactly once, where the
@@ -22,18 +21,19 @@ use Psl\Iter;
  */
 function unique_by(iterable $iterable, Closure $scalar_func): array
 {
-    /** @var list<Ts> $unique */
-    $unique = [];
-    /** @var list<Tv> $original_values */
-    $original_values = [];
+    /** @var array<array-key, true> $seen */
+    $seen = [];
+    /** @var list<Tv> $result */
+    $result = [];
     foreach ($iterable as $v) {
         $scalar = $scalar_func($v);
+        $key = is_int($scalar) || is_string($scalar) ? $scalar : serialize($scalar);
 
-        if (!Iter\contains($unique, $scalar)) {
-            $unique[] = $scalar;
-            $original_values[] = $v;
+        if (!isset($seen[$key])) {
+            $seen[$key] = true;
+            $result[] = $v;
         }
     }
 
-    return $original_values;
+    return $result;
 }

--- a/src/Psl/Vec/unique_scalar.php
+++ b/src/Psl/Vec/unique_scalar.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psl\Vec;
 
 use function array_unique;
+use function array_values;
 use function is_array;
 
 /**
@@ -20,7 +21,7 @@ use function is_array;
 function unique_scalar(iterable $iterable): array
 {
     if (is_array($iterable)) {
-        return namespace\values(array_unique($iterable));
+        return array_values(array_unique($iterable));
     }
 
     return unique_by(

--- a/src/Psl/Vec/zip.php
+++ b/src/Psl/Vec/zip.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Psl\Vec;
 
-use Psl\Iter;
-use Psl\Math;
+use function count;
+use function min;
 
 /**
  * Returns a list where each element is a pair that combines, pairwise,
@@ -37,11 +37,10 @@ use Psl\Math;
 function zip(iterable $first, iterable $second): array
 {
     $one = namespace\values($first);
-
     $two = namespace\values($second);
 
     $result = [];
-    $lesser_count = Math\minva(Iter\count($one), Iter\count($two));
+    $lesser_count = min(count($one), count($two));
     for ($i = 0; $i < $lesser_count; ++$i) {
         $result[] = [$one[$i], $two[$i]];
     }

--- a/tests/benchmark/Async/AsyncBench.php
+++ b/tests/benchmark/Async/AsyncBench.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Async;
+
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\Async;
+
+#[Groups(['async'])]
+final class AsyncBench
+{
+    /**
+     * @param array{ops: int} $params
+     */
+    #[ParamProviders('provideSequenceData')]
+    public function benchSequence(array $params): void
+    {
+        $sequence = new Async\Sequence(static fn(int $v): int => $v * 2);
+
+        $awaitables = [];
+        for ($i = 0; $i < $params['ops']; $i++) {
+            $awaitables[] = Async\run(static fn(): int => $sequence->waitFor($i));
+        }
+
+        foreach ($awaitables as $awaitable) {
+            $awaitable->await();
+        }
+    }
+
+    /**
+     * @param array{ops: int, concurrency: positive-int} $params
+     */
+    #[ParamProviders('provideSemaphoreData')]
+    public function benchSemaphore(array $params): void
+    {
+        $semaphore = new Async\Semaphore($params['concurrency'], static fn(int $v): int => $v * 2);
+
+        $awaitables = [];
+        for ($i = 0; $i < $params['ops']; $i++) {
+            $awaitables[] = Async\run(static fn(): int => $semaphore->waitFor($i));
+        }
+
+        foreach ($awaitables as $awaitable) {
+            $awaitable->await();
+        }
+    }
+
+    /**
+     * @return iterable<string, array{ops: int}>
+     */
+    public function provideSequenceData(): iterable
+    {
+        yield 'few_ops' => ['ops' => 10];
+        yield 'many_ops' => ['ops' => 100];
+    }
+
+    /**
+     * @return iterable<string, array{ops: int, concurrency: positive-int}>
+     */
+    public function provideSemaphoreData(): iterable
+    {
+        yield 'low_concurrency' => ['ops' => 50, 'concurrency' => 2];
+        yield 'high_concurrency' => ['ops' => 50, 'concurrency' => 10];
+    }
+}

--- a/tests/benchmark/Channel/ChannelBench.php
+++ b/tests/benchmark/Channel/ChannelBench.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Channel;
+
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\Channel;
+
+#[Groups(['channel'])]
+final class ChannelBench
+{
+    /**
+     * @param array{messages: int, capacity: positive-int} $params
+     */
+    #[ParamProviders('provideBoundedData')]
+    public function benchBoundedChannelSendReceive(array $params): void
+    {
+        [$receiver, $sender] = Channel\bounded($params['capacity']);
+        for ($i = 0; $i < $params['messages']; $i++) {
+            $sender->send($i);
+            $receiver->receive();
+        }
+    }
+
+    /**
+     * @param array{messages: int} $params
+     */
+    #[ParamProviders('provideUnboundedData')]
+    public function benchUnboundedChannelSendReceive(array $params): void
+    {
+        [$receiver, $sender] = Channel\unbounded();
+        for ($i = 0; $i < $params['messages']; $i++) {
+            $sender->send($i);
+        }
+
+        for ($i = 0; $i < $params['messages']; $i++) {
+            $receiver->receive();
+        }
+    }
+
+    /**
+     * @param array{messages: int} $params
+     */
+    #[ParamProviders('provideUnboundedData')]
+    public function benchUnboundedChannelInterleaved(array $params): void
+    {
+        [$receiver, $sender] = Channel\unbounded();
+        for ($i = 0; $i < $params['messages']; $i++) {
+            $sender->send($i);
+            $receiver->receive();
+        }
+    }
+
+    /**
+     * @return iterable<string, array{messages: int, capacity: int}>
+     */
+    public function provideBoundedData(): iterable
+    {
+        yield 'small' => ['messages' => 100, 'capacity' => 10];
+        yield 'medium' => ['messages' => 1000, 'capacity' => 50];
+        yield 'large' => ['messages' => 10_000, 'capacity' => 100];
+    }
+
+    /**
+     * @return iterable<string, array{messages: int}>
+     */
+    public function provideUnboundedData(): iterable
+    {
+        yield 'small' => ['messages' => 100];
+        yield 'medium' => ['messages' => 1000];
+        yield 'large' => ['messages' => 10_000];
+    }
+}

--- a/tests/benchmark/Collection/CollectionBench.php
+++ b/tests/benchmark/Collection/CollectionBench.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Collection;
+
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\Collection\Map;
+use Psl\Collection\MutableMap;
+use Psl\Collection\MutableVector;
+use Psl\Collection\Vector;
+use Psl\Vec;
+
+#[Groups(['collection'])]
+final class CollectionBench
+{
+    /**
+     * @param array{vector: Vector, mutable_vector: MutableVector, search: int} $params
+     */
+    #[ParamProviders('provideVectorData')]
+    public function benchVectorLinearSearch(array $params): void
+    {
+        $_ = $params['vector']->linearSearch($params['search']);
+    }
+
+    /**
+     * @param array{vector: Vector, mutable_vector: MutableVector, search: int} $params
+     */
+    #[ParamProviders('provideVectorData')]
+    public function benchMutableVectorLinearSearch(array $params): void
+    {
+        $_ = $params['mutable_vector']->linearSearch($params['search']);
+    }
+
+    /**
+     * @param array{map: Map, mutable_map: MutableMap, search: int} $params
+     */
+    #[ParamProviders('provideMapData')]
+    public function benchMapLinearSearch(array $params): void
+    {
+        $_ = $params['map']->linearSearch($params['search']);
+    }
+
+    /**
+     * @param array{mutable_map: MutableMap, search: mixed} $params
+     */
+    #[ParamProviders('provideMapData')]
+    public function benchMutableMapLinearSearch(array $params): void
+    {
+        $_ = $params['mutable_map']->linearSearch($params['search']);
+    }
+
+    /**
+     * @param array{elements: array<int, int>} $params
+     */
+    #[ParamProviders('provideConstructorData')]
+    public function benchVectorConstructor(array $params): void
+    {
+        $_ = new Vector($params['elements']);
+    }
+
+    /**
+     * @param array{elements: array<int, int>} $params
+     */
+    #[ParamProviders('provideConstructorData')]
+    public function benchMutableVectorConstructor(array $params): void
+    {
+        $_ = new MutableVector($params['elements']);
+    }
+
+    /**
+     * @param array{map: Map, zip_with: array<int, int>} $params
+     */
+    #[ParamProviders('provideMapZipData')]
+    public function benchMapZip(array $params): void
+    {
+        $params['map']->zip($params['zip_with']);
+    }
+
+    /**
+     * @param array{map: MutableMap, zip_with: array<int, int>} $params
+     */
+    #[ParamProviders('provideMutableMapZipData')]
+    public function benchMutableMapZip(array $params): void
+    {
+        $params['map']->zip($params['zip_with']);
+    }
+
+    /**
+     * @param array{map: Map, chunk_size: positive-int} $params
+     */
+    #[ParamProviders('provideMapChunkData')]
+    public function benchMapChunk(array $params): void
+    {
+        $params['map']->chunk($params['chunk_size']);
+    }
+
+    /**
+     * @param array{map: MutableMap, chunk_size: positive-int} $params
+     */
+    #[ParamProviders('provideMutableMapChunkData')]
+    public function benchMutableMapChunk(array $params): void
+    {
+        $params['map']->chunk($params['chunk_size']);
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{vector: Vector, mutable_vector: MutableVector, search: int}>
+     */
+    public function provideVectorData(): iterable
+    {
+        $small = Vec\range(1, 10);
+        $medium = Vec\range(1, 100);
+        $large = Vec\range(1, 1000);
+
+        yield 'small (10), found' => [
+            'vector' => new Vector($small),
+            'mutable_vector' => new MutableVector($small),
+            'search' => 5,
+        ];
+        yield 'medium (100), found' => [
+            'vector' => new Vector($medium),
+            'mutable_vector' => new MutableVector($medium),
+            'search' => 50,
+        ];
+        yield 'large (1000), found' => [
+            'vector' => new Vector($large),
+            'mutable_vector' => new MutableVector($large),
+            'search' => 500,
+        ];
+        yield 'large (1000), not found' => [
+            'vector' => new Vector($large),
+            'mutable_vector' => new MutableVector($large),
+            'search' => 9999,
+        ];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{map: Map, mutable_map: MutableMap, search: int}>
+     */
+    public function provideMapData(): iterable
+    {
+        $make = static function (int $size): array {
+            $data = [];
+            for ($i = 0; $i < $size; $i++) {
+                $data['key_' . $i] = $i;
+            }
+
+            return $data;
+        };
+
+        $small = $make(10);
+        $medium = $make(100);
+        $large = $make(1000);
+
+        yield 'small (10), found' => [
+            'map' => new Map($small),
+            'mutable_map' => new MutableMap($small),
+            'search' => 5,
+        ];
+        yield 'medium (100), found' => [
+            'map' => new Map($medium),
+            'mutable_map' => new MutableMap($medium),
+            'search' => 50,
+        ];
+        yield 'large (1000), found' => [
+            'map' => new Map($large),
+            'mutable_map' => new MutableMap($large),
+            'search' => 500,
+        ];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{elements: array<int, int>}>
+     */
+    public function provideConstructorData(): iterable
+    {
+        yield 'small (10)' => ['elements' => Vec\range(1, 10)];
+        yield 'medium (100)' => ['elements' => Vec\range(1, 100)];
+        yield 'large (1000)' => ['elements' => Vec\range(1, 1000)];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{map: Map, zip_with: array<int, int>}>
+     */
+    public function provideMapZipData(): iterable
+    {
+        $make = static function (int $size): array {
+            $data = [];
+            for ($i = 0; $i < $size; $i++) {
+                $data['key_' . $i] = $i;
+            }
+
+            return $data;
+        };
+
+        yield 'small (10)' => ['map' => new Map($make(10)), 'zip_with' => Vec\range(1, 10)];
+        yield 'medium (100)' => ['map' => new Map($make(100)), 'zip_with' => Vec\range(1, 100)];
+        yield 'large (1000)' => ['map' => new Map($make(1000)), 'zip_with' => Vec\range(1, 1000)];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{map: MutableMap, zip_with: array<int, int>}>
+     */
+    public function provideMutableMapZipData(): iterable
+    {
+        $make = static function (int $size): array {
+            $data = [];
+            for ($i = 0; $i < $size; $i++) {
+                $data['key_' . $i] = $i;
+            }
+
+            return $data;
+        };
+
+        yield 'small (10)' => ['map' => new MutableMap($make(10)), 'zip_with' => Vec\range(1, 10)];
+        yield 'medium (100)' => ['map' => new MutableMap($make(100)), 'zip_with' => Vec\range(1, 100)];
+        yield 'large (1000)' => ['map' => new MutableMap($make(1000)), 'zip_with' => Vec\range(1, 1000)];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{map: Map, chunk_size: positive-int}>
+     */
+    public function provideMapChunkData(): iterable
+    {
+        $make = static function (int $size): array {
+            $data = [];
+            for ($i = 0; $i < $size; $i++) {
+                $data['key_' . $i] = $i;
+            }
+
+            return $data;
+        };
+
+        yield 'small (10), chunk 3' => ['map' => new Map($make(10)), 'chunk_size' => 3];
+        yield 'medium (100), chunk 10' => ['map' => new Map($make(100)), 'chunk_size' => 10];
+        yield 'large (1000), chunk 50' => ['map' => new Map($make(1000)), 'chunk_size' => 50];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{map: MutableMap, chunk_size: positive-int}>
+     */
+    public function provideMutableMapChunkData(): iterable
+    {
+        $make = static function (int $size): array {
+            $data = [];
+            for ($i = 0; $i < $size; $i++) {
+                $data['key_' . $i] = $i;
+            }
+
+            return $data;
+        };
+
+        yield 'small (10), chunk 3' => ['map' => new MutableMap($make(10)), 'chunk_size' => 3];
+        yield 'medium (100), chunk 10' => ['map' => new MutableMap($make(100)), 'chunk_size' => 10];
+        yield 'large (1000), chunk 50' => ['map' => new MutableMap($make(1000)), 'chunk_size' => 50];
+    }
+}

--- a/tests/benchmark/DateTime/DateTimeBench.php
+++ b/tests/benchmark/DateTime/DateTimeBench.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\DateTime;
+
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\DateTime\Duration;
+use Psl\DateTime\Timestamp;
+
+#[Groups(['datetime'])]
+final class DateTimeBench
+{
+    /**
+     * @param array{duration: Duration} $params
+     */
+    #[ParamProviders('provideDurationData')]
+    public function benchDurationToString(array $params): void
+    {
+        $params['duration']->toString();
+    }
+
+    /**
+     * @param array{iso: string} $params
+     */
+    #[ParamProviders('provideIso8601DurationData')]
+    public function benchDurationFromIso8601(array $params): void
+    {
+        Duration::fromIso8601($params['iso']);
+    }
+
+    /**
+     * @param array{duration: Duration} $params
+     */
+    #[ParamProviders('provideDurationData')]
+    public function benchDurationToIso8601(array $params): void
+    {
+        $params['duration']->toIso8601();
+    }
+
+    public function benchTimestampFromParts(): void
+    {
+        Timestamp::fromParts(1_709_568_000, 500_000_000);
+    }
+
+    public function benchTimestampFromMilliseconds(): void
+    {
+        Timestamp::fromMilliseconds(1_709_568_000_500);
+    }
+
+    /**
+     * @param array{timestamp: Timestamp} $params
+     */
+    #[ParamProviders('provideTimestampData')]
+    public function benchTimestampToRfc3339(array $params): void
+    {
+        $params['timestamp']->toRfc3339();
+    }
+
+    /**
+     * @return iterable<string, array{duration: Duration}>
+     */
+    public function provideDurationData(): iterable
+    {
+        yield 'zero' => ['duration' => Duration::zero()];
+        yield 'simple_hours' => ['duration' => Duration::hours(5)];
+        yield 'complex' => ['duration' => Duration::fromParts(3, 25, 45, 123_456_789)];
+        yield 'negative' => ['duration' => Duration::fromParts(-2, -30, -15, -500_000_000)];
+    }
+
+    /**
+     * @return iterable<string, array{iso: string}>
+     */
+    public function provideIso8601DurationData(): iterable
+    {
+        yield 'simple' => ['iso' => 'PT5H'];
+        yield 'complex' => ['iso' => 'PT3H25M45.123456789S'];
+        yield 'negative' => ['iso' => '-PT2H30M15.5S'];
+    }
+
+    /**
+     * @return iterable<string, array{timestamp: Timestamp}>
+     */
+    public function provideTimestampData(): iterable
+    {
+        yield 'epoch' => ['timestamp' => Timestamp::fromParts(0, 0)];
+        yield 'recent' => ['timestamp' => Timestamp::fromParts(1_709_568_000, 123_456_789)];
+    }
+}

--- a/tests/benchmark/Dict/DictBench.php
+++ b/tests/benchmark/Dict/DictBench.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Dict;
+
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\Dict;
+use Psl\Vec;
+
+#[Groups(['dict'])]
+final class DictBench
+{
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchUniqueBy(array $params): void
+    {
+        Dict\unique_by($params['data'], static fn(int $v): int => $v % 50);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchGroupBy(array $params): void
+    {
+        Dict\group_by($params['data'], static fn(int $v): int => $v % 10);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchMap(array $params): void
+    {
+        Dict\map($params['data'], static fn(int $v): int => $v * 2);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchMapKeys(array $params): void
+    {
+        Dict\map_keys($params['data'], static fn(int $k): string => 'key_' . $k);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchFilter(array $params): void
+    {
+        Dict\filter($params['data'], static fn(int $v): bool => ($v % 2) === 0);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchPull(array $params): void
+    {
+        Dict\pull($params['data'], static fn(int $v): int => $v * 2, static fn(int $v): string => 'k' . $v);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchSelectKeys(array $params): void
+    {
+        Dict\select_keys($params['data'], Vec\range(0, (int) (count($params['data']) / 2)));
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchEqual(array $params): void
+    {
+        Dict\equal($params['data'], $params['data']);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchSlice(array $params): void
+    {
+        $size = count($params['data']);
+        /** @var non-negative-int $start */
+        $start = (int) ($size / 4);
+        /** @var non-negative-int $length */
+        $length = (int) ($size / 2);
+        $_ = Dict\slice($params['data'], $start, $length);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchFlip(array $params): void
+    {
+        $_ = Dict\flip($params['data']);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchMerge(array $params): void
+    {
+        Dict\merge($params['data'], $params['data'], $params['data']);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchDiff(array $params): void
+    {
+        Dict\diff($params['data'], $params['data']);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchIntersect(array $params): void
+    {
+        Dict\intersect($params['data'], $params['data']);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchFlatten(array $params): void
+    {
+        $_ = Dict\flatten([$params['data'], $params['data'], $params['data']]);
+    }
+
+    /**
+     * @param array{data: array<int, int|null>} $params
+     */
+    #[ParamProviders('provideNullableData')]
+    public function benchFilterNulls(array $params): void
+    {
+        Dict\filter_nulls($params['data']);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchSort(array $params): void
+    {
+        Dict\sort($params['data']);
+    }
+
+    /**
+     * @param array{data: array<int, int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchSortByKey(array $params): void
+    {
+        Dict\sort_by_key($params['data']);
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: array<int, int>}>
+     */
+    public function provideData(): iterable
+    {
+        yield 'small (10)' => ['data' => Vec\range(1, 10)];
+        yield 'medium (100)' => ['data' => Vec\range(1, 100)];
+        yield 'large (1000)' => ['data' => Vec\range(1, 1000)];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: array<int, int|null>}>
+     */
+    public function provideNullableData(): iterable
+    {
+        $make = static function (int $size): array {
+            $data = [];
+            for ($i = 0; $i < $size; $i++) {
+                $data[$i] = ($i % 3) === 0 ? null : $i;
+            }
+
+            return $data;
+        };
+
+        yield 'small (10)' => ['data' => $make(10)];
+        yield 'medium (100)' => ['data' => $make(100)];
+        yield 'large (1000)' => ['data' => $make(1000)];
+    }
+}

--- a/tests/benchmark/Encoding/EncodingBench.php
+++ b/tests/benchmark/Encoding/EncodingBench.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Encoding;
+
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\Encoding\Base64;
+use Psl\Encoding\Hex;
+
+#[Groups(['encoding'])]
+final class EncodingBench
+{
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideBinaryData')]
+    public function benchBase64Encode(array $params): void
+    {
+        $_ = Base64\encode($params['data']);
+    }
+
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideBase64Data')]
+    public function benchBase64Decode(array $params): void
+    {
+        $_ = Base64\decode($params['data']);
+    }
+
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideBinaryData')]
+    public function benchHexEncode(array $params): void
+    {
+        $_ = Hex\encode($params['data']);
+    }
+
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideHexData')]
+    public function benchHexDecode(array $params): void
+    {
+        $_ = Hex\decode($params['data']);
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: string}>
+     */
+    public function provideBinaryData(): iterable
+    {
+        yield 'small (32B)' => ['data' => random_bytes(32)];
+        yield 'medium (256B)' => ['data' => random_bytes(256)];
+        yield 'large (4KB)' => ['data' => random_bytes(4096)];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: string}>
+     */
+    public function provideBase64Data(): iterable
+    {
+        yield 'small (32B)' => ['data' => base64_encode(random_bytes(32))];
+        yield 'medium (256B)' => ['data' => base64_encode(random_bytes(256))];
+        yield 'large (4KB)' => ['data' => base64_encode(random_bytes(4096))];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: string}>
+     */
+    public function provideHexData(): iterable
+    {
+        yield 'small (32B)' => ['data' => bin2hex(random_bytes(32))];
+        yield 'medium (256B)' => ['data' => bin2hex(random_bytes(256))];
+        yield 'large (4KB)' => ['data' => bin2hex(random_bytes(4096))];
+    }
+}

--- a/tests/benchmark/Graph/GraphBench.php
+++ b/tests/benchmark/Graph/GraphBench.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Graph;
+
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\Graph;
+
+#[Groups(['graph'])]
+final class GraphBench
+{
+    /**
+     * @param array{graph: Graph\DirectedGraph, start: string} $params
+     */
+    #[ParamProviders('provideDfsData')]
+    public function benchDfs(array $params): void
+    {
+        $_ = Graph\dfs($params['graph'], $params['start']);
+    }
+
+    /**
+     * @param array{graph: Graph\DirectedGraph<string, int>, from: string, to: string} $params
+     */
+    #[ParamProviders('provideShortestPathData')]
+    public function benchShortestPath(array $params): void
+    {
+        $_ = Graph\shortest_path($params['graph'], $params['from'], $params['to']);
+    }
+
+    /**
+     * @param array{graph: Graph\DirectedGraph, node: string} $params
+     */
+    #[ParamProviders('provideNeighborsData')]
+    public function benchNeighbors(array $params): void
+    {
+        $_ = Graph\neighbors($params['graph'], $params['node']);
+    }
+
+    /**
+     * @param array{graph: Graph\DirectedGraph} $params
+     */
+    #[ParamProviders('provideTopoSortData')]
+    public function benchTopologicalSort(array $params): void
+    {
+        $_ = Graph\topological_sort($params['graph']);
+    }
+
+    /**
+     * @return iterable<string, array{graph: Graph\DirectedGraph, start: string}>
+     */
+    public function provideDfsData(): iterable
+    {
+        $graph = Graph\directed();
+        for ($i = 0; $i < 49; $i++) {
+            $graph = Graph\add_edge($graph, 'n' . $i, 'n' . ($i + 1));
+        }
+
+        yield 'chain_50' => ['graph' => $graph, 'start' => 'n0'];
+
+        $graph = Graph\directed();
+        for ($i = 0; $i < 50; $i++) {
+            $graph = Graph\add_edge($graph, 'center', 'leaf' . $i);
+        }
+
+        yield 'star_50' => ['graph' => $graph, 'start' => 'center'];
+
+        $graph = Graph\directed();
+        for ($r = 0; $r < 10; $r++) {
+            for ($c = 0; $c < 9; $c++) {
+                $graph = Graph\add_edge($graph, $r . '_' . $c, $r . '_' . ($c + 1));
+            }
+
+            if ($r < 9) {
+                for ($c = 0; $c < 10; $c++) {
+                    $graph = Graph\add_edge($graph, $r . '_' . $c, ($r + 1) . '_' . $c);
+                }
+            }
+        }
+
+        yield 'grid_10x10' => ['graph' => $graph, 'start' => '0_0'];
+    }
+
+    /**
+     * @return iterable<string, array{graph: Graph\DirectedGraph<string, int>, from: string, to: string}>
+     */
+    public function provideShortestPathData(): iterable
+    {
+        /** @var Graph\DirectedGraph<string, int> $graph */
+        $graph = Graph\directed();
+        for ($i = 0; $i < 50; $i++) {
+            $graph = Graph\add_edge($graph, 'n' . $i, 'n' . ($i + 1), 1);
+        }
+
+        yield 'chain_50' => ['graph' => $graph, 'from' => 'n0', 'to' => 'n50'];
+
+        /** @var Graph\DirectedGraph<string, int> $graph */
+        $graph = Graph\directed();
+        for ($r = 0; $r < 10; $r++) {
+            for ($c = 0; $c < 9; $c++) {
+                $graph = Graph\add_edge($graph, $r . '_' . $c, $r . '_' . ($c + 1), 1);
+            }
+
+            if ($r < 9) {
+                for ($c = 0; $c < 10; $c++) {
+                    $graph = Graph\add_edge($graph, $r . '_' . $c, ($r + 1) . '_' . $c, 1);
+                }
+            }
+        }
+
+        yield 'grid_10x10' => ['graph' => $graph, 'from' => '0_0', 'to' => '9_9'];
+    }
+
+    /**
+     * @return iterable<string, array{graph: Graph\DirectedGraph, node: string}>
+     */
+    public function provideNeighborsData(): iterable
+    {
+        $graph = Graph\directed();
+        for ($i = 0; $i < 100; $i++) {
+            $graph = Graph\add_edge($graph, 'center', 'leaf' . $i);
+        }
+
+        yield 'star_100' => ['graph' => $graph, 'node' => 'center'];
+    }
+
+    /**
+     * @return iterable<string, array{graph: Graph\DirectedGraph}>
+     */
+    public function provideTopoSortData(): iterable
+    {
+        $graph = Graph\directed();
+        for ($layer = 0; $layer < 5; $layer++) {
+            for ($n = 0; $n < 10; $n++) {
+                if ($layer >= 4) {
+                    continue;
+                }
+
+                for ($next = 0; $next < 10; $next++) {
+                    $graph = Graph\add_edge($graph, $layer . '_' . $n, ($layer + 1) . '_' . $next);
+                }
+            }
+        }
+
+        yield 'layered_5x10' => ['graph' => $graph];
+    }
+}

--- a/tests/benchmark/IO/IOBench.php
+++ b/tests/benchmark/IO/IOBench.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\IO;
+
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\IO\MemoryHandle;
+
+#[Groups(['io'])]
+final class IOBench
+{
+    /**
+     * @param array{chunk_size: int, iterations: int} $params
+     */
+    #[ParamProviders('provideWriteData')]
+    public function benchMemoryHandleWriteAppend(array $params): void
+    {
+        $handle = new MemoryHandle();
+        $chunk = str_repeat('x', $params['chunk_size']);
+        for ($i = 0; $i < $params['iterations']; $i++) {
+            $handle->tryWrite($chunk);
+        }
+    }
+
+    /**
+     * @param array{chunk_size: non-negative-int, iterations: int} $params
+     */
+    #[ParamProviders('provideWriteData')]
+    public function benchMemoryHandleWriteOverwrite(array $params): void
+    {
+        $initial = str_repeat('y', $params['chunk_size'] * $params['iterations']);
+        $handle = new MemoryHandle($initial);
+        $chunk = str_repeat('x', $params['chunk_size']);
+        for ($i = 0; $i < $params['iterations']; $i++) {
+            /** @var non-negative-int $offset */
+            $offset = $i * $params['chunk_size'];
+            $handle->seek($offset);
+            $handle->tryWrite($chunk);
+        }
+    }
+
+    /**
+     * @param array{chunk_size: int, iterations: int} $params
+     */
+    #[ParamProviders('provideWriteData')]
+    public function benchMemoryHandleReadAll(array $params): void
+    {
+        $data = str_repeat('x', $params['chunk_size'] * $params['iterations']);
+        $handle = new MemoryHandle($data);
+        $handle->readAll();
+    }
+
+    /**
+     * @return iterable<string, array{chunk_size: int, iterations: int}>
+     */
+    public function provideWriteData(): iterable
+    {
+        yield 'small_chunks' => ['chunk_size' => 64, 'iterations' => 100];
+        yield 'medium_chunks' => ['chunk_size' => 1024, 'iterations' => 100];
+        yield 'large_chunks' => ['chunk_size' => 8192, 'iterations' => 50];
+    }
+}

--- a/tests/benchmark/Iter/IterBench.php
+++ b/tests/benchmark/Iter/IterBench.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Iter;
+
+use ArrayIterator;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\Iter;
+use Psl\Vec;
+
+#[Groups(['iter'])]
+final class IterBench
+{
+    /**
+     * @param array{data: list<int>, target: int} $params
+     */
+    #[ParamProviders('provideContainsData')]
+    public function benchContainsArray(array $params): void
+    {
+        $_ = Iter\contains($params['data'], $params['target']);
+    }
+
+    /**
+     * @param array{data: ArrayIterator<int, int>, target: int} $params
+     */
+    #[ParamProviders('provideContainsIterableData')]
+    public function benchContainsIterable(array $params): void
+    {
+        $_ = Iter\contains($params['data'], $params['target']);
+    }
+
+    /**
+     * @param array{data: array<int, int>, target: int} $params
+     */
+    #[ParamProviders('provideContainsKeyData')]
+    public function benchContainsKeyArray(array $params): void
+    {
+        $_ = Iter\contains_key($params['data'], $params['target']);
+    }
+
+    /**
+     * @param array{data: ArrayIterator<int, int>, target: int} $params
+     */
+    #[ParamProviders('provideContainsKeyIterableData')]
+    public function benchContainsKeyIterable(array $params): void
+    {
+        $_ = Iter\contains_key($params['data'], $params['target']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchCount(array $params): void
+    {
+        $_ = Iter\count($params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchFirst(array $params): void
+    {
+        $_ = Iter\first($params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchFirstKey(array $params): void
+    {
+        $_ = Iter\first_key($params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchLastKey(array $params): void
+    {
+        $_ = Iter\last_key($params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchLast(array $params): void
+    {
+        $_ = Iter\last($params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchIsEmpty(array $params): void
+    {
+        $_ = Iter\is_empty($params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchReduce(array $params): void
+    {
+        $_ = Iter\reduce($params['data'], static fn(int $acc, int $v): int => $acc + $v, 0);
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: list<int>, target: int}>
+     */
+    public function provideContainsData(): iterable
+    {
+        $large = Vec\range(1, 1000);
+
+        yield 'small, start' => ['data' => Vec\range(1, 10), 'target' => 1];
+        yield 'small, end' => ['data' => Vec\range(1, 10), 'target' => 10];
+        yield 'small, missing' => ['data' => Vec\range(1, 10), 'target' => 99];
+        yield 'large, start' => ['data' => $large, 'target' => 1];
+        yield 'large, end' => ['data' => $large, 'target' => 1000];
+        yield 'large, missing' => ['data' => $large, 'target' => 9999];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: ArrayIterator<int, int>, target: int}>
+     */
+    public function provideContainsIterableData(): iterable
+    {
+        yield 'small, start' => ['data' => new ArrayIterator(Vec\range(1, 10)), 'target' => 1];
+        yield 'large, end' => ['data' => new ArrayIterator(Vec\range(1, 1000)), 'target' => 1000];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: array<int, int>, target: int}>
+     */
+    public function provideContainsKeyData(): iterable
+    {
+        $large = Vec\range(1, 1000);
+
+        yield 'small, start' => ['data' => Vec\range(1, 10), 'target' => 0];
+        yield 'small, end' => ['data' => Vec\range(1, 10), 'target' => 9];
+        yield 'small, missing' => ['data' => Vec\range(1, 10), 'target' => 99];
+        yield 'large, start' => ['data' => $large, 'target' => 0];
+        yield 'large, end' => ['data' => $large, 'target' => 999];
+        yield 'large, missing' => ['data' => $large, 'target' => 9999];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: ArrayIterator<int, int>, target: int}>
+     */
+    public function provideContainsKeyIterableData(): iterable
+    {
+        yield 'small, start' => ['data' => new ArrayIterator(Vec\range(1, 10)), 'target' => 0];
+        yield 'large, end' => ['data' => new ArrayIterator(Vec\range(1, 1000)), 'target' => 999];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: list<int>}>
+     */
+    public function provideArrayData(): iterable
+    {
+        yield 'small (10)' => ['data' => Vec\range(1, 10)];
+        yield 'large (1000)' => ['data' => Vec\range(1, 1000)];
+    }
+}

--- a/tests/benchmark/Math/MathBench.php
+++ b/tests/benchmark/Math/MathBench.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Math;
+
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\Math;
+use Psl\Vec;
+
+#[Groups(['math'])]
+final class MathBench
+{
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchSum(array $params): void
+    {
+        $_ = Math\sum($params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchSumFloats(array $params): void
+    {
+        $_ = Math\sum_floats($params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchMax(array $params): void
+    {
+        $_ = Math\max($params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchMin(array $params): void
+    {
+        $_ = Math\min($params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideData')]
+    public function benchMean(array $params): void
+    {
+        $_ = Math\mean($params['data']);
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: list<int>}>
+     */
+    public function provideData(): iterable
+    {
+        yield 'small (10)' => ['data' => Vec\range(1, 10)];
+        yield 'medium (100)' => ['data' => Vec\range(1, 100)];
+        yield 'large (1000)' => ['data' => Vec\range(1, 1000)];
+    }
+}

--- a/tests/benchmark/Shell/ShellBench.php
+++ b/tests/benchmark/Shell/ShellBench.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Shell;
+
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+
+use function pack;
+use function Psl\Shell\stream_unpack;
+use function str_repeat;
+
+#[Groups(['shell'])]
+final class ShellBench
+{
+    /**
+     * Benchmark stream_unpack parsing (exercises Str\Byte\length/slice in hot loop).
+     *
+     * @param array{content: string} $params
+     */
+    #[ParamProviders('providePackedData')]
+    public function benchStreamUnpack(array $params): void
+    {
+        foreach (stream_unpack($params['content']) as $_type => $_chunk) {
+            // @mago-expect lint:no-empty-loop - consume generator
+        }
+    }
+
+    /**
+     * @return iterable<string, array{content: string}>
+     */
+    public function providePackedData(): iterable
+    {
+        // Few small chunks
+        $content = '';
+        for ($i = 0; $i < 10; $i++) {
+            $chunk = "chunk_{$i}";
+            $content .= pack('C1N1', ($i % 2) + 1, strlen($chunk)) . $chunk;
+        }
+
+        yield 'few_small' => ['content' => $content];
+
+        // Many small chunks
+        $content = '';
+        for ($i = 0; $i < 100; $i++) {
+            $chunk = "chunk_{$i}";
+            $content .= pack('C1N1', ($i % 2) + 1, strlen($chunk)) . $chunk;
+        }
+
+        yield 'many_small' => ['content' => $content];
+
+        // Few large chunks
+        $content = '';
+        for ($i = 0; $i < 5; $i++) {
+            $chunk = str_repeat('x', 10_000);
+            $content .= pack('C1N1', ($i % 2) + 1, strlen($chunk)) . $chunk;
+        }
+
+        yield 'few_large' => ['content' => $content];
+
+        // Many large chunks
+        $content = '';
+        for ($i = 0; $i < 50; $i++) {
+            $chunk = str_repeat('x', 10_000);
+            $content .= pack('C1N1', ($i % 2) + 1, strlen($chunk)) . $chunk;
+        }
+
+        yield 'many_large' => ['content' => $content];
+    }
+}

--- a/tests/benchmark/Str/StrBench.php
+++ b/tests/benchmark/Str/StrBench.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Str;
+
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\Str;
+use Psl\Str\Byte;
+
+#[Groups(['str'])]
+final class StrBench
+{
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideStrings')]
+    public function benchTrim(array $params): void
+    {
+        Str\trim($params['data']);
+    }
+
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideStrings')]
+    public function benchTrimCustomMask(array $params): void
+    {
+        Str\trim($params['data'], 'abc');
+    }
+
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideStrings')]
+    public function benchTrimLeft(array $params): void
+    {
+        Str\trim_left($params['data']);
+    }
+
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideStrings')]
+    public function benchTrimRight(array $params): void
+    {
+        Str\trim_right($params['data']);
+    }
+
+    /**
+     * @param array{data: string, delimiter: string} $params
+     */
+    #[ParamProviders('provideSplitData')]
+    public function benchSplit(array $params): void
+    {
+        Str\split($params['data'], $params['delimiter']);
+    }
+
+    /**
+     * @param array{data: string, needle: string, replacement: string} $params
+     */
+    #[ParamProviders('provideReplaceData')]
+    public function benchReplace(array $params): void
+    {
+        Str\replace($params['data'], $params['needle'], $params['replacement']);
+    }
+
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideStrings')]
+    public function benchContains(array $params): void
+    {
+        Str\contains($params['data'], 'needle');
+    }
+
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideStrings')]
+    public function benchStartsWith(array $params): void
+    {
+        Str\starts_with($params['data'], '  hello');
+    }
+
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideStrings')]
+    public function benchEndsWith(array $params): void
+    {
+        Str\ends_with($params['data'], 'world  ');
+    }
+
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideStrings')]
+    public function benchCapitalize(array $params): void
+    {
+        Str\capitalize($params['data']);
+    }
+
+    /**
+     * @param array{data: string, replacements: array<string, string>} $params
+     */
+    #[ParamProviders('provideByteReplaceEveryData')]
+    public function benchByteReplaceEvery(array $params): void
+    {
+        Str\Byte\replace_every($params['data'], $params['replacements']);
+    }
+
+    /**
+     * @param array{data: string, length: non-negative-int, pad: non-empty-string} $params
+     */
+    #[ParamProviders('providePadData')]
+    public function benchPadLeft(array $params): void
+    {
+        Str\pad_left($params['data'], $params['length'], $params['pad']);
+    }
+
+    /**
+     * @param array{data: string, length: non-negative-int, pad: non-empty-string} $params
+     */
+    #[ParamProviders('providePadData')]
+    public function benchPadRight(array $params): void
+    {
+        Str\pad_right($params['data'], $params['length'], $params['pad']);
+    }
+
+    /**
+     * @param array{data: string, replacements: array<string, string>} $params
+     */
+    #[ParamProviders('provideReplaceEveryData')]
+    public function benchReplaceEvery(array $params): void
+    {
+        Str\replace_every($params['data'], $params['replacements']);
+    }
+
+    /**
+     * @param array{data: string, replacements: array<string, string>} $params
+     */
+    #[ParamProviders('provideReplaceEveryData')]
+    public function benchReplaceEveryCi(array $params): void
+    {
+        Str\replace_every_ci($params['data'], $params['replacements']);
+    }
+
+    /**
+     * @param array{data: string, replacements: array<string, string>} $params
+     */
+    #[ParamProviders('provideReplaceEveryData')]
+    public function benchByteReplaceEveryCi(array $params): void
+    {
+        Str\Byte\replace_every_ci($params['data'], $params['replacements']);
+    }
+
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideStrings')]
+    public function benchUppercase(array $params): void
+    {
+        $_ = Str\uppercase($params['data']);
+    }
+
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideStrings')]
+    public function benchLowercase(array $params): void
+    {
+        $_ = Str\lowercase($params['data']);
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: string}>
+     */
+    public function provideStrings(): iterable
+    {
+        yield 'short' => ['data' => '  hello world  '];
+        yield 'medium' => ['data' => str_repeat('  hello world  ', 10)];
+        yield 'long' => ['data' => str_repeat('  hello world  ', 100)];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: string, delimiter: string}>
+     */
+    public function provideSplitData(): iterable
+    {
+        yield 'single char, short' => ['data' => 'a,b,c,d,e', 'delimiter' => ','];
+        yield 'single char, long' => ['data' => implode(',', range(1, 100)), 'delimiter' => ','];
+        yield 'multi char, short' => ['data' => 'a::b::c::d::e', 'delimiter' => '::'];
+        yield 'multi char, long' => ['data' => implode('::', range(1, 100)), 'delimiter' => '::'];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: string, needle: string, replacement: string}>
+     */
+    public function provideReplaceData(): iterable
+    {
+        yield 'present, short' => ['data' => 'hello world', 'needle' => 'world', 'replacement' => 'earth'];
+        yield 'absent, short' => ['data' => 'hello world', 'needle' => 'xyz', 'replacement' => 'abc'];
+        yield 'present, long' => [
+            'data' => str_repeat('hello world ', 100),
+            'needle' => 'world',
+            'replacement' => 'earth',
+        ];
+        yield 'absent, long' => ['data' => str_repeat('hello world ', 100), 'needle' => 'xyz', 'replacement' => 'abc'];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: string, replacements: array<string, string>}>
+     */
+    public function provideByteReplaceEveryData(): iterable
+    {
+        yield 'few replacements' => [
+            'data' => 'hello world foo bar',
+            'replacements' => ['hello' => 'hi', 'world' => 'earth'],
+        ];
+        yield 'many replacements' => [
+            'data' => str_repeat('hello world foo bar baz ', 20),
+            'replacements' => ['hello' => 'hi', 'world' => 'earth', 'foo' => 'qux', 'bar' => 'quux', 'baz' => 'corge'],
+        ];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: string, length: int, pad: string}>
+     */
+    public function providePadData(): iterable
+    {
+        yield 'short, space' => ['data' => 'hello', 'length' => 20, 'pad' => ' '];
+        yield 'short, multi' => ['data' => 'hello', 'length' => 20, 'pad' => '-='];
+        yield 'long, space' => ['data' => 'hello', 'length' => 200, 'pad' => ' '];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: string, replacements: array<string, string>}>
+     */
+    public function provideReplaceEveryData(): iterable
+    {
+        yield 'few replacements' => [
+            'data' => 'hello world foo bar',
+            'replacements' => ['hello' => 'hi', 'world' => 'earth'],
+        ];
+        yield 'many replacements' => [
+            'data' => str_repeat('hello world foo bar baz ', 20),
+            'replacements' => ['hello' => 'hi', 'world' => 'earth', 'foo' => 'qux', 'bar' => 'quux', 'baz' => 'corge'],
+        ];
+    }
+}

--- a/tests/benchmark/Terminal/TerminalBench.php
+++ b/tests/benchmark/Terminal/TerminalBench.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Terminal;
+
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\Terminal\Buffer;
+use Psl\Terminal\Cell;
+use Psl\Terminal\Internal\CsiKeyMap;
+use Psl\Terminal\Internal\EventParser;
+use Psl\Terminal\Internal\SgrMouseParser;
+use Psl\Terminal\Layout\Constraint;
+use Psl\Terminal\Rect;
+
+use function Psl\Terminal\Layout\Internal\solve;
+
+#[Groups(['terminal'])]
+final class TerminalBench
+{
+    /**
+     * @param array{data: string} $params
+     */
+    #[ParamProviders('provideEventParserData')]
+    public function benchEventParserFeed(array $params): void
+    {
+        $parser = new EventParser();
+        $parser->feed($params['data']);
+    }
+
+    /**
+     * @return iterable<string, array{data: string}>
+     */
+    public function provideEventParserData(): iterable
+    {
+        yield 'printable_short' => ['data' => 'hello'];
+        yield 'printable_long' => ['data' => str_repeat('abcdefghij', 10)];
+        yield 'arrow_keys' => ['data' => "\e[A\e[B\e[C\e[D\e[A\e[B\e[C\e[D"];
+        yield 'csi_mixed' => ['data' => "\e[1;5A\e[3~\e[15~\e[H\e[F\e[5;2~"];
+        yield 'sgr_mouse' => ['data' => "\e[<0;10;20M\e[<0;10;20m\e[<32;15;25M"];
+        yield 'paste_short' => ['data' => "\e[200~hello world\e[201~"];
+        yield 'paste_long' => ['data' => "\e[200~" . str_repeat('paste content ', 50) . "\e[201~"];
+        yield 'utf8' => ['data' => 'héllo wörld àçé ñ ü'];
+    }
+
+    public function benchCsiKeyMapSimple(): void
+    {
+        CsiKeyMap::map('', 'A');
+        CsiKeyMap::map('', 'B');
+        CsiKeyMap::map('', 'C');
+        CsiKeyMap::map('', 'D');
+        CsiKeyMap::map('', 'H');
+        CsiKeyMap::map('', 'F');
+    }
+
+    public function benchCsiKeyMapTilde(): void
+    {
+        CsiKeyMap::map('1', '~');
+        CsiKeyMap::map('3', '~');
+        CsiKeyMap::map('5', '~');
+        CsiKeyMap::map('15', '~');
+        CsiKeyMap::map('5;5', '~');
+    }
+
+    public function benchCsiKeyMapModified(): void
+    {
+        CsiKeyMap::map('1;5', 'A');
+        CsiKeyMap::map('1;2', 'D');
+        CsiKeyMap::map('1;3', 'C');
+        CsiKeyMap::map('97;5', 'u');
+    }
+
+    public function benchSgrMouseParser(): void
+    {
+        SgrMouseParser::parse('0;10;20', false);
+        SgrMouseParser::parse('0;10;20', true);
+        SgrMouseParser::parse('32;15;25', false);
+        SgrMouseParser::parse('64;5;10', false);
+    }
+
+    /**
+     * @param array{width: int, height: int} $params
+     */
+    #[ParamProviders('provideBufferSizes')]
+    public function benchBufferCreate(array $params): void
+    {
+        new Buffer($params['width'], $params['height']);
+    }
+
+    /**
+     * @param array{width: int, height: int} $params
+     */
+    #[ParamProviders('provideBufferSizes')]
+    public function benchBufferFill(array $params): void
+    {
+        $buffer = new Buffer($params['width'], $params['height']);
+        $cell = new Cell('X', []);
+        $buffer->fill($cell);
+    }
+
+    /**
+     * @param array{width: int, height: int} $params
+     */
+    #[ParamProviders('provideBufferSizes')]
+    public function benchBufferResize(array $params): void
+    {
+        $buffer = new Buffer(10, 10);
+        $buffer->resize($params['width'], $params['height']);
+    }
+
+    /**
+     * @return iterable<string, array{width: int, height: int}>
+     */
+    public function provideBufferSizes(): iterable
+    {
+        yield 'small_24x80' => ['width' => 80, 'height' => 24];
+        yield 'medium_50x120' => ['width' => 120, 'height' => 50];
+        yield 'large_100x200' => ['width' => 200, 'height' => 100];
+    }
+
+    /**
+     * @param array{constraints: list<Constraint>} $params
+     */
+    #[ParamProviders('provideLayoutData')]
+    public function benchLayoutSolve(array $params): void
+    {
+        $rect = new Rect(0, 0, 200, 100);
+        solve($rect, $params['constraints'], false);
+    }
+
+    /**
+     * @return iterable<string, array{constraints: list<Constraint>}>
+     */
+    public function provideLayoutData(): iterable
+    {
+        yield 'few_fixed' => ['constraints' => [
+            Constraint::fixed(20),
+            Constraint::fixed(30),
+            Constraint::fixed(50),
+        ]];
+        yield 'few_mixed' => ['constraints' => [
+            Constraint::fixed(20),
+            Constraint::fill(),
+            Constraint::fixed(30),
+        ]];
+        yield 'many_mixed' => ['constraints' => [
+            Constraint::fixed(10),
+            Constraint::fill(),
+            Constraint::fixed(10),
+            Constraint::fill(),
+            Constraint::fixed(10),
+            Constraint::fill(),
+            Constraint::fixed(10),
+            Constraint::fill(),
+            Constraint::fixed(10),
+            Constraint::fill(),
+        ]];
+    }
+}

--- a/tests/benchmark/Tree/TreeBench.php
+++ b/tests/benchmark/Tree/TreeBench.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Tree;
+
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\Tree;
+
+#[Groups(['tree'])]
+final class TreeBench
+{
+    /**
+     * @param array{tree: Tree\NodeInterface} $params
+     */
+    #[ParamProviders('provideTreeData')]
+    public function benchDepth(array $params): void
+    {
+        Tree\depth($params['tree']);
+    }
+
+    /**
+     * @param array{tree: Tree\NodeInterface, path: list<non-negative-int>} $params
+     */
+    #[ParamProviders('provideAtIndexData')]
+    public function benchAtIndex(array $params): void
+    {
+        Tree\at_index($params['tree'], $params['path']);
+    }
+
+    /**
+     * @return iterable<string, array{tree: Tree\NodeInterface}>
+     */
+    public function provideTreeData(): iterable
+    {
+        $children = [];
+        for ($i = 0; $i < 10; $i++) {
+            $grandchildren = [];
+            for ($j = 0; $j < 10; $j++) {
+                $grandchildren[] = Tree\leaf(($i * 10) + $j);
+            }
+
+            $children[] = Tree\tree($i, $grandchildren);
+        }
+
+        yield 'wide_shallow' => ['tree' => Tree\tree(0, $children)];
+
+        $node = Tree\leaf(0);
+        for ($i = 0; $i < 20; $i++) {
+            $node = Tree\tree($i, [$node]);
+        }
+
+        yield 'deep_narrow' => ['tree' => $node];
+
+        // Balanced binary tree: depth 8
+        yield 'balanced_depth8' => ['tree' => self::buildBalancedTree(8)];
+    }
+
+    /**
+     * @return iterable<string, array{tree: Tree\NodeInterface, path: list<non-negative-int>}>
+     */
+    public function provideAtIndexData(): iterable
+    {
+        $node = Tree\leaf(0);
+        for ($i = 0; $i < 15; $i++) {
+            $node = Tree\tree($i, [$node]);
+        }
+
+        yield 'deep_path' => ['tree' => $node, 'path' => array_fill(0, 15, 0)];
+
+        $children = [];
+        for ($i = 0; $i < 20; $i++) {
+            $grandchildren = [];
+            for ($j = 0; $j < 5; $j++) {
+                $grandchildren[] = Tree\leaf(($i * 5) + $j);
+            }
+
+            $children[] = Tree\tree($i, $grandchildren);
+        }
+
+        yield 'wide_middle' => ['tree' => Tree\tree(0, $children), 'path' => [10, 2]];
+    }
+
+    private static function buildBalancedTree(int $depth): Tree\NodeInterface
+    {
+        if ($depth === 0) {
+            return Tree\leaf(0);
+        }
+
+        return Tree\tree(0, [
+            self::buildBalancedTree($depth - 1),
+            self::buildBalancedTree($depth - 1),
+        ]);
+    }
+}

--- a/tests/benchmark/Vec/VecBench.php
+++ b/tests/benchmark/Vec/VecBench.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Benchmark\Vec;
+
+use ArrayIterator;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\ParamProviders;
+use Psl\Vec;
+
+#[Groups(['vec'])]
+final class VecBench
+{
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchMap(array $params): void
+    {
+        Vec\map($params['data'], static fn(int $v): int => $v * 2);
+    }
+
+    /**
+     * @param array{data: ArrayIterator<int, int>} $params
+     */
+    #[ParamProviders('provideIterableData')]
+    public function benchMapIterable(array $params): void
+    {
+        Vec\map($params['data'], static fn(int $v): int => $v * 2);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchFilter(array $params): void
+    {
+        Vec\filter($params['data'], static fn(int $v): bool => ($v % 2) === 0);
+    }
+
+    /**
+     * @param array{data: ArrayIterator<int, int>} $params
+     */
+    #[ParamProviders('provideIterableData')]
+    public function benchFilterIterable(array $params): void
+    {
+        Vec\filter($params['data'], static fn(int $v): bool => ($v % 2) === 0);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideUniqueByData')]
+    public function benchUniqueBy(array $params): void
+    {
+        Vec\unique_by($params['data'], static fn(int $v): int => $v % 50);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchSort(array $params): void
+    {
+        Vec\sort($params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchSortBy(array $params): void
+    {
+        Vec\sort_by($params['data'], static fn(int $v): int => -$v);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchFlatMap(array $params): void
+    {
+        Vec\flat_map($params['data'], static fn(int $v): array => [$v, $v * 2]);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchChunk(array $params): void
+    {
+        $_ = Vec\chunk($params['data'], 10);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchReverse(array $params): void
+    {
+        Vec\reverse($params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchFill(array $params): void
+    {
+        $_ = Vec\fill(count($params['data']), 42);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchZip(array $params): void
+    {
+        Vec\zip($params['data'], $params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchConcat(array $params): void
+    {
+        Vec\concat($params['data'], $params['data'], $params['data']);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchSlice(array $params): void
+    {
+        $size = count($params['data']);
+        /** @var non-negative-int $start */
+        $start = (int) ($size / 4);
+        /** @var non-negative-int $length */
+        $length = (int) ($size / 2);
+        $_ = Vec\slice($params['data'], $start, $length);
+    }
+
+    /**
+     * @param array{data: list<int>} $params
+     */
+    #[ParamProviders('provideArrayData')]
+    public function benchFlatten(array $params): void
+    {
+        $_ = Vec\flatten([$params['data'], $params['data'], $params['data']]);
+    }
+
+    /**
+     * @param array{data: list<int|null>} $params
+     */
+    #[ParamProviders('provideNullableData')]
+    public function benchFilterNulls(array $params): void
+    {
+        Vec\filter_nulls($params['data']);
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: list<int>}>
+     */
+    public function provideArrayData(): iterable
+    {
+        yield 'small (10)' => ['data' => Vec\range(1, 10)];
+        yield 'medium (100)' => ['data' => Vec\range(1, 100)];
+        yield 'large (1000)' => ['data' => Vec\range(1, 1000)];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: ArrayIterator<int, int>}>
+     */
+    public function provideIterableData(): iterable
+    {
+        yield 'small (10)' => ['data' => new ArrayIterator(Vec\range(1, 10))];
+        yield 'medium (100)' => ['data' => new ArrayIterator(Vec\range(1, 100))];
+        yield 'large (1000)' => ['data' => new ArrayIterator(Vec\range(1, 1000))];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: list<int>}>
+     */
+    public function provideUniqueByData(): iterable
+    {
+        yield 'small (10)' => ['data' => Vec\range(1, 10)];
+        yield 'medium (100)' => ['data' => Vec\range(1, 100)];
+        yield 'large (1000)' => ['data' => Vec\range(1, 1000)];
+    }
+
+    /**
+     * @return iterable<non-empty-string, array{data: list<int|null>}>
+     */
+    public function provideNullableData(): iterable
+    {
+        $make = static function (int $size): array {
+            $data = [];
+            for ($i = 0; $i < $size; $i++) {
+                $data[] = ($i % 3) === 0 ? null : $i;
+            }
+
+            return $data;
+        };
+
+        yield 'small (10)' => ['data' => $make(10)];
+        yield 'medium (100)' => ['data' => $make(100)];
+        yield 'large (1000)' => ['data' => $make(1000)];
+    }
+}

--- a/tests/unit/Dict/FilterTest.php
+++ b/tests/unit/Dict/FilterTest.php
@@ -8,6 +8,7 @@ use Closure;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psl\Dict;
+use Psl\Iter;
 
 final class FilterTest extends TestCase
 {
@@ -26,5 +27,19 @@ final class FilterTest extends TestCase
         yield [[], ['a', 'b'], static fn(): bool => false];
         yield [['a', 'b'], ['a', 'b'], static fn(string $_): bool => true];
         yield [['a'], ['a', 'b'], static fn(string $v): bool => 'b' !== $v];
+    }
+
+    public function testFilterWithNonArrayIterable(): void
+    {
+        $iterator = Iter\Iterator::create(['a' => 1, 'b' => 0, 'c' => 3]);
+
+        static::assertSame(['a' => 1, 'c' => 3], Dict\filter($iterator));
+    }
+
+    public function testFilterWithNonArrayIterableAndPredicate(): void
+    {
+        $iterator = Iter\Iterator::create(['a' => 1, 'b' => 2, 'c' => 3]);
+
+        static::assertSame(['b' => 2, 'c' => 3], Dict\filter($iterator, static fn(int $v): bool => $v > 1));
     }
 }

--- a/tests/unit/Dict/FlattenTest.php
+++ b/tests/unit/Dict/FlattenTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Dict;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Dict;
+
+final class FlattenTest extends TestCase
+{
+    public function testFlattenEmpty(): void
+    {
+        static::assertSame([], Dict\flatten([]));
+    }
+
+    public function testFlattenAllArrays(): void
+    {
+        static::assertSame(['a' => 1, 'b' => 2, 'c' => 3], Dict\flatten([['a' => 1], ['b' => 2, 'c' => 3]]));
+    }
+}

--- a/tests/unit/Dict/FlipTest.php
+++ b/tests/unit/Dict/FlipTest.php
@@ -18,4 +18,11 @@ final class FlipTest extends TestCase
 
         static::assertSame(['x' => 'a', 'y' => 'b'], $result);
     }
+
+    public function testFlipWithArray(): void
+    {
+        $result = Dict\flip(['a' => 'x', 'b' => 'y']);
+
+        static::assertSame(['x' => 'a', 'y' => 'b'], $result);
+    }
 }

--- a/tests/unit/Dict/GroupByTest.php
+++ b/tests/unit/Dict/GroupByTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psl\Collection;
 use Psl\Dict;
-use Psl\Exception;
 use Psl\Str;
 
 final class GroupByTest extends TestCase
@@ -43,10 +42,7 @@ final class GroupByTest extends TestCase
 
     public function testGroupByThrowsWhenKeyFunReturnsNonArrayKey(): void
     {
-        $this->expectException(Exception\InvariantViolationException::class);
-        $this->expectExceptionMessage(
-            'Expected $key_func to return a value of type array-key, value of type (object) returned.',
-        );
+        $this->expectException(\TypeError::class);
 
         Dict\group_by([0, 1, 2, 3, 4, 5], static fn(int $x): Collection\Vector => new Collection\Vector([$x, $x]));
     }

--- a/tests/unit/Dict/MergeTest.php
+++ b/tests/unit/Dict/MergeTest.php
@@ -7,6 +7,7 @@ namespace Psl\Tests\Unit\Dict;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psl\Dict;
+use Psl\Iter;
 
 final class MergeTest extends TestCase
 {
@@ -41,5 +42,21 @@ final class MergeTest extends TestCase
                 [2 => 9, 3 => 8],
             ],
         ];
+    }
+
+    public function testMergeWithMixedArrayAndNonArrayRest(): void
+    {
+        $iterator = Iter\Iterator::create(['c' => 'd']);
+        $result = Dict\merge(['a' => 'b'], $iterator);
+
+        static::assertSame(['a' => 'b', 'c' => 'd'], $result);
+    }
+
+    public function testMergeWithNonArrayFirst(): void
+    {
+        $iterator = Iter\Iterator::create(['a' => 'b']);
+        $result = Dict\merge($iterator, ['c' => 'd']);
+
+        static::assertSame(['a' => 'b', 'c' => 'd'], $result);
     }
 }

--- a/tests/unit/Dict/SliceTest.php
+++ b/tests/unit/Dict/SliceTest.php
@@ -7,6 +7,7 @@ namespace Psl\Tests\Unit\Dict;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psl\Dict;
+use Psl\Iter;
 
 final class SliceTest extends TestCase
 {
@@ -22,5 +23,26 @@ final class SliceTest extends TestCase
     {
         yield [['c' => 3, 'd' => 4], ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4], 2];
         yield [['b' => 2, 'c' => 3], ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4], 1, 2];
+    }
+
+    public function testSliceWithNonArrayIterable(): void
+    {
+        $iterator = Iter\Iterator::create(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]);
+
+        static::assertSame(['c' => 3, 'd' => 4], Dict\slice($iterator, 2));
+    }
+
+    public function testSliceWithNonArrayIterableAndLength(): void
+    {
+        $iterator = Iter\Iterator::create(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]);
+
+        static::assertSame(['b' => 2, 'c' => 3], Dict\slice($iterator, 1, 2));
+    }
+
+    public function testSliceWithNonArrayIterableZeroLength(): void
+    {
+        $iterator = Iter\Iterator::create(['a' => 1, 'b' => 2]);
+
+        static::assertSame([], Dict\slice($iterator, 0, 0));
     }
 }

--- a/tests/unit/Dict/SortByKeyTest.php
+++ b/tests/unit/Dict/SortByKeyTest.php
@@ -8,6 +8,7 @@ use Closure;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psl\Dict;
+use Psl\Iter;
 use Psl\Str;
 
 final class SortByKeyTest extends TestCase
@@ -32,5 +33,12 @@ final class SortByKeyTest extends TestCase
                 static fn(string $a, string $b): int => Str\ord($a) > Str\ord($b) ? -1 : 1,
             ],
         ];
+    }
+
+    public function testSortByKeyWithNonArrayIterable(): void
+    {
+        $iterator = Iter\Iterator::create(['c' => 3, 'a' => 1, 'b' => 2]);
+
+        static::assertSame(['a' => 1, 'b' => 2, 'c' => 3], Dict\sort_by_key($iterator));
     }
 }

--- a/tests/unit/Dict/SortTest.php
+++ b/tests/unit/Dict/SortTest.php
@@ -8,6 +8,7 @@ use Closure;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psl\Dict;
+use Psl\Iter;
 
 final class SortTest extends TestCase
 {
@@ -42,5 +43,12 @@ final class SortTest extends TestCase
                 ['foo' => 'bar', 'bar' => 'baz'],
             ],
         ];
+    }
+
+    public function testSortWithNonArrayIterable(): void
+    {
+        $iterator = Iter\Iterator::create(['c' => 3, 'a' => 1, 'b' => 2]);
+
+        static::assertSame(['a' => 1, 'b' => 2, 'c' => 3], Dict\sort($iterator));
     }
 }

--- a/tests/unit/Graph/AddNodeTest.php
+++ b/tests/unit/Graph/AddNodeTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Psl\Tests\Unit\Graph;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psl\Graph;
+use stdClass;
 
 final class AddNodeTest extends TestCase
 {
@@ -47,5 +49,35 @@ final class AddNodeTest extends TestCase
         $graph2 = Graph\add_node($graph, 'A');
 
         static::assertSame($graph, $graph2);
+    }
+
+    #[DataProvider('provideNodeTypes')]
+    public function testAddNodeWithVariousTypes(mixed $node): void
+    {
+        $graph = Graph\directed();
+        $graph = Graph\add_node($graph, $node);
+
+        static::assertTrue($graph->hasNode($node));
+        static::assertCount(1, $graph->getNodes());
+    }
+
+    public static function provideNodeTypes(): iterable
+    {
+        yield 'int' => [42];
+        yield 'float' => [3.14];
+        yield 'bool true' => [true];
+        yield 'bool false' => [false];
+        yield 'array' => [['a', 'b']];
+        yield 'object' => [new stdClass()];
+        yield 'resource' => [STDIN];
+    }
+
+    public function testAddEdgeWithIntNodes(): void
+    {
+        $graph = Graph\directed();
+        $graph = Graph\add_edge($graph, 1, 2);
+        $graph = Graph\add_edge($graph, 2, 3);
+
+        static::assertSame([1, 2, 3], Graph\dfs($graph, 1));
     }
 }

--- a/tests/unit/Graph/DfsTest.php
+++ b/tests/unit/Graph/DfsTest.php
@@ -62,4 +62,18 @@ final class DfsTest extends TestCase
         static::assertContains('B', $result);
         static::assertContains('C', $result);
     }
+
+    public function testDfsSkipsAlreadyVisitedNodeFromStack(): void
+    {
+        $graph = Graph\directed();
+        $graph = Graph\add_edge($graph, 'A', 'B');
+        $graph = Graph\add_edge($graph, 'A', 'C');
+        $graph = Graph\add_edge($graph, 'B', 'C');
+
+        $result = Graph\dfs($graph, 'A');
+        static::assertCount(3, $result);
+        static::assertSame('A', $result[0]);
+        static::assertContains('B', $result);
+        static::assertContains('C', $result);
+    }
 }

--- a/tests/unit/Graph/Internal/GetNodeKeyTest.php
+++ b/tests/unit/Graph/Internal/GetNodeKeyTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\Graph\Internal;
+
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+use function Psl\Graph\Internal\get_node_key;
+
+final class GetNodeKeyTest extends TestCase
+{
+    public function testObject(): void
+    {
+        $obj = new stdClass();
+        $key = get_node_key($obj);
+
+        static::assertStringStartsWith('o:', $key);
+    }
+
+    public function testArray(): void
+    {
+        $key = get_node_key(['a', 'b']);
+
+        static::assertStringStartsWith('a:', $key);
+    }
+
+    public function testResource(): void
+    {
+        $key = get_node_key(STDIN);
+
+        static::assertStringStartsWith('r:', $key);
+    }
+
+    public function testBoolTrue(): void
+    {
+        static::assertSame('b:1', get_node_key(true));
+    }
+
+    public function testBoolFalse(): void
+    {
+        static::assertSame('b:0', get_node_key(false));
+    }
+
+    public function testInt(): void
+    {
+        static::assertSame('i:42', get_node_key(42));
+    }
+
+    public function testFloat(): void
+    {
+        static::assertSame('f:3.14', get_node_key(3.14));
+    }
+
+    public function testString(): void
+    {
+        static::assertSame('s:hello', get_node_key('hello'));
+    }
+
+    public function testNull(): void
+    {
+        static::assertSame('n:null', get_node_key(null));
+    }
+}

--- a/tests/unit/Math/SqrtTest.php
+++ b/tests/unit/Math/SqrtTest.php
@@ -27,4 +27,12 @@ final class SqrtTest extends TestCase
             [1,                       1],
         ];
     }
+
+    public function testSqrtThrowsForNegativeNumber(): void
+    {
+        $this->expectException(Math\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$number must be a non-negative number.');
+
+        Math\sqrt(-1.0);
+    }
 }

--- a/tests/unit/Str/ContainsTest.php
+++ b/tests/unit/Str/ContainsTest.php
@@ -28,4 +28,10 @@ final class ContainsTest extends TestCase
             [true,  'مرحبا بكم',    'بكم',   5],
         ];
     }
+
+    public function testContainsWithNonUtf8Encoding(): void
+    {
+        static::assertTrue(Str\contains('Hello, World', 'World', 0, Str\Encoding::Iso88591));
+        static::assertFalse(Str\contains('Hello, World', 'world', 0, Str\Encoding::Iso88591));
+    }
 }

--- a/tests/unit/Str/EndsWithTest.php
+++ b/tests/unit/Str/EndsWithTest.php
@@ -30,4 +30,10 @@ final class EndsWithTest extends TestCase
             [true,  'مرحبا بكم',     'بكم'],
         ];
     }
+
+    public function testEndsWithNonUtf8Encoding(): void
+    {
+        static::assertTrue(Str\ends_with('Hello, World', 'World', Str\Encoding::Iso88591));
+        static::assertFalse(Str\ends_with('Hello, World', 'world', Str\Encoding::Iso88591));
+    }
 }

--- a/tests/unit/Str/EndsWithTest.php
+++ b/tests/unit/Str/EndsWithTest.php
@@ -35,5 +35,7 @@ final class EndsWithTest extends TestCase
     {
         static::assertTrue(Str\ends_with('Hello, World', 'World', Str\Encoding::Iso88591));
         static::assertFalse(Str\ends_with('Hello, World', 'world', Str\Encoding::Iso88591));
+        static::assertTrue(Str\ends_with('Hello', 'Hello', Str\Encoding::Iso88591));
+        static::assertFalse(Str\ends_with('Hi', 'Hello, World', Str\Encoding::Iso88591));
     }
 }

--- a/tests/unit/Str/ReplaceEveryCiTest.php
+++ b/tests/unit/Str/ReplaceEveryCiTest.php
@@ -58,4 +58,13 @@ final class ReplaceEveryCiTest extends TestCase
             Str\Encoding::Iso88591,
         ));
     }
+
+    public function testReplaceEveryCiWithEmptyNeedleInNonUtf8(): void
+    {
+        static::assertSame('Hello, World!', Str\replace_every_ci(
+            'Hello, You!',
+            ['' => 'SKIP', 'you' => 'World'],
+            Str\Encoding::Iso88591,
+        ));
+    }
 }

--- a/tests/unit/Str/ReplaceEveryCiTest.php
+++ b/tests/unit/Str/ReplaceEveryCiTest.php
@@ -49,4 +49,13 @@ final class ReplaceEveryCiTest extends TestCase
             ],
         ];
     }
+
+    public function testReplaceEveryCiWithNonUtf8Encoding(): void
+    {
+        static::assertSame('Hello, World!', Str\replace_every_ci(
+            'Hello, You!',
+            ['you' => 'World'],
+            Str\Encoding::Iso88591,
+        ));
+    }
 }

--- a/tests/unit/Str/ReplaceEveryTest.php
+++ b/tests/unit/Str/ReplaceEveryTest.php
@@ -46,4 +46,13 @@ final class ReplaceEveryTest extends TestCase
             ],
         ];
     }
+
+    public function testReplaceEveryWithNonUtf8Encoding(): void
+    {
+        static::assertSame('Hello, World!', Str\replace_every(
+            'Hello, You!',
+            ['You' => 'World'],
+            Str\Encoding::Iso88591,
+        ));
+    }
 }

--- a/tests/unit/Str/ReplaceTest.php
+++ b/tests/unit/Str/ReplaceTest.php
@@ -25,4 +25,19 @@ final class ReplaceTest extends TestCase
             ['foo',           'foo',         'bar', 'baz'],
         ];
     }
+
+    public function testReplaceWithEmptyNeedle(): void
+    {
+        static::assertSame('Hello', Str\replace('Hello', '', 'World'));
+    }
+
+    public function testReplaceWithNonUtf8Encoding(): void
+    {
+        static::assertSame('Hello, World!', Str\replace('Hello, You!', 'You', 'World', Str\Encoding::Iso88591));
+    }
+
+    public function testReplaceWithNonUtf8EncodingNoMatch(): void
+    {
+        static::assertSame('Hello', Str\replace('Hello', 'xyz', 'World', Str\Encoding::Iso88591));
+    }
 }

--- a/tests/unit/Str/StartsWithTest.php
+++ b/tests/unit/Str/StartsWithTest.php
@@ -37,4 +37,10 @@ final class StartsWithTest extends TestCase
             [true,  'fôo',          'fô'],
         ];
     }
+
+    public function testStartsWithNonUtf8Encoding(): void
+    {
+        static::assertTrue(Str\starts_with('Hello, World', 'Hello', Str\Encoding::Iso88591));
+        static::assertFalse(Str\starts_with('Hello, World', 'world', Str\Encoding::Iso88591));
+    }
 }

--- a/tests/unit/Terminal/BufferTest.php
+++ b/tests/unit/Terminal/BufferTest.php
@@ -375,6 +375,73 @@ final class BufferTest extends TestCase
         static::assertStringContainsString("\e[0m", $written);
     }
 
+    public function testFlushSgrResetOnCursorJump(): void
+    {
+        $buffer = new Buffer(5, 1);
+        $bold = Style\bold();
+        $buffer->set(0, 0, new Cell('A', [$bold]));
+        $buffer->set(4, 0, new Cell('B'));
+
+        $output = new IO\MemoryHandle();
+        $buffer->flush($output);
+
+        $written = $output->getBuffer();
+        static::assertStringContainsString('A', $written);
+        static::assertStringContainsString('B', $written);
+        $resetCount = substr_count($written, "\e[0m");
+        static::assertGreaterThanOrEqual(1, $resetCount);
+    }
+
+    public function testFlushStyleChangeResetsOldStyle(): void
+    {
+        $buffer = new Buffer(2, 1);
+        $bold = Style\bold();
+        $fg = Ansi\foreground(Color\red());
+        $buffer->set(0, 0, new Cell('A', [$bold]));
+        $buffer->set(1, 0, new Cell('B', [$fg]));
+
+        $output = new IO\MemoryHandle();
+        $buffer->flush($output);
+
+        $written = $output->getBuffer();
+        static::assertStringContainsString('A', $written);
+        static::assertStringContainsString('B', $written);
+        $resetCount = substr_count($written, "\e[0m");
+        static::assertGreaterThanOrEqual(2, $resetCount);
+    }
+
+    public function testFlushStyledThenUnstyled(): void
+    {
+        $buffer = new Buffer(2, 1);
+        $bold = Style\bold();
+        $buffer->set(0, 0, new Cell('A', [$bold]));
+        $buffer->set(1, 0, new Cell('B'));
+
+        $output = new IO\MemoryHandle();
+        $buffer->flush($output);
+
+        $written = $output->getBuffer();
+        static::assertStringContainsString('A', $written);
+        static::assertStringContainsString('B', $written);
+    }
+
+    public function testFlushConsecutiveSameStyle(): void
+    {
+        $buffer = new Buffer(3, 1);
+        $bold = Style\bold();
+        $buffer->set(0, 0, new Cell('A', [$bold]));
+        $buffer->set(1, 0, new Cell('B', [$bold]));
+        $buffer->set(2, 0, new Cell('C', [$bold]));
+
+        $output = new IO\MemoryHandle();
+        $buffer->flush($output);
+
+        $written = $output->getBuffer();
+        static::assertStringContainsString('A', $written);
+        static::assertStringContainsString('B', $written);
+        static::assertStringContainsString('C', $written);
+    }
+
     public function testFlushWritesNothingWhenUnchangedMultiRow(): void
     {
         $syncOverhead = Str\Byte\length(

--- a/tests/unit/Type/MapTypeTest.php
+++ b/tests/unit/Type/MapTypeTest.php
@@ -205,4 +205,20 @@ final class MapTypeTest extends TypeTestCase
             static::assertSame($expectedMessage, $e->getMessage());
         }
     }
+
+    public function testMatchesReturnsFalseForInvalidValueType(): void
+    {
+        $type = Type\map(Type\int(), Type\int());
+        $map = new Collection\Map([0 => 'not an int']);
+
+        static::assertFalse($type->matches($map));
+    }
+
+    public function testMatchesReturnsFalseForInvalidKeyType(): void
+    {
+        $type = Type\map(Type\int(), Type\string());
+        $map = new Collection\Map(['not_int' => 'value']);
+
+        static::assertFalse($type->matches($map));
+    }
 }

--- a/tests/unit/Type/MutableMapTypeTest.php
+++ b/tests/unit/Type/MutableMapTypeTest.php
@@ -222,4 +222,20 @@ final class MutableMapTypeTest extends TypeTestCase
             static::assertSame($expectedMessage, $e->getMessage());
         }
     }
+
+    public function testMatchesReturnsFalseForInvalidValueType(): void
+    {
+        $type = Type\mutable_map(Type\int(), Type\int());
+        $map = new Collection\MutableMap([0 => 'not an int']);
+
+        static::assertFalse($type->matches($map));
+    }
+
+    public function testMatchesReturnsFalseForInvalidKeyType(): void
+    {
+        $type = Type\mutable_map(Type\int(), Type\string());
+        $map = new Collection\MutableMap(['not_int' => 'value']);
+
+        static::assertFalse($type->matches($map));
+    }
 }

--- a/tests/unit/Type/MutableVectorTypeTest.php
+++ b/tests/unit/Type/MutableVectorTypeTest.php
@@ -202,4 +202,12 @@ final class MutableVectorTypeTest extends TypeTestCase
             static::assertSame($expectedMessage, $e->getMessage());
         }
     }
+
+    public function testMatchesReturnsFalseForInvalidElementType(): void
+    {
+        $type = Type\mutable_vector(Type\int());
+        $vector = new Collection\MutableVector(['not an int']);
+
+        static::assertFalse($type->matches($vector));
+    }
 }

--- a/tests/unit/Type/ShapeTypeTest.php
+++ b/tests/unit/Type/ShapeTypeTest.php
@@ -352,4 +352,11 @@ final class ShapeTypeTest extends TypeTestCase
             static::assertSame($expectedMessage, $e->getMessage());
         }
     }
+
+    public function testMatchesReturnsFalseForUnknownFields(): void
+    {
+        $type = Type\shape(['name' => Type\string()]);
+
+        static::assertFalse($type->matches(['name' => 'saif', 'extra' => 123]));
+    }
 }

--- a/tests/unit/Type/VectorTypeTest.php
+++ b/tests/unit/Type/VectorTypeTest.php
@@ -202,4 +202,12 @@ final class VectorTypeTest extends TypeTestCase
             static::assertSame($expectedMessage, $e->getMessage());
         }
     }
+
+    public function testMatchesReturnsFalseForInvalidElementType(): void
+    {
+        $type = Type\vector(Type\int());
+        $vector = new Collection\Vector(['not an int']);
+
+        static::assertFalse($type->matches($vector));
+    }
 }

--- a/tests/unit/Vec/ChunkTest.php
+++ b/tests/unit/Vec/ChunkTest.php
@@ -6,6 +6,7 @@ namespace Psl\Tests\Unit\Vec;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psl\Iter;
 use Psl\Vec;
 
 final class ChunkTest extends TestCase
@@ -28,5 +29,19 @@ final class ChunkTest extends TestCase
         yield [[[1, 2, 3], [4, 5, 6], [7, 8, 9]], Vec\range(1, 9), 3];
         yield [[[1, 3, 5], [7, 9]], Vec\range(1, 9, 2), 3];
         yield [[[1, 3], [5, 7], [9]], Vec\range(1, 9, 2), 2];
+    }
+
+    public function testChunkWithNonArrayIterable(): void
+    {
+        $iterator = Iter\Iterator::create([1, 2, 3, 4, 5]);
+
+        static::assertSame([[1, 2], [3, 4], [5]], Vec\chunk($iterator, 2));
+    }
+
+    public function testChunkWithNonArrayIterableExactDivision(): void
+    {
+        $iterator = Iter\Iterator::create([1, 2, 3, 4, 5, 6]);
+
+        static::assertSame([[1, 2, 3], [4, 5, 6]], Vec\chunk($iterator, 3));
     }
 }

--- a/tests/unit/Vec/ConcatTest.php
+++ b/tests/unit/Vec/ConcatTest.php
@@ -6,6 +6,7 @@ namespace Psl\Tests\Unit\Vec;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psl\Iter;
 use Psl\Vec;
 
 final class ConcatTest extends TestCase
@@ -43,5 +44,12 @@ final class ConcatTest extends TestCase
                 [1, 2, 3],
             ],
         ];
+    }
+
+    public function testConcatWithNonArrayIterable(): void
+    {
+        $iterator = Iter\Iterator::create(['x' => 'a', 'y' => 'b']);
+
+        static::assertSame(['c', 'a', 'b'], Vec\concat(['c'], $iterator));
     }
 }

--- a/tests/unit/Vec/FilterTest.php
+++ b/tests/unit/Vec/FilterTest.php
@@ -7,6 +7,7 @@ namespace Psl\Tests\Unit\Vec;
 use Closure;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psl\Iter;
 use Psl\Vec;
 
 final class FilterTest extends TestCase
@@ -26,5 +27,19 @@ final class FilterTest extends TestCase
         yield [[], ['a', 'b'], static fn(): false => false];
         yield [['a', 'b'], ['a', 'b'], static fn(string $_): bool => true];
         yield [['a'], ['a', 'b'], static fn(string $v): bool => 'b' !== $v];
+    }
+
+    public function testFilterWithNonArrayIterable(): void
+    {
+        $iterator = Iter\Iterator::create([1, 0, 3]);
+
+        static::assertSame([1, 3], Vec\filter($iterator));
+    }
+
+    public function testFilterWithNonArrayIterableAndPredicate(): void
+    {
+        $iterator = Iter\Iterator::create([1, 2, 3]);
+
+        static::assertSame([2, 3], Vec\filter($iterator, static fn(int $v): bool => $v > 1));
     }
 }

--- a/tests/unit/Vec/SliceTest.php
+++ b/tests/unit/Vec/SliceTest.php
@@ -6,6 +6,7 @@ namespace Psl\Tests\Unit\Vec;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psl\Iter;
 use Psl\Vec;
 
 final class SliceTest extends TestCase
@@ -22,5 +23,26 @@ final class SliceTest extends TestCase
     {
         yield [[0, 1, 2, 3, 4, 5], [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5], 5];
         yield [[0, 1, 2], [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5], 5, 3];
+    }
+
+    public function testSliceWithNonArrayIterable(): void
+    {
+        $iterator = Iter\Iterator::create([1, 2, 3, 4, 5]);
+
+        static::assertSame([3, 4, 5], Vec\slice($iterator, 2));
+    }
+
+    public function testSliceWithNonArrayIterableAndLength(): void
+    {
+        $iterator = Iter\Iterator::create([1, 2, 3, 4, 5]);
+
+        static::assertSame([2, 3], Vec\slice($iterator, 1, 2));
+    }
+
+    public function testSliceWithNonArrayIterableZeroLength(): void
+    {
+        $iterator = Iter\Iterator::create([1, 2, 3]);
+
+        static::assertSame([], Vec\slice($iterator, 0, 0));
     }
 }


### PR DESCRIPTION
Results ( compared to main ):

```
./vendor/bin/phpbench run --config config/phpbench.json --ref=benchmark_reference
PHPBench (1.4.3) running benchmarks... #standwithukraine
with configuration file: /Users/azjezz/Project/psl/config/phpbench.json
with PHP version 8.5.2, xdebug ❌, opcache ✔
comparing [actual vs. benchmark_reference]

\Psl\Tests\Benchmark\Tree\TreeBench

    benchDepth # wide_shallow...............R1 I2 - [Mo2.900μs vs. Mo3.000μs] -3.33% (±1.37%)
    benchDepth # deep_narrow................R1 I2 - [Mo37.304μs vs. Mo31.831μs] +17.19% (±1.53%)
    benchDepth # balanced_depth8............R1 I0 - [Mo21.766μs vs. Mo23.121μs] -5.86% (±1.26%)
    benchAtIndex # deep_path................R1 I4 - [Mo26.755μs vs. Mo57.060μs] -53.11% (±1.95%)
    benchAtIndex # wide_middle..............R4 I4 - [Mo0.200μs vs. Mo0.500μs] -60.00% (±0.00%)

\Psl\Tests\Benchmark\Collection\CollectionBench

    benchVectorLinearSearch # small (10), f.R4 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchVectorLinearSearch # medium (100),.R2 I2 - [Mo0.100μs vs. Mo4.586μs] -97.82% (±0.00%)
    benchVectorLinearSearch # large (1000),.R1 I0 - [Mo0.500μs vs. Mo5.791μs] -91.37% (±0.00%)
    benchVectorLinearSearch # large (1000),.R2 I3 - [Mo1.000μs vs. Mo7.219μs] -86.15% (±0.00%)
    benchMutableVectorLinearSearch # small .R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchMutableVectorLinearSearch # medium.R2 I2 - [Mo0.100μs vs. Mo4.700μs] -97.87% (±0.00%)
    benchMutableVectorLinearSearch # large .R2 I4 - [Mo0.500μs vs. Mo5.586μs] -91.05% (±0.00%)
    benchMutableVectorLinearSearch # large .R2 I4 - [Mo1.000μs vs. Mo7.403μs] -86.49% (±0.00%)
    benchMapLinearSearch # small (10), foun.R5 I4 - [Mo0.000μs vs. Mo11.213μs] -100.00% (±0.00%)
    benchMapLinearSearch # medium (100), fo.R2 I4 - [Mo0.100μs vs. Mo5.080μs] -98.03% (±0.00%)
    benchMapLinearSearch # large (1000), fo.R1 I4 - [Mo0.500μs vs. Mo6.162μs] -91.89% (±0.00%)
    benchMutableMapLinearSearch # small (10.R5 I4 - [Mo0.000μs vs. Mo11.902μs] -100.00% (±0.00%)
    benchMutableMapLinearSearch # medium (1.R5 I4 - [Mo0.100μs vs. Mo5.100μs] -98.04% (±0.00%)
    benchMutableMapLinearSearch # large (10.R5 I4 - [Mo0.500μs vs. Mo6.348μs] -92.12% (±0.00%)
    benchVectorConstructor # small (10).....R2 I1 - [Mo0.100μs vs. Mo9.985μs] -99.00% (±0.00%)
    benchVectorConstructor # medium (100)...R5 I4 - [Mo0.300μs vs. Mo6.866μs] -95.63% (±0.00%)
    benchVectorConstructor # large (1000)...R1 I0 - [Mo1.697μs vs. Mo11.122μs] -84.75% (±2.95%)
    benchMutableVectorConstructor # small (.R2 I3 - [Mo0.100μs vs. Mo10.552μs] -99.05% (±0.00%)
    benchMutableVectorConstructor # medium .R5 I4 - [Mo0.200μs vs. Mo5.345μs] -96.26% (±0.00%)
    benchMutableVectorConstructor # large (.R1 I0 - [Mo1.697μs vs. Mo10.416μs] -83.71% (±2.95%)
    benchMapZip # small (10)................R1 I2 - [Mo16.646μs vs. Mo19.897μs] -16.34% (±2.26%)
    benchMapZip # medium (100)..............R1 I3 - [Mo14.277μs vs. Mo24.599μs] -41.96% (±2.26%)
    benchMapZip # large (1000)..............R1 I4 - [Mo47.363μs vs. Mo803.216μs] -94.10% (±0.59%)
    benchMutableMapZip # small (10).........R1 I1 - [Mo16.208μs vs. Mo20.644μs] -21.49% (±1.92%)
    benchMutableMapZip # medium (100).......R1 I4 - [Mo18.153μs vs. Mo28.334μs] -35.93% (±1.93%)
    benchMutableMapZip # large (1000).......R1 I4 - [Mo51.336μs vs. Mo808.513μs] -93.65% (±0.73%)
    benchMapChunk # small (10), chunk 3.....R1 I2 - [Mo0.700μs vs. Mo68.291μs] -98.97% (±0.00%)
    benchMapChunk # medium (100), chunk 10..R1 I3 - [Mo1.600μs vs. Mo82.666μs] -98.06% (±2.47%)
    benchMapChunk # large (1000), chunk 50..R1 I4 - [Mo19.249μs vs. Mo1.775ms] -98.92% (±1.13%)
    benchMutableMapChunk # small (10), chun.R1 I4 - [Mo0.600μs vs. Mo105.090μs] -99.43% (±0.00%)
    benchMutableMapChunk # medium (100), ch.R1 I0 - [Mo1.800μs vs. Mo115.295μs] -98.44% (±2.25%)
    benchMutableMapChunk # large (1000), ch.R1 I4 - [Mo18.514μs vs. Mo1.970ms] -99.06% (±0.91%)

\Psl\Tests\Benchmark\Iter\IterBench

    benchContainsArray # small, start.......R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchContainsArray # small, end.........R5 I4 - [Mo0.000μs vs. Mo8.571μs] -100.00% (±0.00%)
    benchContainsArray # small, missing.....R5 I4 - [Mo0.000μs vs. Mo8.162μs] -100.00% (±0.00%)
    benchContainsArray # large, start.......R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchContainsArray # large, end.........R5 I4 - [Mo1.000μs vs. Mo5.703μs] -82.47% (±0.00%)
    benchContainsArray # large, missing.....R5 I4 - [Mo1.000μs vs. Mo6.114μs] -83.64% (±0.00%)
    benchContainsIterable # small, start....R5 I4 - [Mo0.100μs vs. Mo0.000μs] +0.00% (±0.00%)
    benchContainsIterable # large, end......R5 I4 - [Mo21.823μs vs. Mo21.469μs] +1.65% (±0.71%)
    benchContainsKeyArray # small, start....R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchContainsKeyArray # small, end......R5 I4 - [Mo0.000μs vs. Mo10.799μs] -100.00% (±0.00%)
    benchContainsKeyArray # small, missing..R5 I4 - [Mo0.000μs vs. Mo10.270μs] -100.00% (±0.00%)
    benchContainsKeyArray # large, start....R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchContainsKeyArray # large, end......R5 I4 - [Mo0.000μs vs. Mo6.697μs] -100.00% (±0.00%)
    benchContainsKeyArray # large, missing..R5 I4 - [Mo0.000μs vs. Mo6.895μs] -100.00% (±0.00%)
    benchContainsKeyIterable # small, start.R2 I3 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchContainsKeyIterable # large, end...R1 I0 - [Mo25.517μs vs. Mo24.864μs] +2.62% (±0.88%)
    benchCount # small (10).................R1 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCount # large (1000)...............R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchFirst # small (10).................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchFirst # large (1000)...............R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchFirstKey # small (10)..............R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchFirstKey # large (1000)............R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchLastKey # small (10)...............R5 I4 - [Mo0.000μs vs. Mo11.345μs] -100.00% (±0.00%)
    benchLastKey # large (1000).............R5 I4 - [Mo0.000μs vs. Mo7.448μs] -100.00% (±0.00%)
    benchLast # small (10)..................R5 I4 - [Mo0.000μs vs. Mo9.723μs] -100.00% (±0.00%)
    benchLast # large (1000)................R5 I4 - [Mo0.000μs vs. Mo6.223μs] -100.00% (±0.00%)
    benchIsEmpty # small (10)...............R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchIsEmpty # large (1000).............R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchReduce # small (10)................R5 I4 - [Mo13.148μs vs. Mo13.756μs] -4.42% (±2.37%)
    benchReduce # large (1000)..............R5 I4 - [Mo13.240μs vs. Mo13.634μs] -2.89% (±1.76%)

\Psl\Tests\Benchmark\DateTime\DateTimeBench

    benchDurationToString # zero............R5 I4 - [Mo0.200μs vs. Mo31.730μs] -99.37% (±0.00%)
    benchDurationToString # simple_hours....R2 I3 - [Mo0.200μs vs. Mo30.581μs] -99.35% (±0.00%)
    benchDurationToString # complex.........R5 I4 - [Mo0.400μs vs. Mo0.900μs] -55.56% (±0.00%)
    benchDurationToString # negative........R5 I4 - [Mo0.400μs vs. Mo1.000μs] -60.00% (±0.00%)
    benchDurationFromIso8601 # simple.......R1 I3 - [Mo0.400μs vs. Mo0.500μs] -20.00% (±0.00%)
    benchDurationFromIso8601 # complex......R5 I4 - [Mo0.500μs vs. Mo1.897μs] -73.64% (±0.00%)
    benchDurationFromIso8601 # negative.....R1 I4 - [Mo0.500μs vs. Mo34.011μs] -98.53% (±0.00%)
    benchDurationToIso8601 # zero...........R1 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchDurationToIso8601 # simple_hours...R2 I3 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchDurationToIso8601 # complex........R2 I4 - [Mo0.300μs vs. Mo0.800μs] -62.50% (±0.00%)
    benchDurationToIso8601 # negative.......R4 I4 - [Mo0.300μs vs. Mo0.800μs] -62.50% (±0.00%)
    benchTimestampFromParts.................R5 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchTimestampFromMilliseconds..........R5 I4 - [Mo0.100μs vs. Mo0.200μs] -50.00% (±0.00%)
    benchTimestampToRfc3339 # epoch.........R1 I3 - [Mo30.796μs vs. Mo31.790μs] -3.13% (±1.71%)
    benchTimestampToRfc3339 # recent........R1 I4 - [Mo32.402μs vs. Mo32.856μs] -1.38% (±2.64%)

\Psl\Tests\Benchmark\Shell\ShellBench

    benchStreamUnpack # few_small...........R1 I4 - [Mo21.495μs vs. Mo63.970μs] -66.40% (±2.49%)
    benchStreamUnpack # many_small..........R1 I4 - [Mo30.464μs vs. Mo55.688μs] -45.29% (±2.92%)
    benchStreamUnpack # few_large...........R1 I2 - [Mo29.552μs vs. Mo63.354μs] -53.35% (±0.89%)
    benchStreamUnpack # many_large..........R1 I4 - [Mo310.890μs vs. Mo321.060μs] -3.17% (±1.62%)

\Psl\Tests\Benchmark\Async\AsyncBench

    benchSequence # few_ops.................R1 I4 - [Mo204.396μs vs. Mo292.382μs] -30.09% (±1.32%)
    benchSequence # many_ops................R1 I4 - [Mo273.473μs vs. Mo231.321μs] +18.22% (±1.21%)
    benchSemaphore # low_concurrency........R1 I4 - [Mo244.920μs vs. Mo238.086μs] +2.87% (±1.62%)
    benchSemaphore # high_concurrency.......R1 I4 - [Mo245.229μs vs. Mo243.784μs] +0.59% (±1.23%)

\Psl\Tests\Benchmark\IO\IOBench

    benchMemoryHandleWriteAppend # small_ch.R1 I1 - [Mo8.322μs vs. Mo14.463μs] -42.46% (±1.79%)
    benchMemoryHandleWriteAppend # medium_c.R1 I4 - [Mo10.300μs vs. Mo265.792μs] -96.12% (±1.37%)
    benchMemoryHandleWriteAppend # large_ch.R1 I4 - [Mo31.895μs vs. Mo231.117μs] -86.20% (±2.60%)
    benchMemoryHandleWriteOverwrite # small.R1 I4 - [Mo50.895μs vs. Mo43.664μs] +16.56% (±2.09%)
    benchMemoryHandleWriteOverwrite # mediu.R1 I2 - [Mo484.161μs vs. Mo479.298μs] +1.01% (±0.65%)
    benchMemoryHandleWriteOverwrite # large.R1 I4 - [Mo841.297μs vs. Mo857.903μs] -1.94% (±1.28%)
    benchMemoryHandleReadAll # small_chunks.R1 I4 - [Mo0.500μs vs. Mo0.500μs] 0.00% (±0.00%)
    benchMemoryHandleReadAll # medium_chunk.R1 I0 - [Mo2.000μs vs. Mo1.903μs] +5.07% (±2.02%)
    benchMemoryHandleReadAll # large_chunks.R1 I2 - [Mo20.345μs vs. Mo19.970μs] +1.88% (±1.45%)

\Psl\Tests\Benchmark\Graph\GraphBench

    benchDfs # chain_50.....................R1 I4 - [Mo31.022μs vs. Mo44.350μs] -30.05% (±1.03%)
    benchDfs # star_50......................R1 I4 - [Mo97.624μs vs. Mo114.468μs] -14.71% (±2.11%)
    benchDfs # grid_10x10...................R1 I4 - [Mo43.774μs vs. Mo97.043μs] -54.89% (±1.67%)
    benchShortestPath # chain_50............R1 I4 - [Mo90.226μs vs. Mo92.171μs] -2.11% (±0.91%)
    benchShortestPath # grid_10x10..........R1 I4 - [Mo141.720μs vs. Mo158.111μs] -10.37% (±2.00%)
    benchNeighbors..........................R1 I4 - [Mo2.761μs vs. Mo3.197μs] -13.63% (±2.69%)
    benchTopologicalSort....................R1 I4 - [Mo122.406μs vs. Mo124.542μs] -1.72% (±1.79%)

\Psl\Tests\Benchmark\Terminal\TerminalBench

    benchEventParserFeed # printable_short..R1 I4 - [Mo38.102μs vs. Mo47.017μs] -18.96% (±1.66%)
    benchEventParserFeed # printable_long...R1 I4 - [Mo18.564μs vs. Mo51.374μs] -63.86% (±2.33%)
    benchEventParserFeed # arrow_keys.......R1 I4 - [Mo4.100μs vs. Mo130.430μs] -96.86% (±0.00%)
    benchEventParserFeed # csi_mixed........R1 I4 - [Mo96.945μs vs. Mo157.713μs] -38.53% (±1.68%)
    benchEventParserFeed # sgr_mouse........R1 I4 - [Mo90.174μs vs. Mo109.005μs] -17.28% (±1.90%)
    benchEventParserFeed # paste_short......R1 I4 - [Mo0.500μs vs. Mo0.800μs] -37.50% (±0.00%)
    benchEventParserFeed # paste_long.......R1 I4 - [Mo0.500μs vs. Mo0.900μs] -44.44% (±0.00%)
    benchEventParserFeed # utf8.............R1 I4 - [Mo119.741μs vs. Mo176.276μs] -32.07% (±2.39%)
    benchCsiKeyMapSimple....................R1 I3 - [Mo0.700μs vs. Mo0.700μs] 0.00% (±0.00%)
    benchCsiKeyMapTilde.....................R2 I4 - [Mo0.900μs vs. Mo0.900μs] 0.00% (±0.00%)
    benchCsiKeyMapModified..................R2 I3 - [Mo1.000μs vs. Mo1.397μs] -28.40% (±0.00%)
    benchSgrMouseParser.....................R1 I1 - [Mo1.500μs vs. Mo1.800μs] -16.66% (±0.00%)
    benchBufferCreate # small_24x80.........R1 I4 - [Mo0.500μs vs. Mo17.440μs] -97.13% (±0.00%)
    benchBufferCreate # medium_50x120.......R1 I3 - [Mo0.700μs vs. Mo41.855μs] -98.33% (±0.00%)
    benchBufferCreate # large_100x200.......R1 I4 - [Mo1.100μs vs. Mo139.625μs] -99.21% (±0.00%)
    benchBufferFill # small_24x80...........R1 I3 - [Mo13.815μs vs. Mo31.057μs] -55.52% (±2.42%)
    benchBufferFill # medium_50x120.........R2 I2 - [Mo6.291μs vs. Mo77.386μs] -91.87% (±1.63%)
    benchBufferFill # large_100x200.........R2 I4 - [Mo6.809μs vs. Mo245.430μs] -97.23% (±1.49%)
    benchBufferResize # small_24x80.........R1 I3 - [Mo0.800μs vs. Mo18.978μs] -95.78% (±0.00%)
    benchBufferResize # medium_50x120.......R1 I4 - [Mo1.000μs vs. Mo42.897μs] -97.67% (±0.00%)
    benchBufferResize # large_100x200.......R1 I4 - [Mo1.403μs vs. Mo142.479μs] -99.02% (±3.40%)
    benchLayoutSolve # few_fixed............R2 I4 - [Mo1.100μs vs. Mo1.300μs] -15.38% (±0.00%)
    benchLayoutSolve # few_mixed............R1 I1 - [Mo1.100μs vs. Mo1.303μs] -15.60% (±0.00%)
    benchLayoutSolve # many_mixed...........R4 I4 - [Mo68.679μs vs. Mo81.290μs] -15.51% (±2.11%)

\Psl\Tests\Benchmark\Encoding\EncodingBench

    benchBase64Encode # small (32B).........R4 I4 - [Mo44.477μs vs. Mo73.631μs] -39.59% (±2.34%)
    benchBase64Encode # medium (256B).......R4 I4 - [Mo28.402μs vs. Mo61.219μs] -53.61% (±0.74%)
    benchBase64Encode # large (4KB).........R4 I4 - [Mo298.713μs vs. Mo410.824μs] -27.29% (±0.84%)
    benchBase64Decode # small (32B).........R4 I4 - [Mo53.931μs vs. Mo84.293μs] -36.02% (±1.00%)
    benchBase64Decode # medium (256B).......R4 I4 - [Mo23.101μs vs. Mo54.455μs] -57.58% (±0.86%)
    benchBase64Decode # large (4KB).........R1 I2 - [Mo193.779μs vs. Mo302.986μs] -36.04% (±1.57%)
    benchHexEncode # small (32B)............R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchHexEncode # medium (256B)..........R5 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchHexEncode # large (4KB)............R5 I4 - [Mo2.000μs vs. Mo2.000μs] -0.01% (±0.00%)
    benchHexDecode # small (32B)............R5 I4 - [Mo0.100μs vs. Mo0.200μs] -50.00% (±0.00%)
    benchHexDecode # medium (256B)..........R1 I1 - [Mo0.900μs vs. Mo1.000μs] -10.00% (±0.00%)
    benchHexDecode # large (4KB)............R1 I4 - [Mo12.452μs vs. Mo12.860μs] -3.17% (±1.29%)

\Psl\Tests\Benchmark\Math\MathBench

    benchSum # small (10)...................R5 I4 - [Mo0.000μs vs. Mo9.538μs] -100.00% (±0.00%)
    benchSum # medium (100).................R5 I4 - [Mo0.200μs vs. Mo5.014μs] -96.01% (±0.00%)
    benchSum # large (1000).................R5 I4 - [Mo2.003μs vs. Mo6.912μs] -71.02% (±2.40%)
    benchSumFloats # small (10).............R5 I4 - [Mo0.000μs vs. Mo8.640μs] -100.00% (±0.00%)
    benchSumFloats # medium (100)...........R5 I4 - [Mo0.300μs vs. Mo5.114μs] -94.13% (±0.00%)
    benchSumFloats # large (1000)...........R5 I4 - [Mo2.097μs vs. Mo10.174μs] -79.39% (±2.38%)
    benchMax # small (10)...................R5 I4 - [Mo0.000μs vs. Mo9.225μs] -100.00% (±0.00%)
    benchMax # medium (100).................R2 I4 - [Mo0.400μs vs. Mo10.163μs] -96.06% (±0.00%)
    benchMax # large (1000).................R2 I4 - [Mo3.400μs vs. Mo11.810μs] -71.21% (±2.38%)
    benchMin # small (10)...................R5 I4 - [Mo0.000μs vs. Mo8.252μs] -100.00% (±0.00%)
    benchMin # medium (100).................R5 I4 - [Mo0.400μs vs. Mo10.477μs] -96.18% (±0.00%)
    benchMin # large (1000).................R5 I4 - [Mo3.397μs vs. Mo12.263μs] -72.30% (±1.46%)
    benchMean # small (10)..................R1 I2 - [Mo8.714μs vs. Mo10.668μs] -18.32% (±1.44%)
    benchMean # medium (100)................R5 I4 - [Mo5.600μs vs. Mo5.652μs] -0.93% (±0.00%)
    benchMean # large (1000)................R5 I4 - [Mo13.634μs vs. Mo13.623μs] +0.09% (±1.10%)

\Psl\Tests\Benchmark\Channel\CommunicationBench

    benchBoundedCommunication...............R5 I4 - [Mo2.567ms vs. Mo2.553ms] +0.56% (±0.88%)
    benchUnboundedCommunication.............R1 I3 - [Mo2.534ms vs. Mo2.589ms] -2.11% (±0.38%)

\Psl\Tests\Benchmark\Channel\ChannelBench

    benchBoundedChannelSendReceive # small..R1 I4 - [Mo29.822μs vs. Mo29.392μs] +1.46% (±3.06%)
    benchBoundedChannelSendReceive # medium.R1 I2 - [Mo110.095μs vs. Mo110.193μs] -0.09% (±1.23%)
    benchBoundedChannelSendReceive # large..R1 I3 - [Mo985.157μs vs. Mo997.664μs] -1.25% (±1.68%)
    benchUnboundedChannelSendReceive # smal.R1 I4 - [Mo18.486μs vs. Mo18.603μs] -0.63% (±1.96%)
    benchUnboundedChannelSendReceive # medi.R1 I4 - [Mo550.182μs vs. Mo553.720μs] -0.64% (±1.16%)
    benchUnboundedChannelSendReceive # larg.R1 I4 - [Mo50.093ms vs. Mo50.601ms] -1.00% (±0.26%)
    benchUnboundedChannelInterleaved # smal.R1 I4 - [Mo24.259μs vs. Mo24.177μs] +0.34% (±2.14%)
    benchUnboundedChannelInterleaved # medi.R1 I4 - [Mo76.507μs vs. Mo77.065μs] -0.72% (±1.71%)
    benchUnboundedChannelInterleaved # larg.R1 I4 - [Mo655.438μs vs. Mo669.160μs] -2.05% (±0.57%)

\Psl\Tests\Benchmark\Type\VecTypeBench

    benchCoerce # mixed, empty array........R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # mixed, empty iterable.....R5 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchCoerce # mixed, non-empty array....R5 I4 - [Mo0.200μs vs. Mo0.200μs] 0.00% (±0.00%)
    benchCoerce # mixed, non-empty iterable.R2 I3 - [Mo0.300μs vs. Mo0.400μs] -25.00% (±0.00%)
    benchCoerce # mixed, large array........R1 I2 - [Mo18.479μs vs. Mo18.688μs] -1.12% (±1.15%)
    benchCoerce # mixed, large iterable.....R1 I4 - [Mo16.503μs vs. Mo16.996μs] -2.90% (±1.04%)
    benchCoerce # int, empty array..........R1 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # int, empty iterable.......R5 I4 - [Mo0.000μs vs. Mo0.100μs] -100.00% (±0.00%)
    benchCoerce # int, non-empty array......R5 I4 - [Mo0.100μs vs. Mo0.200μs] -50.00% (±0.00%)
    benchCoerce # int, non-empty iterable...R5 I4 - [Mo0.300μs vs. Mo0.300μs] 0.00% (±0.00%)
    benchAssert # mixed, empty array........R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchAssert # mixed, non-empty array....R5 I4 - [Mo0.100μs vs. Mo0.200μs] -50.00% (±0.00%)
    benchAssert # mixed, large array........R5 I4 - [Mo18.617μs vs. Mo18.699μs] -0.44% (±2.23%)
    benchAssert # int, empty array..........R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchAssert # int, non-empty array......R5 I4 - [Mo0.200μs vs. Mo0.100μs] +100.00% (±0.00%)
    benchMatch # mixed, empty array.........R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchMatch # mixed, non-empty array.....R5 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchMatch # mixed, large array.........R5 I4 - [Mo6.061μs vs. Mo6.546μs] -7.41% (±1.23%)
    benchMatch # int, empty array...........R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchMatch # int, non-empty array.......R2 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)

\Psl\Tests\Benchmark\Type\DictTypeBench

    benchCoerce # generic array, empty arra.R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # generic array, empty iter.R2 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchCoerce # generic array, non-empty .R2 I2 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchCoerce # generic array, non-empty .R5 I4 - [Mo0.200μs vs. Mo0.200μs] 0.00% (±0.00%)
    benchCoerce # generic array, large arra.R5 I4 - [Mo22.971μs vs. Mo22.759μs] +0.93% (±1.47%)
    benchCoerce # generic array, large iter.R1 I4 - [Mo21.456μs vs. Mo20.948μs] +2.42% (±1.77%)
    benchCoerce # int array, empty array....R5 I4 - [Mo0.000μs vs. Mo0.100μs] -100.00% (±0.00%)
    benchCoerce # int array, empty iterable.R5 I4 - [Mo0.000μs vs. Mo0.100μs] -100.00% (±0.00%)
    benchCoerce # int array, non-empty arra.R2 I3 - [Mo0.300μs vs. Mo0.400μs] -25.00% (±0.00%)
    benchCoerce # int array, non-empty iter.R3 I4 - [Mo0.400μs vs. Mo0.400μs] 0.00% (±0.00%)
    benchCoerce # int array, large array....R3 I4 - [Mo24.526μs vs. Mo24.179μs] +1.43% (±2.78%)
    benchCoerce # int array, large iterable.R3 I4 - [Mo22.813μs vs. Mo22.223μs] +2.65% (±1.52%)
    benchCoerce # map, empty array..........R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # map, empty iterable.......R5 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchCoerce # map, non-empty array......R5 I4 - [Mo0.300μs vs. Mo0.200μs] +50.00% (±0.00%)
    benchCoerce # map, non-empty iterable...R1 I4 - [Mo0.400μs vs. Mo0.400μs] 0.00% (±0.00%)
    benchCoerce # map, large array..........R4 I4 - [Mo26.466μs vs. Mo25.493μs] +3.81% (±2.13%)
    benchCoerce # map, large iterable.......R4 I4 - [Mo22.984μs vs. Mo23.656μs] -2.84% (±2.35%)
    benchAssert # generic array, empty arra.R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchAssert # generic array, non-empty .R2 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchAssert # generic array, large arra.R2 I4 - [Mo24.407μs vs. Mo22.421μs] +8.86% (±3.14%)
    benchAssert # int array, empty array....R2 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchAssert # int array, non-empty arra.R5 I4 - [Mo0.200μs vs. Mo0.300μs] -33.33% (±0.00%)
    benchAssert # int array, large array....R1 I1 - [Mo23.330μs vs. Mo23.093μs] +1.03% (±2.44%)
    benchAssert # map, empty array..........R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchAssert # map, non-empty array......R2 I3 - [Mo0.300μs vs. Mo0.300μs] 0.00% (±0.00%)
    benchAssert # map, large array..........R1 I1 - [Mo24.745μs vs. Mo24.665μs] +0.33% (±1.83%)
    benchMatch # generic array, empty array.R2 I1 - [Mo0.100μs vs. Mo0.000μs] +0.00% (±0.00%)
    benchMatch # generic array, non-empty a.R2 I4 - [Mo0.200μs vs. Mo0.100μs] +100.00% (±0.00%)
    benchMatch # generic array, large array.R1 I2 - [Mo3.000μs vs. Mo23.040μs] -86.98% (±0.00%)
    benchMatch # int array, empty array.....R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchMatch # int array, non-empty array.R5 I4 - [Mo0.400μs vs. Mo0.300μs] +33.33% (±0.00%)
    benchMatch # int array, large array.....R1 I4 - [Mo3.000μs vs. Mo23.048μs] -86.98% (±1.32%)
    benchMatch # map, empty array...........R5 I4 - [Mo0.000μs vs. Mo0.100μs] -100.00% (±0.00%)
    benchMatch # map, non-empty array.......R5 I4 - [Mo0.400μs vs. Mo0.300μs] +33.33% (±0.00%)
    benchMatch # map, large array...........R5 I4 - [Mo3.100μs vs. Mo24.593μs] -87.39% (±0.00%)

\Psl\Tests\Benchmark\Type\NonEmptyStringTypeBench

    benchCoerce # string....................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # int.......................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (ex.R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (im.R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchAssert.............................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchMatch..............................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)

\Psl\Tests\Benchmark\Type\StringTypeBench

    benchCoerce # string....................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # int.......................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (ex.R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (im.R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchAssert.............................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchMatch..............................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)

\Psl\Tests\Benchmark\Type\ArrayKeyTypeBench

    benchCoerce # string....................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # int.......................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (ex.R5 I4 - [Mo3.000μs vs. Mo3.000μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (im.R5 I4 - [Mo2.987μs vs. Mo3.000μs] -0.42% (±2.72%)
    benchAssert # string....................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchAssert # int.......................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchMatch # string.....................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchMatch # int........................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)

\Psl\Tests\Benchmark\Type\IntTypeBench

    benchCoerce # int.......................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # string....................R5 I4 - [Mo0.300μs vs. Mo0.300μs] 0.00% (±0.00%)
    benchCoerce # float.....................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (ex.R2 I4 - [Mo0.300μs vs. Mo0.300μs] 0.00% (±0.00%)
    benchCoerce # instanceof Stringable (im.R5 I4 - [Mo0.300μs vs. Mo0.300μs] 0.00% (±0.00%)
    benchAssert.............................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchMatch..............................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)

\Psl\Tests\Benchmark\Type\ShapeTypeBench

    benchCoerce # empty shape, empty array .R5 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchCoerce # empty shape, empty iterab.R5 I4 - [Mo0.200μs vs. Mo0.100μs] +100.00% (±0.00%)
    benchCoerce # empty shape, non-empty ar.R2 I4 - [Mo0.200μs vs. Mo0.200μs] 0.00% (±0.00%)
    benchCoerce # empty shape, non-empty it.R2 I4 - [Mo0.300μs vs. Mo0.300μs] 0.00% (±0.00%)
    benchCoerce # complex shape with option.R1 I4 - [Mo0.400μs vs. Mo0.500μs] -20.00% (±0.00%)
    benchCoerce # complex shape with option.R2 I2 - [Mo16.035μs vs. Mo11.197μs] +43.21% (±2.74%)
    benchCoerce # complex shape with option.R1 I2 - [Mo0.600μs vs. Mo0.600μs] 0.00% (±0.00%)
    benchCoerce # complex shape with option.R1 I3 - [Mo34.000μs vs. Mo36.323μs] -6.40% (±1.70%)
    benchCoerce # real-life-type-usage......R1 I1 - [Mo89.909μs vs. Mo91.110μs] -1.32% (±2.37%)
    benchAssert # empty shape, empty array .R1 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchAssert # empty shape, non-empty ar.R2 I2 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchAssert # complex shape with option.R2 I3 - [Mo0.400μs vs. Mo11.295μs] -96.46% (±0.00%)
    benchAssert # complex shape with option.R1 I3 - [Mo19.974μs vs. Mo28.579μs] -30.11% (±0.80%)
    benchAssert # real-life-type-usage......R1 I4 - [Mo112.428μs vs. Mo107.198μs] +4.88% (±1.27%)
    benchMatch # empty shape, empty array v.R1 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchMatch # empty shape, non-empty arr.R5 I4 - [Mo0.000μs vs. Mo0.100μs] -100.00% (±0.00%)
    benchMatch # complex shape with optiona.R5 I4 - [Mo0.400μs vs. Mo12.637μs] -96.83% (±0.00%)
    benchMatch # complex shape with optiona.R1 I0 - [Mo0.500μs vs. Mo28.505μs] -98.25% (±0.00%)
    benchMatch # real-life-type-usage.......R1 I4 - [Mo116.042μs vs. Mo107.354μs] +8.09% (±2.19%)

\Psl\Tests\Benchmark\Vec\VecBench

    benchMap # small (10)...................R5 I4 - [Mo0.400μs vs. Mo0.400μs] 0.00% (±0.00%)
    benchMap # medium (100).................R5 I4 - [Mo2.100μs vs. Mo2.197μs] -4.39% (±1.89%)
    benchMap # large (1000).................R3 I4 - [Mo22.295μs vs. Mo23.350μs] -4.52% (±2.11%)
    benchMapIterable # small (10)...........R1 I3 - [Mo13.358μs vs. Mo11.919μs] +12.07% (±2.61%)
    benchMapIterable # medium (100).........R1 I4 - [Mo10.462μs vs. Mo9.182μs] +13.94% (±1.67%)
    benchMapIterable # large (1000).........R1 I1 - [Mo34.638μs vs. Mo31.655μs] +9.42% (±1.94%)
    benchFilter # small (10)................R1 I2 - [Mo0.400μs vs. Mo0.400μs] 0.00% (±0.00%)
    benchFilter # medium (100)..............R1 I4 - [Mo2.303μs vs. Mo2.203μs] +4.54% (±2.09%)
    benchFilter # large (1000)..............R1 I4 - [Mo20.446μs vs. Mo20.208μs] +1.18% (±2.73%)
    benchFilterIterable # small (10)........R4 I4 - [Mo18.138μs vs. Mo15.678μs] +15.69% (±2.15%)
    benchFilterIterable # medium (100)......R1 I3 - [Mo9.306μs vs. Mo8.996μs] +3.45% (±2.73%)
    benchFilterIterable # large (1000)......R1 I3 - [Mo31.972μs vs. Mo30.744μs] +3.99% (±2.51%)
    benchUniqueBy # small (10)..............R1 I0 - [Mo23.791μs vs. Mo36.741μs] -35.24% (±3.10%)
    benchUniqueBy # medium (100)............R2 I2 - [Mo22.864μs vs. Mo22.422μs] +1.97% (±2.80%)
    benchUniqueBy # large (1000)............R2 I4 - [Mo31.953μs vs. Mo79.357μs] -59.73% (±2.13%)
    benchSort # small (10)..................R5 I4 - [Mo0.100μs vs. Mo0.200μs] -50.00% (±0.00%)
    benchSort # medium (100)................R5 I4 - [Mo1.700μs vs. Mo1.697μs] +0.21% (±2.33%)
    benchSort # large (1000)................R5 I4 - [Mo26.124μs vs. Mo25.560μs] +2.21% (±1.79%)
    benchSortBy # small (10)................R5 I4 - [Mo28.586μs vs. Mo30.229μs] -5.44% (±0.44%)
    benchSortBy # medium (100)..............R5 I4 - [Mo18.418μs vs. Mo18.829μs] -2.19% (±1.81%)
    benchSortBy # large (1000)..............R5 I4 - [Mo72.735μs vs. Mo77.464μs] -6.11% (±2.43%)
    benchFlatMap # small (10)...............R1 I2 - [Mo28.179μs vs. Mo29.814μs] -5.48% (±1.11%)
    benchFlatMap # medium (100).............R1 I4 - [Mo10.134μs vs. Mo10.129μs] +0.05% (±1.49%)
    benchFlatMap # large (1000).............R1 I4 - [Mo45.749μs vs. Mo46.223μs] -1.02% (±1.05%)
    benchChunk # small (10).................R5 I4 - [Mo0.100μs vs. Mo15.884μs] -99.37% (±0.00%)
    benchChunk # medium (100)...............R1 I0 - [Mo0.800μs vs. Mo12.689μs] -93.70% (±0.00%)
    benchChunk # large (1000)...............R1 I4 - [Mo6.922μs vs. Mo22.488μs] -69.22% (±2.15%)
    benchReverse # small (10)...............R2 I4 - [Mo0.100μs vs. Mo9.560μs] -98.95% (±0.00%)
    benchReverse # medium (100).............R1 I1 - [Mo0.500μs vs. Mo7.148μs] -93.01% (±0.00%)
    benchReverse # large (1000).............R1 I4 - [Mo3.243μs vs. Mo12.307μs] -73.65% (±2.71%)
    benchFill # small (10)..................R5 I4 - [Mo0.000μs vs. Mo6.466μs] -100.00% (±0.00%)
    benchFill # medium (100)................R2 I3 - [Mo0.200μs vs. Mo4.905μs] -95.92% (±0.00%)
    benchFill # large (1000)................R2 I4 - [Mo1.297μs vs. Mo8.214μs] -84.21% (±3.89%)
    benchZip # small (10)...................R1 I1 - [Mo11.299μs vs. Mo11.679μs] -3.25% (±2.24%)
    benchZip # medium (100).................R1 I3 - [Mo9.570μs vs. Mo10.569μs] -9.45% (±1.92%)
    benchZip # large (1000).................R1 I2 - [Mo34.848μs vs. Mo35.549μs] -1.97% (±0.42%)
    benchConcat # small (10)................R1 I0 - [Mo0.400μs vs. Mo17.074μs] -97.66% (±0.00%)
    benchConcat # medium (100)..............R1 I3 - [Mo1.500μs vs. Mo13.878μs] -89.19% (±0.00%)
    benchConcat # large (1000)..............R1 I4 - [Mo16.007μs vs. Mo28.215μs] -43.27% (±1.14%)
    benchSlice # small (10).................R2 I3 - [Mo0.100μs vs. Mo13.491μs] -99.26% (±0.00%)
    benchSlice # medium (100)...............R5 I4 - [Mo0.400μs vs. Mo9.951μs] -95.98% (±0.00%)
    benchSlice # large (1000)...............R4 I4 - [Mo2.103μs vs. Mo8.866μs] -76.28% (±2.29%)
    benchFlatten # small (10)...............R5 I4 - [Mo0.400μs vs. Mo12.462μs] -96.79% (±0.00%)
    benchFlatten # medium (100).............R1 I3 - [Mo1.803μs vs. Mo13.876μs] -87.00% (±2.66%)
    benchFlatten # large (1000).............R1 I4 - [Mo23.266μs vs. Mo29.730μs] -21.74% (±1.00%)
    benchFilterNulls # small (10)...........R1 I4 - [Mo0.400μs vs. Mo0.400μs] 0.00% (±0.00%)
    benchFilterNulls # medium (100).........R1 I4 - [Mo2.461μs vs. Mo2.500μs] -1.57% (±3.02%)
    benchFilterNulls # large (1000).........R1 I4 - [Mo21.140μs vs. Mo21.458μs] -1.48% (±1.34%)

\Psl\Tests\Benchmark\Dict\DictBench

    benchUniqueBy # small (10)..............R1 I3 - [Mo22.708μs vs. Mo51.345μs] -55.77% (±0.90%)
    benchUniqueBy # medium (100)............R1 I4 - [Mo25.144μs vs. Mo27.208μs] -7.59% (±1.92%)
    benchUniqueBy # large (1000)............R1 I4 - [Mo35.105μs vs. Mo89.266μs] -60.67% (±2.17%)
    benchGroupBy # small (10)...............R1 I4 - [Mo21.105μs vs. Mo34.260μs] -38.40% (±2.51%)
    benchGroupBy # medium (100).............R1 I4 - [Mo13.739μs vs. Mo39.808μs] -65.49% (±0.55%)
    benchGroupBy # large (1000).............R1 I4 - [Mo30.848μs vs. Mo97.218μs] -68.27% (±0.48%)
    benchMap # small (10)...................R1 I3 - [Mo16.394μs vs. Mo18.871μs] -13.12% (±1.90%)
    benchMap # medium (100).................R1 I4 - [Mo7.509μs vs. Mo8.119μs] -7.52% (±1.35%)
    benchMap # large (1000).................R1 I4 - [Mo17.155μs vs. Mo17.503μs] -1.99% (±0.68%)
    benchMapKeys # small (10)...............R1 I4 - [Mo15.691μs vs. Mo17.147μs] -8.49% (±1.24%)
    benchMapKeys # medium (100).............R1 I4 - [Mo21.090μs vs. Mo20.519μs] +2.78% (±2.52%)
    benchMapKeys # large (1000).............R1 I4 - [Mo62.390μs vs. Mo63.216μs] -1.31% (±0.74%)
    benchFilter # small (10)................R5 I4 - [Mo0.400μs vs. Mo0.400μs] 0.00% (±0.00%)
    benchFilter # medium (100)..............R1 I0 - [Mo2.003μs vs. Mo2.097μs] -4.45% (±2.40%)
    benchFilter # large (1000)..............R1 I2 - [Mo19.220μs vs. Mo19.322μs] -0.53% (±0.60%)
    benchPull # small (10)..................R2 I4 - [Mo20.486μs vs. Mo24.513μs] -16.43% (±2.54%)
    benchPull # medium (100)................R1 I1 - [Mo11.288μs vs. Mo10.600μs] +6.49% (±2.30%)
    benchPull # large (1000)................R1 I4 - [Mo55.772μs vs. Mo55.976μs] -0.36% (±0.75%)
    benchSelectKeys # small (10)............R1 I1 - [Mo27.574μs vs. Mo46.904μs] -41.21% (±1.31%)
    benchSelectKeys # medium (100)..........R1 I4 - [Mo15.393μs vs. Mo18.758μs] -17.94% (±1.86%)
    benchSelectKeys # large (1000)..........R1 I4 - [Mo25.737μs vs. Mo267.766μs] -90.39% (±1.08%)
    benchEqual # small (10).................R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchEqual # medium (100)...............R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchEqual # large (1000)...............R5 I4 - [Mo0.000μs vs. Mo0.000μs] 0.00% (±0.00%)
    benchSlice # small (10).................R5 I4 - [Mo0.100μs vs. Mo15.951μs] -99.37% (±0.00%)
    benchSlice # medium (100)...............R5 I4 - [Mo0.400μs vs. Mo10.500μs] -96.19% (±0.00%)
    benchSlice # large (1000)...............R5 I4 - [Mo2.600μs vs. Mo10.381μs] -74.96% (±1.55%)
    benchFlip # small (10)..................R2 I1 - [Mo0.100μs vs. Mo26.513μs] -99.62% (±0.00%)
    benchFlip # medium (100)................R5 I4 - [Mo0.500μs vs. Mo11.800μs] -95.76% (±0.00%)
    benchFlip # large (1000)................R1 I1 - [Mo3.700μs vs. Mo57.548μs] -93.57% (±2.14%)
    benchMerge # small (10).................R2 I4 - [Mo0.300μs vs. Mo11.856μs] -97.47% (±0.00%)
    benchMerge # medium (100)...............R5 I4 - [Mo1.397μs vs. Mo13.622μs] -89.75% (±3.60%)
    benchMerge # large (1000)...............R5 I4 - [Mo14.445μs vs. Mo25.900μs] -44.23% (±1.28%)
    benchDiff # small (10)..................R1 I3 - [Mo0.400μs vs. Mo0.500μs] -20.00% (±0.00%)
    benchDiff # medium (100)................R1 I4 - [Mo3.600μs vs. Mo3.757μs] -4.19% (±0.00%)
    benchDiff # large (1000)................R1 I4 - [Mo46.424μs vs. Mo47.129μs] -1.49% (±0.95%)
    benchIntersect # small (10).............R1 I2 - [Mo1.000μs vs. Mo1.100μs] -9.09% (±0.00%)
    benchIntersect # medium (100)...........R1 I4 - [Mo36.055μs vs. Mo36.560μs] -1.38% (±0.32%)
    benchIntersect # large (1000)...........R1 I4 - [Mo672.886μs vs. Mo678.056μs] -0.76% (±0.22%)
    benchFlatten # small (10)...............R2 I3 - [Mo0.300μs vs. Mo12.390μs] -97.58% (±0.00%)
    benchFlatten # medium (100).............R2 I4 - [Mo1.300μs vs. Mo14.367μs] -90.95% (±0.00%)
    benchFlatten # large (1000).............R2 I4 - [Mo14.735μs vs. Mo25.924μs] -43.16% (±2.38%)
    benchFilterNulls # small (10)...........R5 I4 - [Mo0.400μs vs. Mo0.400μs] 0.00% (±0.00%)
    benchFilterNulls # medium (100).........R5 I4 - [Mo2.197μs vs. Mo2.203μs] -0.30% (±2.27%)
    benchFilterNulls # large (1000).........R5 I4 - [Mo19.774μs vs. Mo20.161μs] -1.92% (±1.31%)
    benchSort # small (10)..................R5 I4 - [Mo0.100μs vs. Mo13.679μs] -99.27% (±0.00%)
    benchSort # medium (100)................R5 I4 - [Mo1.500μs vs. Mo11.312μs] -86.74% (±0.00%)
    benchSort # large (1000)................R5 I4 - [Mo25.792μs vs. Mo40.075μs] -35.64% (±2.35%)
    benchSortByKey # small (10).............R2 I4 - [Mo0.100μs vs. Mo12.722μs] -99.21% (±0.00%)
    benchSortByKey # medium (100)...........R3 I3 - [Mo1.203μs vs. Mo11.010μs] -89.07% (±3.95%)
    benchSortByKey # large (1000)...........R2 I4 - [Mo20.440μs vs. Mo34.346μs] -40.49% (±1.27%)

\Psl\Tests\Benchmark\Str\StrBench

    benchTrim # short.......................R2 I4 - [Mo0.500μs vs. Mo0.500μs] 0.00% (±0.00%)
    benchTrim # medium......................R1 I1 - [Mo0.800μs vs. Mo0.800μs] 0.00% (±0.00%)
    benchTrim # long........................R1 I2 - [Mo3.213μs vs. Mo3.261μs] -1.48% (±2.45%)
    benchTrimCustomMask # short.............R2 I3 - [Mo0.400μs vs. Mo0.400μs] 0.00% (±0.00%)
    benchTrimCustomMask # medium............R1 I3 - [Mo0.500μs vs. Mo0.500μs] 0.00% (±0.00%)
    benchTrimCustomMask # long..............R1 I4 - [Mo1.300μs vs. Mo1.400μs] -7.14% (±0.00%)
    benchTrimLeft # short...................R1 I4 - [Mo0.500μs vs. Mo0.500μs] 0.00% (±0.00%)
    benchTrimLeft # medium..................R1 I2 - [Mo0.500μs vs. Mo0.500μs] 0.00% (±0.00%)
    benchTrimLeft # long....................R1 I4 - [Mo1.000μs vs. Mo1.000μs] 0.00% (±0.00%)
    benchTrimRight # short..................R1 I4 - [Mo0.500μs vs. Mo0.500μs] 0.00% (±0.00%)
    benchTrimRight # medium.................R5 I4 - [Mo0.600μs vs. Mo0.600μs] 0.00% (±0.00%)
    benchTrimRight # long...................R5 I4 - [Mo2.297μs vs. Mo2.397μs] -4.17% (±2.17%)
    benchSplit # single char, short.........R1 I3 - [Mo22.588μs vs. Mo26.488μs] -14.72% (±3.12%)
    benchSplit # single char, long..........R1 I4 - [Mo64.786μs vs. Mo76.555μs] -15.37% (±0.79%)
    benchSplit # multi char, short..........R1 I4 - [Mo22.638μs vs. Mo24.953μs] -9.28% (±2.52%)
    benchSplit # multi char, long...........R1 I4 - [Mo71.059μs vs. Mo83.735μs] -15.14% (±0.35%)
    benchReplace # present, short...........R5 I4 - [Mo0.100μs vs. Mo0.300μs] -66.67% (±0.00%)
    benchReplace # absent, short............R4 I4 - [Mo0.100μs vs. Mo0.200μs] -50.00% (±0.00%)
    benchReplace # present, long............R4 I4 - [Mo1.397μs vs. Mo2.203μs] -36.61% (±3.60%)
    benchReplace # absent, long.............R5 I4 - [Mo0.100μs vs. Mo1.100μs] -90.91% (±0.00%)
    benchContains # short...................R5 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchContains # medium..................R5 I4 - [Mo0.000μs vs. Mo0.300μs] -100.00% (±0.00%)
    benchContains # long....................R5 I4 - [Mo0.100μs vs. Mo1.300μs] -92.31% (±0.00%)
    benchStartsWith # short.................R5 I4 - [Mo0.000μs vs. Mo0.200μs] -100.00% (±0.00%)
    benchStartsWith # medium................R5 I4 - [Mo0.000μs vs. Mo0.300μs] -100.00% (±0.00%)
    benchStartsWith # long..................R5 I4 - [Mo0.000μs vs. Mo1.203μs] -100.00% (±0.00%)
    benchEndsWith # short...................R5 I4 - [Mo0.000μs vs. Mo0.300μs] -100.00% (±0.00%)
    benchEndsWith # medium..................R2 I3 - [Mo0.100μs vs. Mo0.500μs] -80.00% (±0.00%)
    benchEndsWith # long....................R5 I4 - [Mo0.000μs vs. Mo2.497μs] -100.00% (±0.00%)
    benchCapitalize # short.................R5 I4 - [Mo0.500μs vs. Mo0.500μs] 0.00% (±0.00%)
    benchCapitalize # medium................R1 I0 - [Mo0.900μs vs. Mo1.000μs] -10.00% (±0.00%)
    benchCapitalize # long..................R1 I4 - [Mo4.409μs vs. Mo5.457μs] -19.22% (±2.30%)
    benchByteReplaceEvery # few replacement.R5 I4 - [Mo0.100μs vs. Mo0.200μs] -50.00% (±0.00%)
    benchByteReplaceEvery # many replacemen.R5 I4 - [Mo2.300μs vs. Mo2.500μs] -8.00% (±1.72%)
    benchPadLeft # short, space.............R4 I4 - [Mo0.200μs vs. Mo52.718μs] -99.62% (±0.00%)
    benchPadLeft # short, multi.............R2 I1 - [Mo0.200μs vs. Mo34.682μs] -99.42% (±0.00%)
    benchPadLeft # long, space..............R5 I4 - [Mo0.400μs vs. Mo49.623μs] -99.19% (±0.00%)
    benchPadRight # short, space............R2 I1 - [Mo0.200μs vs. Mo51.205μs] -99.61% (±0.00%)
    benchPadRight # short, multi............R5 I4 - [Mo0.200μs vs. Mo34.805μs] -99.43% (±0.00%)
    benchPadRight # long, space.............R5 I4 - [Mo0.400μs vs. Mo47.938μs] -99.17% (±0.00%)
    benchReplaceEvery # few replacements....R5 I4 - [Mo0.200μs vs. Mo0.500μs] -60.00% (±0.00%)
    benchReplaceEvery # many replacements...R1 I1 - [Mo2.303μs vs. Mo73.490μs] -96.87% (±2.09%)
    benchReplaceEveryCi # few replacements..R5 I4 - [Mo0.300μs vs. Mo1.900μs] -84.21% (±0.00%)
    benchReplaceEveryCi # many replacements.R5 I4 - [Mo2.500μs vs. Mo21.610μs] -88.43% (±1.59%)
    benchByteReplaceEveryCi # few replaceme.R2 I2 - [Mo0.200μs vs. Mo0.200μs] 0.00% (±0.00%)
    benchByteReplaceEveryCi # many replacem.R2 I4 - [Mo2.500μs vs. Mo15.708μs] -84.08% (±0.00%)
    benchUppercase # short..................R5 I4 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchUppercase # medium.................R1 I3 - [Mo0.500μs vs. Mo0.500μs] 0.00% (±0.00%)
    benchUppercase # long...................R1 I4 - [Mo3.200μs vs. Mo3.161μs] +1.24% (±2.47%)
    benchLowercase # short..................R2 I3 - [Mo0.100μs vs. Mo0.100μs] 0.00% (±0.00%)
    benchLowercase # medium.................R2 I4 - [Mo0.500μs vs. Mo0.500μs] 0.00% (±0.00%)
    benchLowercase # long...................R1 I0 - [Mo3.600μs vs. Mo3.600μs] +0.01% (±1.10%)
```