### PR TITLE
bc(async): fix `ingoing`->`ongoing` typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - **BC** - `TCP\Socket` setter/getter methods (`setReuseAddress`, `setReusePort`, `setNoDelay`, etc.) have been removed. Use configuration objects instead.
 - **BC** - `TCP\Connector` constructor now accepts `TCP\ConnectConfiguration` instead of `bool $noDelay`.
 - **BC** - `Socks\Connector` constructor changed from `(string $proxyHost, int $proxyPort, ?string $username, ?string $password, ConnectorInterface $connector)` to `(ConnectorInterface $connector, Socks\Configuration $configuration)`.
+- **BC** - Renamed `ingoing` to `ongoing` across `Semaphore`, `Sequence`, `KeyedSemaphore`, and `KeyedSequence` (`hasIngoingOperations()` -> `hasOngoingOperations()`, `getIngoingOperations()` -> `getOngoingOperations()`, etc.).
 
 ### features
 

--- a/docs/content/async/async.md
+++ b/docs/content/async/async.md
@@ -94,7 +94,7 @@ Limits the number of concurrent operations. All operations use the same processi
 
 @example('async/async-semaphore.php')
 
-The semaphore provides methods to inspect state (`getPendingOperations()`, `getIngoingOperations()`, `hasPendingOperations()`) and to cancel pending work. Both `waitFor()` and `waitForPending()` accept an optional `CancellationTokenInterface`.
+The semaphore provides methods to inspect state (`getPendingOperations()`, `getOngoingOperations()`, `hasPendingOperations()`) and to cancel pending work. Both `waitFor()` and `waitForPending()` accept an optional `CancellationTokenInterface`.
 
 ### KeyedSemaphore
 

--- a/src/Psl/Async/KeyedSemaphore.php
+++ b/src/Psl/Async/KeyedSemaphore.php
@@ -34,7 +34,7 @@ final class KeyedSemaphore
     /**
      * @var array<Tk, int<0, max>>
      */
-    private array $ingoing = [];
+    private array $ongoing = [];
 
     /**
      * @var array<Tk, list<Suspension>>
@@ -58,7 +58,7 @@ final class KeyedSemaphore
     /**
      * Run the operation using the given `$input`.
      *
-     * If the concurrency limit has been reached for the given `$key`, this method will wait until one of the ingoing operations has completed.
+     * If the concurrency limit has been reached for the given `$key`, this method will wait until one of the ongoing operations has completed.
      *
      * @param Tk $key
      * @param Tin $input
@@ -74,8 +74,8 @@ final class KeyedSemaphore
         mixed $input,
         CancellationTokenInterface $cancellation = new NullCancellationToken(),
     ): mixed {
-        $this->ingoing[$key] ??= 0;
-        if ($this->ingoing[$key] === $this->concurrencyLimit) {
+        $this->ongoing[$key] ??= 0;
+        if ($this->ongoing[$key] === $this->concurrencyLimit) {
             $cancellation->throwIfCancelled();
 
             $suspension = EventLoop::getSuspension();
@@ -100,7 +100,7 @@ final class KeyedSemaphore
             }
         }
 
-        $this->ingoing[$key]++;
+        $this->ongoing[$key]++;
 
         try {
             return ($this->operation)($key, $input);
@@ -115,7 +115,7 @@ final class KeyedSemaphore
                     $suspension->resume();
                 }
 
-                $this->ingoing[$key]--;
+                $this->ongoing[$key]--;
             } else {
                 foreach ($this->waits[$key] ?? [] as $suspension) {
                     $suspension->resume();
@@ -123,9 +123,9 @@ final class KeyedSemaphore
 
                 unset($this->waits[$key]);
 
-                $this->ingoing[$key]--;
-                if (0 === $this->ingoing[$key]) {
-                    unset($this->ingoing[$key]);
+                $this->ongoing[$key]--;
+                if (0 === $this->ongoing[$key]) {
+                    unset($this->ongoing[$key]);
                 }
             }
         }
@@ -226,7 +226,7 @@ final class KeyedSemaphore
     }
 
     /**
-     * Get the number of ingoing operations for the given key.
+     * Get the number of ongoing operations for the given key.
      *
      * The returned number will always be lower, or equal to the concurrency limit.
      *
@@ -234,43 +234,43 @@ final class KeyedSemaphore
      *
      * @return int<0, max>
      */
