### PR TITLE
feat(tls): introduce TCPConnector for poolable TLS connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.1.0
+
+### features
+
+* feat(tls): introduce `TLS\TCPConnector` for poolable TLS connections
+* feat(tls): `TLS\StreamInterface` now extends `TCP\StreamInterface`, enabling TLS streams to be used with `TCP\SocketPoolInterface`
+
 ## 5.0.0
 
 ### breaking changes

--- a/docs/content/networking/tls.md
+++ b/docs/content/networking/tls.md
@@ -32,6 +32,12 @@ Use `Acceptor` to perform TLS handshakes on incoming streams:
 
 @example('networking/tls-lazy-acceptor.php')
 
+### TLS Connection Pooling
+
+`TLS\TCPConnector` implements `TCP\ConnectorInterface`, which means it can be used with `TCP\SocketPool` to enable connection pooling for TLS connections. This avoids repeated TLS handshakes when making multiple requests to the same host:
+
+@example('networking/tls-pool.php')
+
 ## Examples
 
 ### HTTPS Client with ALPN

--- a/docs/examples/networking/tls-pool.php
+++ b/docs/examples/networking/tls-pool.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+use Psl\TCP;
+use Psl\TLS;
+
+// Create a TLS-aware connector that implements TCP\ConnectorInterface
+$connector = new TLS\TCPConnector(
+    new TCP\Connector(),
+    new TLS\Connector(TLS\ClientConfig::default()->withPeerVerification(true)),
+);
+
+// Use it with a standard TCP socket pool for connection reuse
+$pool = new TCP\SocketPool($connector);
+
+// First request — establishes a new TLS connection
+$stream = $pool->checkout('example.com', 443);
+$stream->writeAll("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: keep-alive\r\n\r\n");
+$response = $stream->read();
+$pool->checkin($stream);
+
+// Second request — reuses the existing TLS connection (no new handshake)
+$stream = $pool->checkout('example.com', 443);
+$stream->writeAll("GET /about HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n");
+$response = $stream->read();
+$pool->clear($stream);
+
+$pool->close();

--- a/src/Psl/Internal/Loader.php
+++ b/src/Psl/Internal/Loader.php
@@ -1155,6 +1155,7 @@ final class Loader
         'Psl\\TLS\\LazyAcceptor' => 'Psl/TLS/LazyAcceptor.php',
         'Psl\\TLS\\ClientHello' => 'Psl/TLS/ClientHello.php',
         'Psl\\TLS\\Version' => 'Psl/TLS/Version.php',
+        'Psl\\TLS\\TCPConnector' => 'Psl/TLS/TCPConnector.php',
         'Psl\\TLS\\StreamInterface' => 'Psl/TLS/StreamInterface.php',
         'Psl\\TLS\\Internal\\Stream' => 'Psl/TLS/Internal/Stream.php',
         'Psl\\TLS\\Internal\\ClientHelloParser' => 'Psl/TLS/Internal/ClientHelloParser.php',

--- a/src/Psl/TLS/StreamInterface.php
+++ b/src/Psl/TLS/StreamInterface.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Psl\TLS;
 
-use Psl\Network;
+use Psl\TCP;
 
 /**
  * A TLS-encrypted network stream with access to TLS connection state.
  */
