### PR TITLE
chore(str): clarify width semantics in width(), truncate(), and width_slice()

### DIFF
--- a/packages/str/src/Psl/Str/truncate.php
+++ b/packages/str/src/Psl/Str/truncate.php
@@ -7,18 +7,15 @@ namespace Psl\Str;
 use function mb_strimwidth;
 
 /**
- * Get truncated string with specified width.
+ * Truncate a string to the given display width as defined by {@see mb_strimwidth()}.
  *
- * @param int $offset The start position offset. Number of
- *                    characters from the beginning of string. (First character is 0)
- * @param int $width the width of the desired trim
- * @param string|null $trimMarker a string that is added to the end of string
- *                                 when string is truncated
+ * For grapheme-based slicing, use {@see Grapheme\slice()}.
+ *
+ * @param int $offset The start position offset in codepoints (0-indexed).
+ * @param int $width The maximum display width of the result.
+ * @param null|string $trimMarker Appended to the result when the string is truncated.
  *
  * @throws Exception\OutOfBoundsException If the offset is out-of-bounds.
- *
- * @return string The truncated string. If trim_marker is set,
- *                trim_marker is appended to the return value.
  *
  * @pure
  */

--- a/packages/str/src/Psl/Str/width.php
+++ b/packages/str/src/Psl/Str/width.php
@@ -7,7 +7,10 @@ namespace Psl\Str;
 use function mb_strwidth;
 
 /**
- * Return width of length.
+ * Return the display width of a string as defined by {@see mb_strwidth()}.
+ *
+ * For codepoint counting, use {@see length()}.
+ * For grapheme cluster counting, use {@see Grapheme\length()}.
  *
  * @pure
  */

--- a/packages/str/src/Psl/Str/width_slice.php
+++ b/packages/str/src/Psl/Str/width_slice.php
@@ -7,7 +7,11 @@ namespace Psl\Str;
 use function mb_strimwidth;
 
 /**
- * Returns a substring truncated to the given display width.
+ * Returns a substring truncated to the given display width as defined by {@see mb_strimwidth()}.
+ *
+ * See {@see width()}.
+ *
+ * For grapheme-based slicing, use {@see Grapheme\slice()}.
  *
  * @param int<0, max> $offset Codepoint offset to start from.
  * @param int<0, max> $width Maximum display width of the result.


### PR DESCRIPTION
closes #698