-    public function getIngoingOperations(string|int $key): int
+    public function getOngoingOperations(string|int $key): int
     {
-        return $this->ingoing[$key] ?? 0;
+        return $this->ongoing[$key] ?? 0;
     }
 
     /**
-     * Get the number of total ingoing operations.
+     * Get the number of total ongoing operations.
      *
-     * The returned number can be higher than the concurrency limit, as it is the sum of all ingoing operations using different keys.
+     * The returned number can be higher than the concurrency limit, as it is the sum of all ongoing operations using different keys.
      *
      * @return int<0, max>
      */
-    public function getTotalIngoingOperations(): int
+    public function getTotalOngoingOperations(): int
     {
         /** @var int<0, max> */
-        return array_sum($this->ingoing);
+        return array_sum($this->ongoing);
     }
 
     /**
-     * Check if the semaphore has any ingoing operations for the given key.
+     * Check if the semaphore has any ongoing operations for the given key.
      *
-     * If this method returns `true`, it does not mean future calls to `waitFor` will wait, since a semaphore can have multiple ingoing operations
+     * If this method returns `true`, it does not mean future calls to `waitFor` will wait, since a semaphore can have multiple ongoing operations
      * at the same time for the same key.
      *
      * @param Tk $key
      */
-    public function hasIngoingOperations(string|int $key): bool
+    public function hasOngoingOperations(string|int $key): bool
     {
-        return array_key_exists($key, $this->ingoing);
+        return array_key_exists($key, $this->ongoing);
     }
 
     /**
-     * Check if the semaphore has any ingoing operations.
+     * Check if the semaphore has any ongoing operations.
      */
-    public function hasAnyIngoingOperations(): bool
+    public function hasAnyOngoingOperations(): bool
     {
-        return [] !== $this->ingoing;
+        return [] !== $this->ongoing;
     }
 
     /**
@@ -286,7 +286,7 @@ final class KeyedSemaphore
         string|int $key,
         CancellationTokenInterface $cancellation = new NullCancellationToken(),
     ): void {
-        if (($this->ingoing[$key] ?? 0) !== $this->concurrencyLimit) {
+        if (($this->ongoing[$key] ?? 0) !== $this->concurrencyLimit) {
             return;
         }
 

--- a/src/Psl/Async/KeyedSequence.php
+++ b/src/Psl/Async/KeyedSequence.php
@@ -32,7 +32,7 @@ final class KeyedSequence
     /**
      * @var array<Tk, bool>
      */
-    private array $ingoing = [];
+    private array $ongoing = [];
 
     /**
      * @var array<Tk, list<Suspension>>
@@ -68,7 +68,7 @@ final class KeyedSequence
         mixed $input,
         CancellationTokenInterface $cancellation = new NullCancellationToken(),
     ): mixed {
-        if (array_key_exists($key, $this->ingoing)) {
+        if (array_key_exists($key, $this->ongoing)) {
             $cancellation->throwIfCancelled();
 
             $suspension = EventLoop::getSuspension();
@@ -93,7 +93,7 @@ final class KeyedSequence
             }
         }
 
-        $this->ingoing[$key] = true;
+        $this->ongoing[$key] = true;
 
         try {
             return ($this->operation)($key, $input);
@@ -111,7 +111,7 @@ final class KeyedSequence
                     $suspension->resume();
                 }
 
-                unset($this->waits[$key], $this->ingoing[$key]);
+                unset($this->waits[$key], $this->ongoing[$key]);
             }
         }
     }
@@ -201,40 +201,40 @@ final class KeyedSequence
     }
 
     /**
-     * Check if there's an ingoing operation for the given key.
+     * Check if there's an ongoing operation for the given key.
      *
      * If this method returns `true`, it means the sequence is busy, future calls to `waitFor` will wait.
      * If this method returns `false`, it means the sequence is not busy, future calls to `waitFor` will execute immediately.
      *
      * @param Tk $key
      */