-interface StreamInterface extends Network\StreamInterface
+interface StreamInterface extends TCP\StreamInterface
 {
     /**
      * Returns the TLS connection state for this connection.

--- a/src/Psl/TLS/TCPConnector.php
+++ b/src/Psl/TLS/TCPConnector.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\TLS;
+
+use Psl\DateTime\Duration;
+use Psl\Network;
+use Psl\TCP;
+
+/**
+ * A TCP connector that upgrades connections to TLS after establishing them.
+ *
+ * Composes a {@see TCP\ConnectorInterface} for the underlying TCP connection
+ * and a {@see Connector} for the TLS handshake, allowing each layer to be
+ * configured independently.
+ *
+ * The resulting streams can be used with {@see TCP\SocketPoolInterface} to
+ * enable connection pooling for TLS connections (e.g. DNS-over-TLS).
+ */
+final readonly class TCPConnector implements TCP\ConnectorInterface
+{
+    public function __construct(
+        private TCP\ConnectorInterface $tcpConnector,
+        private Connector $tlsConnector,
+    ) {}
+
+    /**
+     * Connect to the given host over TCP and perform a TLS handshake.
+     *
+     * The $host parameter is used both as the TCP connection target and as the
+     * TLS Server Name Indication (SNI) value, unless overridden by the
+     * {@see ClientConfig::$peerName} of the TLS connector.
+     *
+     * @param non-empty-string $host
+     * @param int<0, 65535> $port
+     *
+     * @throws Network\Exception\RuntimeException If the TCP connection fails.
+     * @throws Network\Exception\TimeoutException If the connection times out.
+     * @throws Exception\HandshakeFailedException If the TLS handshake fails.
+     */
+    public function connect(string $host, int $port, null|Duration $timeout = null): TCP\StreamInterface
+    {
+        $stream = $this->tcpConnector->connect($host, $port, $timeout);
+
+        return $this->tlsConnector->connect($stream, $host);
+    }
+}

--- a/tests/unit/TLS/TCPConnectorTest.php
+++ b/tests/unit/TLS/TCPConnectorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Tests\Unit\TLS;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Async;
+use Psl\TCP;
+use Psl\TLS;
+
+final class TCPConnectorTest extends TestCase
+{
+    private const string CERT_FILE = __DIR__ . '/../../fixture/certs/server.crt';
+    private const string KEY_FILE = __DIR__ . '/../../fixture/certs/server.key';
+
+    public function testTCPConnectorImplementsConnectorInterface(): void
+    {
+        $connector = new TLS\TCPConnector(new TCP\Connector(), TLS\Connector::default());
+
+        static::assertInstanceOf(TCP\ConnectorInterface::class, $connector);
+    }
+
+    public function testTCPConnectorConnectsAndUpgradesToTls(): void
+    {
+        $cert = TLS\Certificate::create(self::CERT_FILE, self::KEY_FILE);
+        $server_config = TLS\ServerConfig::create($cert);
+        $acceptor = new TLS\Acceptor($server_config);
+
+        $listener = TCP\listen('127.0.0.1', 0);
+        $port = $listener->getLocalAddress()->port;
+
+        Async\concurrently([
+            'server' => static function () use ($listener, $acceptor): void {
+                $connection = $listener->accept();
+                $tls = $acceptor->accept($connection);
+                $data = $tls->read();
+                static::assertSame('hello from tcp-connector', $data);
+                $tls->writeAll('hello back');
+                $tls->close();
+                $listener->close();
+            },
+            'client' => static function () use ($port): void {
+                $config = TLS\ClientConfig::default()->withPeerVerification(false)->withAllowSelfSigned(true);
+
+                $connector = new TLS\TCPConnector(new TCP\Connector(), new TLS\Connector($config));
+
+                $stream = $connector->connect('127.0.0.1', $port);
+
+                static::assertInstanceOf(TCP\StreamInterface::class, $stream);
+                static::assertInstanceOf(TLS\StreamInterface::class, $stream);
+
+                $stream->writeAll('hello from tcp-connector');
+                $response = $stream->readAll();
+                static::assertSame('hello back', $response);
+                $stream->close();
+            },
+        ]);
+    }
+
+    public function testTCPConnectorWorksWithSocketPool(): void
+    {
+        $cert = TLS\Certificate::create(self::CERT_FILE, self::KEY_FILE);
+        $server_config = TLS\ServerConfig::create($cert);
+        $acceptor = new TLS\Acceptor($server_config);
+
+        $listener = TCP\listen('127.0.0.1', 0);
+        $port = $listener->getLocalAddress()->port;
+
+        Async\concurrently([
+            'server' => static function () use ($listener, $acceptor): void {
+                $connection = $listener->accept();
+                $tls = $acceptor->accept($connection);
+                $data = $tls->read();
+                static::assertSame('pooled-request', $data);
+                $tls->writeAll('pooled-response');
+                $tls->close();
+                $listener->close();
+            },
+            'client' => static function () use ($port): void {
+                $config = TLS\ClientConfig::default()->withPeerVerification(false)->withAllowSelfSigned(true);
+
+                $pool = new TCP\SocketPool(new TLS\TCPConnector(new TCP\Connector(), new TLS\Connector($config)));
+
+                $stream = $pool->checkout('127.0.0.1', $port);
+                static::assertInstanceOf(TLS\StreamInterface::class, $stream);
+
+                $stream->writeAll('pooled-request');
+                $response = $stream->readAll();
+                static::assertSame('pooled-response', $response);
+
+                $pool->clear($stream);
+                $pool->close();
+            },
+        ]);
+    }
+}


### PR DESCRIPTION
- `TLS\StreamInterface` now extends `TCP\StreamInterface` (not a BC break, since `TCP\StreamInterface` extends `Network\StreamInterface`)
- New `TLS\TCPConnector` implements `TCP\ConnectorInterface`, composing a TCP connector and TLS connector
- This allows passing `TLS\TCPConnector` to `TCP\SocketPool` for TLS connection reuse without repeated handshakes

Before this change, TLS connections could not be pooled because `TLS\StreamInterface` extended `Network\StreamInterface` directly, so it incompatible with `TCP\SocketPoolInterface` which requires `TCP\StreamInterface`. This was discovered while building DNS-over-TLS in another project.

