### PR TITLE
feat: add replace for azjezz/psl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "phpunit/phpunit": "^13.0.5"
     },
     "replace": {
+        "azjezz/psl": "self.version",
         "php-standard-library/ansi": "self.version",
         "php-standard-library/async": "self.version",
         "php-standard-library/binary": "self.version",


### PR DESCRIPTION
## Summary
- Add `"azjezz/psl": "self.version"` to the `replace` section of `composer.json`
- This prevents namespace conflicts when downstream packages still require `azjezz/psl` but the root project uses `php-standard-library/php-standard-library`

## Context
The library was republished under a new Composer package name. Downstream packages that haven't updated yet still require `azjezz/psl`, which causes Composer to install both packages, resulting in namespace collisions since both provide the `Psl\` namespace.

Adding `replace` tells Composer that this package satisfies `azjezz/psl`, so only one copy gets installed.

Resolves https://github.com/php-standard-library/php-standard-library/issues/687