-    public function hasIngoingOperations(string|int $key): bool
+    public function hasOngoingOperations(string|int $key): bool
     {
-        return array_key_exists($key, $this->ingoing);
+        return array_key_exists($key, $this->ongoing);
     }
 
     /**
-     * Check if the sequence has any ingoing operations.
+     * Check if the sequence has any ongoing operations.
      */
-    public function hasAnyIngoingOperations(): bool
+    public function hasAnyOngoingOperations(): bool
     {
-        return [] !== $this->ingoing;
+        return [] !== $this->ongoing;
     }
 
     /**
-     * Get the number of total ingoing operations.
+     * Get the number of total ongoing operations.
      *
      * @return int<0, max>
      */
-    public function getTotalIngoingOperations(): int
+    public function getTotalOngoingOperations(): int
     {
-        return count($this->ingoing);
+        return count($this->ongoing);
     }
 
     /**
      * Wait for all pending operations associated with the given key to finish execution.
      *
-     * If the sequence does not have any ingoing operations for the given key, this method will return immediately.
+     * If the sequence does not have any ongoing operations for the given key, this method will return immediately.
      *
      * @param Tk $key
      *
@@ -244,7 +244,7 @@ final class KeyedSequence
         string|int $key,
         CancellationTokenInterface $cancellation = new NullCancellationToken(),
     ): void {
-        if (!array_key_exists($key, $this->ingoing)) {
+        if (!array_key_exists($key, $this->ongoing)) {
             return;
         }
 

--- a/src/Psl/Async/Semaphore.php
+++ b/src/Psl/Async/Semaphore.php
@@ -30,7 +30,7 @@ final class Semaphore
     /**
      * @var int<0, max>
      */
-    private int $ingoing = 0;
+    private int $ongoing = 0;
 
     /**
      * @var list<Suspension>
@@ -54,7 +54,7 @@ final class Semaphore
     /**
      * Run the operation using the given `$input`.
      *
-     * If the concurrency limit has been reached, this method will wait until one of the ingoing operations has completed.
+     * If the concurrency limit has been reached, this method will wait until one of the ongoing operations has completed.
      *
      * @param Tin $input
      *
@@ -66,7 +66,7 @@ final class Semaphore
      */
     public function waitFor(mixed $input, CancellationTokenInterface $cancellation = new NullCancellationToken()): mixed
     {
-        if ($this->ingoing === $this->concurrencyLimit) {
+        if ($this->ongoing === $this->concurrencyLimit) {
             $cancellation->throwIfCancelled();
 
             $suspension = EventLoop::getSuspension();
@@ -87,7 +87,7 @@ final class Semaphore
             }
         }
 
-        $this->ingoing++;
+        $this->ongoing++;
 
         try {
             return ($this->operation)($input);
@@ -103,7 +103,7 @@ final class Semaphore
                 $this->waits = [];
             }
 
-            $this->ingoing--;
+            $this->ongoing--;
         }
     }
 
@@ -154,26 +154,26 @@ final class Semaphore
     }
 
     /**
-     * Get the number of ingoing operations.
+     * Get the number of ongoing operations.
      *
      * The returned number will always be lower, or equal to the concurrency limit.
      *
      * @return int<0, max>
      */
-    public function getIngoingOperations(): int
+    public function getOngoingOperations(): int
     {
-        return $this->ingoing;
+        return $this->ongoing;
     }
 
     /**
-     * Check if the semaphore has any ingoing operations.
+     * Check if the semaphore has any ongoing operations.
      *
-     * If this method returns `true`, it does not mean future calls to `waitFor` will wait, since a semaphore can have multiple ingoing operations
+     * If this method returns `true`, it does not mean future calls to `waitFor` will wait, since a semaphore can have multiple ongoing operations
      * at the same time.
      */
