### PR TITLE
fix(str): reject invalid Unicode code points in chr() and from_code_points()

### DIFF
--- a/packages/str/src/Psl/Str/chr.php
+++ b/packages/str/src/Psl/Str/chr.php
@@ -7,7 +7,7 @@ namespace Psl\Str;
 use function mb_chr;
 
 /**
- * Return a specific character.
+ * Return the character for a given Unicode code point.
  *
  * Example:
  *
@@ -17,9 +17,16 @@ use function mb_chr;
  *      Str\chr(1604)
  *      => Str('ل')
  *
+ * @throws Exception\OutOfBoundsException If the code point is out of the valid Unicode range.
+ *
  * @pure
  */
 function chr(int $codepoint, Encoding $encoding = Encoding::Utf8): string
 {
-    return (string) mb_chr($codepoint, $encoding->value);
+    $result = mb_chr($codepoint, $encoding->value);
+    if (false === $result) {
+        throw new Exception\OutOfBoundsException('Code point ' . $codepoint . ' is not a valid Unicode code point.');
+    }
+
+    return $result;
 }

--- a/packages/str/src/Psl/Str/from_code_points.php
+++ b/packages/str/src/Psl/Str/from_code_points.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Psl\Str;
 
 /**
- * Create a Multi-byte string from code points.
+ * Create a UTF-8 string from Unicode code points.
+ *
+ * @see chr()
  *
  * Example:
  *
@@ -15,32 +17,15 @@ namespace Psl\Str;
  *      Str\from_code_points(72, 101, 108, 108, 111)
  *      => Str('Hello')
  *
+ * @throws Exception\OutOfBoundsException If a code point is out of the valid Unicode range.
+ *
  * @pure
  */
 function from_code_points(int ...$codePoints): string
 {
     $string = '';
     foreach ($codePoints as $code) {
-        $code %= 0x20_0000;
-
-        if (0x80 > $code) {
-            $string .= Byte\chr($code);
-            continue;
-        }
-
-        if (0x800 > $code) {
-            $string .= Byte\chr(0xC0 | ($code >> 6)) . Byte\chr(0x80 | ($code & 0x3F));
-            continue;
-        }
-
-        if (0x1_0000 > $code) {
-            $string .= Byte\chr(0xE0 | ($code >> 12)) . Byte\chr(0x80 | (($code >> 6) & 0x3F));
-            $string .= Byte\chr(0x80 | ($code & 0x3F));
-            continue;
-        }
-
-        $string .= Byte\chr(0xF0 | ($code >> 18)) . Byte\chr(0x80 | (($code >> 12) & 0x3F));
-        $string .= Byte\chr(0x80 | (($code >> 6) & 0x3F)) . Byte\chr(0x80 | ($code & 0x3F));
+        $string .= namespace\chr($code);
     }
 
     return $string;

--- a/packages/str/tests/unit/ChrTest.php
+++ b/packages/str/tests/unit/ChrTest.php
@@ -26,4 +26,25 @@ final class ChrTest extends TestCase
             ['A', 65],
         ];
     }
+
+    public function testNegativeCodePointThrows(): void
+    {
+        $this->expectException(Str\Exception\OutOfBoundsException::class);
+
+        Str\chr(-1);
+    }
+
+    public function testSurrogateThrows(): void
+    {
+        $this->expectException(Str\Exception\OutOfBoundsException::class);
+
+        Str\chr(0xD800);
+    }
+
+    public function testAboveUnicodeMaxThrows(): void
+    {
+        $this->expectException(Str\Exception\OutOfBoundsException::class);
+
+        Str\chr(0x11_0000);
+    }
 }

--- a/packages/str/tests/unit/FromCodePointsTest.php
+++ b/packages/str/tests/unit/FromCodePointsTest.php
@@ -22,5 +22,42 @@ final class FromCodePointsTest extends TestCase
         static::assertSame('ς', Str\from_code_points(962));
 
         static::assertSame("\u{10001}", Str\from_code_points(65_537));
+
+        static::assertSame("\u{10FFFF}", Str\from_code_points(0x10_FFFF));
+    }
+
+    public function testNegativeCodePointThrows(): void
+    {
+        $this->expectException(Str\Exception\OutOfBoundsException::class);
+
+        Str\from_code_points(-1);
+    }
+
+    public function testSurrogateStartThrows(): void
+    {
+        $this->expectException(Str\Exception\OutOfBoundsException::class);
+
+        Str\from_code_points(0xD800);
+    }
+
+    public function testSurrogateEndThrows(): void
+    {
+        $this->expectException(Str\Exception\OutOfBoundsException::class);
+
+        Str\from_code_points(0xDFFF);
+    }
+
+    public function testAboveUnicodeMaxThrows(): void
+    {
+        $this->expectException(Str\Exception\OutOfBoundsException::class);
+
+        Str\from_code_points(0x11_0000);
+    }
+
+    public function testInvalidCodePointAmongValidOnesThrows(): void
+    {
+        $this->expectException(Str\Exception\OutOfBoundsException::class);
+
+        Str\from_code_points(72, 101, 0xD800, 108, 111);
     }
 }


### PR DESCRIPTION
`chr()` silently returned empty string for invalid code points, and `from_code_points()` used a hand-rolled UTF-8 encoder that silently produced invalid byte sequences for surrogates and out-of-range values.

Both now throw `OutOfBoundsException` for invalid input, and `from_code_points()` delegates to `chr()` for consistent behavior.

Argubly, this is a BC break, but, it is not something worth bumping 7.x for or waiting months to fix.

closes #699