-    public function hasIngoingOperations(): bool
+    public function hasOngoingOperations(): bool
     {
-        return $this->ingoing > 0;
+        return $this->ongoing > 0;
     }
 
     /**
@@ -183,7 +183,7 @@ final class Semaphore
      */
     public function waitForPending(CancellationTokenInterface $cancellation = new NullCancellationToken()): void
     {
-        if ($this->ingoing !== $this->concurrencyLimit) {
+        if ($this->ongoing !== $this->concurrencyLimit) {
             return;
         }
 

--- a/src/Psl/Async/Sequence.php
+++ b/src/Psl/Async/Sequence.php
@@ -26,7 +26,7 @@ use function array_splice;
  */
 final class Sequence
 {
-    private bool $ingoing = false;
+    private bool $ongoing = false;
 
     /**
      * @var list<Suspension>
@@ -58,7 +58,7 @@ final class Sequence
      */
     public function waitFor(mixed $input, CancellationTokenInterface $cancellation = new NullCancellationToken()): mixed
     {
-        if ($this->ingoing) {
+        if ($this->ongoing) {
             $cancellation->throwIfCancelled();
 
             $suspension = EventLoop::getSuspension();
@@ -79,7 +79,7 @@ final class Sequence
             }
         }
 
-        $this->ingoing = true;
+        $this->ongoing = true;
 
         try {
             return ($this->operation)($input);
@@ -94,7 +94,7 @@ final class Sequence
 
                 $this->waits = [];
 
-                $this->ingoing = false;
+                $this->ongoing = false;
             }
         }
     }
@@ -136,14 +136,14 @@ final class Sequence
     }
 
     /**
-     * Check if the sequence has any ingoing operations.
+     * Check if the sequence has any ongoing operations.
      *
      * If this method returns `true`, it means future calls to `waitFor` will wait.
      * If this method returns `false`, it means future calls to `waitFor` will execute immediately.
      */
-    public function hasIngoingOperations(): bool
+    public function hasOngoingOperations(): bool
     {
-        return $this->ingoing;
+        return $this->ongoing;
     }
 
     /**
@@ -153,7 +153,7 @@ final class Sequence
      */
     public function waitForPending(CancellationTokenInterface $cancellation = new NullCancellationToken()): void
     {
-        if (!$this->ingoing) {
+        if (!$this->ongoing) {
             return;
         }
 

--- a/tests/unit/Async/KeyedSemaphoreTest.php
+++ b/tests/unit/Async/KeyedSemaphoreTest.php
@@ -235,40 +235,40 @@ final class KeyedSemaphoreTest extends TestCase
 
         $one = Async\run(static fn(): string => $ks->waitFor($key, 'one'));
         $two = Async\run(static fn(): string => $ks->waitFor($key, 'two'));
-        static::assertSame(0, $ks->getIngoingOperations($key));
+        static::assertSame(0, $ks->getOngoingOperations($key));
         static::assertSame(0, $ks->getPendingOperations($key));
-        static::assertFalse($ks->hasIngoingOperations($key));
+        static::assertFalse($ks->hasOngoingOperations($key));
         static::assertFalse($ks->hasPendingOperations($key));
-        static::assertSame(0, $ks->getTotalIngoingOperations());
+        static::assertSame(0, $ks->getTotalOngoingOperations());
         static::assertSame(0, $ks->getTotalPendingOperations());
-        static::assertFalse($ks->hasAnyIngoingOperations());
+        static::assertFalse($ks->hasAnyOngoingOperations());
         static::assertFalse($ks->hasAnyPendingOperations());
         Async\later();
-        static::assertSame(1, $ks->getIngoingOperations($key));
+        static::assertSame(1, $ks->getOngoingOperations($key));
         static::assertSame(1, $ks->getPendingOperations($key));
         static::assertTrue($ks->hasPendingOperations($key));
-        static::assertTrue($ks->hasIngoingOperations($key));
-        static::assertSame(1, $ks->getTotalIngoingOperations());
+        static::assertTrue($ks->hasOngoingOperations($key));
+        static::assertSame(1, $ks->getTotalOngoingOperations());
         static::assertSame(1, $ks->getTotalPendingOperations());
         static::assertTrue($ks->hasAnyPendingOperations());
-        static::assertTrue($ks->hasAnyIngoingOperations());
+        static::assertTrue($ks->hasAnyOngoingOperations());
         $one->await();
-        static::assertSame(1, $ks->getIngoingOperations($key));
+        static::assertSame(1, $ks->getOngoingOperations($key));
         static::assertSame(0, $ks->getPendingOperations($key));
-        static::assertTrue($ks->hasIngoingOperations($key));
+        static::assertTrue($ks->hasOngoingOperations($key));
         static::assertFalse($ks->hasPendingOperations($key));
-        static::assertSame(1, $ks->getTotalIngoingOperations());
+        static::assertSame(1, $ks->getTotalOngoingOperations());
         static::assertSame(0, $ks->getTotalPendingOperations());
-        static::assertTrue($ks->hasAnyIngoingOperations());
+        static::assertTrue($ks->hasAnyOngoingOperations());
         static::assertFalse($ks->hasAnyPendingOperations());
         $two->await();
-        static::assertSame(0, $ks->getIngoingOperations($key));
+        static::assertSame(0, $ks->getOngoingOperations($key));
         static::assertSame(0, $ks->getPendingOperations($key));
-        static::assertFalse($ks->hasIngoingOperations($key));
+        static::assertFalse($ks->hasOngoingOperations($key));
         static::assertFalse($ks->hasPendingOperations($key));
-        static::assertSame(0, $ks->getTotalIngoingOperations());
+        static::assertSame(0, $ks->getTotalOngoingOperations());
         static::assertSame(0, $ks->getTotalPendingOperations());
-        static::assertFalse($ks->hasAnyIngoingOperations());
+        static::assertFalse($ks->hasAnyOngoingOperations());
         static::assertFalse($ks->hasAnyPendingOperations());
     }
 
@@ -301,8 +301,8 @@ final class KeyedSemaphoreTest extends TestCase
         });
         static::assertSame(1, $ks->getConcurrencyLimit());
 
-        static::assertFalse($ks->hasIngoingOperations('foo'));
-        static::assertFalse($ks->hasIngoingOperations('bar'));
+        static::assertFalse($ks->hasOngoingOperations('foo'));
+        static::assertFalse($ks->hasOngoingOperations('bar'));
         static::assertFalse($ks->hasPendingOperations('foo'));
         static::assertFalse($ks->hasPendingOperations('bar'));
 
@@ -311,8 +311,8 @@ final class KeyedSemaphoreTest extends TestCase
 
         Async\later();
 
-        static::assertTrue($ks->hasIngoingOperations('foo'));
-        static::assertTrue($ks->hasIngoingOperations('bar'));
+        static::assertTrue($ks->hasOngoingOperations('foo'));
+        static::assertTrue($ks->hasOngoingOperations('bar'));
         static::assertFalse($ks->hasPendingOperations('foo'));
         static::assertFalse($ks->hasPendingOperations('bar'));
 
@@ -321,24 +321,24 @@ final class KeyedSemaphoreTest extends TestCase
 
         Async\later();
 
-        static::assertTrue($ks->hasIngoingOperations('foo'));
-        static::assertTrue($ks->hasIngoingOperations('bar'));
+        static::assertTrue($ks->hasOngoingOperations('foo'));
+        static::assertTrue($ks->hasOngoingOperations('bar'));
         static::assertTrue($ks->hasPendingOperations('foo'));
         static::assertTrue($ks->hasPendingOperations('bar'));
 
         static::assertSame('one', $fooOne->await());
         static::assertSame('one', $barOne->await());
 
-        static::assertTrue($ks->hasIngoingOperations('foo'));
-        static::assertTrue($ks->hasIngoingOperations('bar'));
+        static::assertTrue($ks->hasOngoingOperations('foo'));
+        static::assertTrue($ks->hasOngoingOperations('bar'));
         static::assertFalse($ks->hasPendingOperations('foo'));
         static::assertFalse($ks->hasPendingOperations('bar'));
 
         static::assertSame('two', $fooTwo->await());
         static::assertSame('two', $barTwo->await());
 
-        static::assertFalse($ks->hasIngoingOperations('foo'));
-        static::assertFalse($ks->hasIngoingOperations('bar'));
+        static::assertFalse($ks->hasOngoingOperations('foo'));
+        static::assertFalse($ks->hasOngoingOperations('bar'));
         static::assertFalse($ks->hasPendingOperations('foo'));
         static::assertFalse($ks->hasPendingOperations('bar'));
     }
@@ -349,7 +349,7 @@ final class KeyedSemaphoreTest extends TestCase
 
         $ks->waitForPending('key');
 
-        static::assertFalse($ks->hasIngoingOperations('key'));
+        static::assertFalse($ks->hasOngoingOperations('key'));
     }
 
     public function testWaitForCancelledWhileWaitingForSlot(): void

--- a/tests/unit/Async/KeyedSequenceTest.php
+++ b/tests/unit/Async/KeyedSequenceTest.php
@@ -198,35 +198,35 @@ final class KeyedSequenceTest extends TestCase
         $one = Async\run(static fn(): string => $ks->waitFor($key, 'one'));
         $two = Async\run(static fn(): string => $ks->waitFor($key, 'two'));
         static::assertSame(0, $ks->getPendingOperations($key));
-        static::assertFalse($ks->hasIngoingOperations($key));
+        static::assertFalse($ks->hasOngoingOperations($key));
         static::assertFalse($ks->hasPendingOperations($key));
-        static::assertSame(0, $ks->getTotalIngoingOperations());
+        static::assertSame(0, $ks->getTotalOngoingOperations());
         static::assertSame(0, $ks->getTotalPendingOperations());
-        static::assertFalse($ks->hasAnyIngoingOperations());
+        static::assertFalse($ks->hasAnyOngoingOperations());
         static::assertFalse($ks->hasAnyPendingOperations());
         Async\later();
         static::assertSame(1, $ks->getPendingOperations($key));
         static::assertTrue($ks->hasPendingOperations($key));
-        static::assertTrue($ks->hasIngoingOperations($key));
-        static::assertSame(1, $ks->getTotalIngoingOperations());
+        static::assertTrue($ks->hasOngoingOperations($key));
+        static::assertSame(1, $ks->getTotalOngoingOperations());
         static::assertSame(1, $ks->getTotalPendingOperations());
         static::assertTrue($ks->hasAnyPendingOperations());
-        static::assertTrue($ks->hasAnyIngoingOperations());
+        static::assertTrue($ks->hasAnyOngoingOperations());
         $one->await();
         static::assertSame(0, $ks->getPendingOperations($key));
-        static::assertTrue($ks->hasIngoingOperations($key));
+        static::assertTrue($ks->hasOngoingOperations($key));
         static::assertFalse($ks->hasPendingOperations($key));
-        static::assertSame(1, $ks->getTotalIngoingOperations());
+        static::assertSame(1, $ks->getTotalOngoingOperations());
         static::assertSame(0, $ks->getTotalPendingOperations());
-        static::assertTrue($ks->hasAnyIngoingOperations());
+        static::assertTrue($ks->hasAnyOngoingOperations());
         static::assertFalse($ks->hasAnyPendingOperations());
         $two->await();
         static::assertSame(0, $ks->getPendingOperations($key));
-        static::assertFalse($ks->hasIngoingOperations($key));
+        static::assertFalse($ks->hasOngoingOperations($key));
         static::assertFalse($ks->hasPendingOperations($key));
-        static::assertSame(0, $ks->getTotalIngoingOperations());
+        static::assertSame(0, $ks->getTotalOngoingOperations());
         static::assertSame(0, $ks->getTotalPendingOperations());
-        static::assertFalse($ks->hasAnyIngoingOperations());
+        static::assertFalse($ks->hasAnyOngoingOperations());
         static::assertFalse($ks->hasAnyPendingOperations());
     }
 
@@ -260,8 +260,8 @@ final class KeyedSequenceTest extends TestCase
             return $input;
         });
 
-        static::assertFalse($ks->hasIngoingOperations('foo'));
-        static::assertFalse($ks->hasIngoingOperations('bar'));
+        static::assertFalse($ks->hasOngoingOperations('foo'));
+        static::assertFalse($ks->hasOngoingOperations('bar'));
         static::assertFalse($ks->hasPendingOperations('foo'));
         static::assertFalse($ks->hasPendingOperations('bar'));
 
@@ -270,8 +270,8 @@ final class KeyedSequenceTest extends TestCase
 
         Async\later();
 
-        static::assertTrue($ks->hasIngoingOperations('foo'));
-        static::assertTrue($ks->hasIngoingOperations('bar'));
+        static::assertTrue($ks->hasOngoingOperations('foo'));
+        static::assertTrue($ks->hasOngoingOperations('bar'));
         static::assertFalse($ks->hasPendingOperations('foo'));
         static::assertFalse($ks->hasPendingOperations('bar'));
 
@@ -280,24 +280,24 @@ final class KeyedSequenceTest extends TestCase
 
         Async\later();
 
-        static::assertTrue($ks->hasIngoingOperations('foo'));
-        static::assertTrue($ks->hasIngoingOperations('bar'));
+        static::assertTrue($ks->hasOngoingOperations('foo'));
+        static::assertTrue($ks->hasOngoingOperations('bar'));
         static::assertTrue($ks->hasPendingOperations('foo'));
         static::assertTrue($ks->hasPendingOperations('bar'));
 
         static::assertSame('one', $fooOne->await());
         static::assertSame('one', $barOne->await());
 
-        static::assertTrue($ks->hasIngoingOperations('foo'));
-        static::assertTrue($ks->hasIngoingOperations('bar'));
+        static::assertTrue($ks->hasOngoingOperations('foo'));
+        static::assertTrue($ks->hasOngoingOperations('bar'));
         static::assertFalse($ks->hasPendingOperations('foo'));
         static::assertFalse($ks->hasPendingOperations('bar'));
 
         static::assertSame('two', $fooTwo->await());
         static::assertSame('two', $barTwo->await());
 
-        static::assertFalse($ks->hasIngoingOperations('foo'));
-        static::assertFalse($ks->hasIngoingOperations('bar'));
+        static::assertFalse($ks->hasOngoingOperations('foo'));
+        static::assertFalse($ks->hasOngoingOperations('bar'));
         static::assertFalse($ks->hasPendingOperations('foo'));
         static::assertFalse($ks->hasPendingOperations('bar'));
     }
@@ -308,7 +308,7 @@ final class KeyedSequenceTest extends TestCase
 
         $ks->waitForPending('key');
 
-        static::assertFalse($ks->hasIngoingOperations('key'));
+        static::assertFalse($ks->hasOngoingOperations('key'));
     }
 
     public function testWaitForCancelledWhileWaiting(): void

--- a/tests/unit/Async/SemaphoreTest.php
+++ b/tests/unit/Async/SemaphoreTest.php
@@ -189,24 +189,24 @@ final class SemaphoreTest extends TestCase
 
         $one = Async\run(static fn(): string => $semaphore->waitFor('one'));
         $two = Async\run(static fn(): string => $semaphore->waitFor('two'));
-        static::assertSame(0, $semaphore->getIngoingOperations());
+        static::assertSame(0, $semaphore->getOngoingOperations());
         static::assertSame(0, $semaphore->getPendingOperations());
-        static::assertFalse($semaphore->hasIngoingOperations());
+        static::assertFalse($semaphore->hasOngoingOperations());
         static::assertFalse($semaphore->hasPendingOperations());
         Async\later();
-        static::assertSame(1, $semaphore->getIngoingOperations());
+        static::assertSame(1, $semaphore->getOngoingOperations());
         static::assertSame(1, $semaphore->getPendingOperations());
         static::assertTrue($semaphore->hasPendingOperations());
-        static::assertTrue($semaphore->hasIngoingOperations());
+        static::assertTrue($semaphore->hasOngoingOperations());
         $one->await();
-        static::assertSame(1, $semaphore->getIngoingOperations());
+        static::assertSame(1, $semaphore->getOngoingOperations());
         static::assertSame(0, $semaphore->getPendingOperations());
-        static::assertTrue($semaphore->hasIngoingOperations());
+        static::assertTrue($semaphore->hasOngoingOperations());
         static::assertFalse($semaphore->hasPendingOperations());
         $two->await();
-        static::assertSame(0, $semaphore->getIngoingOperations());
+        static::assertSame(0, $semaphore->getOngoingOperations());
         static::assertSame(0, $semaphore->getPendingOperations());
-        static::assertFalse($semaphore->hasIngoingOperations());
+        static::assertFalse($semaphore->hasOngoingOperations());
         static::assertFalse($semaphore->hasPendingOperations());
     }
 
@@ -235,7 +235,7 @@ final class SemaphoreTest extends TestCase
 
         $semaphore->waitForPending();
 
-        static::assertFalse($semaphore->hasIngoingOperations());
+        static::assertFalse($semaphore->hasOngoingOperations());
     }
 
     public function testWaitForCancelledWhileWaitingForSlot(): void

--- a/tests/unit/Async/SequenceTest.php
+++ b/tests/unit/Async/SequenceTest.php
@@ -182,19 +182,19 @@ final class SequenceTest extends TestCase
 
         $one = Async\run(static fn(): string => $s->waitFor('one'));
         $two = Async\run(static fn(): string => $s->waitFor('two'));
-        static::assertFalse($s->hasIngoingOperations());
+        static::assertFalse($s->hasOngoingOperations());
         static::assertFalse($s->hasPendingOperations());
         static::assertSame(0, $s->getPendingOperations());
         Async\later();
-        static::assertTrue($s->hasIngoingOperations());
+        static::assertTrue($s->hasOngoingOperations());
         static::assertTrue($s->hasPendingOperations());
         static::assertSame(1, $s->getPendingOperations());
         $one->await();
-        static::assertTrue($s->hasIngoingOperations());
+        static::assertTrue($s->hasOngoingOperations());
         static::assertFalse($s->hasPendingOperations());
         static::assertSame(0, $s->getPendingOperations());
         $two->await();
-        static::assertFalse($s->hasIngoingOperations());
+        static::assertFalse($s->hasOngoingOperations());
         static::assertFalse($s->hasPendingOperations());
         static::assertSame(0, $s->getPendingOperations());
     }
@@ -212,19 +212,19 @@ final class SequenceTest extends TestCase
 
         $one = Async\run(static fn(): string => $s->waitFor('one'));
         $two = Async\run(static fn(): string => $s->waitFor('two'));
-        static::assertFalse($s->hasIngoingOperations());
+        static::assertFalse($s->hasOngoingOperations());
         static::assertFalse($s->hasPendingOperations());
         static::assertSame(0, $s->getPendingOperations());
         static::assertFalse($one->isComplete());
         static::assertFalse($two->isComplete());
         Async\later();
-        static::assertTrue($s->hasIngoingOperations());
+        static::assertTrue($s->hasOngoingOperations());
         static::assertTrue($s->hasPendingOperations());
         static::assertSame(1, $s->getPendingOperations());
         static::assertFalse($one->isComplete());
         static::assertFalse($two->isComplete());
         $s->waitForPending();
-        static::assertFalse($s->hasIngoingOperations());
+        static::assertFalse($s->hasOngoingOperations());
         static::assertFalse($s->hasPendingOperations());
         static::assertSame(0, $s->getPendingOperations());
         static::assertTrue($one->isComplete());
@@ -237,7 +237,7 @@ final class SequenceTest extends TestCase
 
         $s->waitForPending();
 
-        static::assertFalse($s->hasIngoingOperations());
+        static::assertFalse($s->hasOngoingOperations());
     }
 
     public function testWaitForCancelledWhileWaiting(): void


### PR DESCRIPTION
bothered me for 4 years...