### PR TITLE
feat: add `bin/psl detect-packages` command

### DIFF
--- a/bin/psl
+++ b/bin/psl
@@ -106,7 +106,8 @@ function detect_packages_command(array $arguments): never
 
             $content = File\read($entry);
             foreach ($nsToDir as $ns => $dir) {
-                if (Regex\matches($content, '/Psl\\\\' . $ns . '[\\\\\\s;,)]/')) {
+                $escapedNs = Str\replace($ns, '\\', '\\\\');
+                if (Regex\matches($content, '/Psl\\\\' . $escapedNs . '[\\\\\\s;,)]/')) {
                     $found[$dir] = true;
                 }
             }

--- a/bin/psl
+++ b/bin/psl
@@ -3,6 +3,7 @@
 
 declare(strict_types=1);
 
+use Psl\Dict;
 use Psl\Env;
 use Psl\File;
 use Psl\Filesystem;
@@ -35,35 +36,67 @@ require (static function (): string {
 function detect_packages_command(array $arguments): never
 {
     $composer = false;
-    $path = null;
+    /** @var list<string> $srcPaths */
+    $srcPaths = [];
+    /** @var list<string> $devPaths */
+    $devPaths = [];
+    $mode = 'src';
 
     foreach ($arguments as $arg) {
         if ($arg === '--composer') {
             $composer = true;
+        } elseif ($arg === '--src') {
+            $mode = 'src';
+        } elseif ($arg === '--dev') {
+            $mode = 'dev';
         } elseif (!Str\starts_with($arg, '-')) {
-            $path = $arg;
+            if ($mode === 'dev') {
+                $devPaths[] = $arg;
+            } else {
+                $srcPaths[] = $arg;
+            }
         }
     }
 
-    if ($path === null) {
-        IO\write_error_line('Usage: psl detect-packages <path> [--composer]');
+    if ($srcPaths === [] && $devPaths === []) {
+        IO\write_error_line('Usage: psl detect-packages <path>... [--dev <path>...] [--composer]');
+        IO\write_error_line('');
+        IO\write_error_line('Scan PHP files for PSL namespace usage and report which');
+        IO\write_error_line('php-standard-library/* packages are needed.');
+        IO\write_error_line('');
+        IO\write_error_line('Arguments:');
+        IO\write_error_line('  <path>...   Directories to scan (mapped to require)');
+        IO\write_error_line('');
+        IO\write_error_line('Options:');
+        IO\write_error_line('  --src       Mark following paths as require (default)');
+        IO\write_error_line('  --dev       Mark following paths as require-dev');
+        IO\write_error_line('  --composer  Output JSON snippet for composer.json');
+        IO\write_error_line('');
+        IO\write_error_line('Examples:');
+        IO\write_error_line('  psl detect-packages src/');
+        IO\write_error_line('  psl detect-packages src/ --dev tests/');
+        IO\write_error_line('  psl detect-packages src/ --dev tests/ --composer');
         exit(1);
     }
 
-    if (!Filesystem\is_directory($path)) {
-        IO\write_error_line('Error: "%s" is not a directory.', $path);
-        exit(1);
+    foreach (Vec\concat($srcPaths, $devPaths) as $path) {
+        if (!Filesystem\is_directory($path)) {
+            IO\write_error_line('Error: "%s" is not a directory.', $path);
+            exit(1);
+        }
     }
 
     $nsToDir = package_namespace_map();
 
-    /** @var array<string, true> $used */
-    $used = [];
-
-    $scan = static function (string $directory) use ($nsToDir, &$used, &$scan): void {
+    /**
+     * @return array<string, true>
+     */
+    $scan = static function (string $directory) use ($nsToDir, &$scan): array {
+        /** @var array<string, true> $found */
+        $found = [];
         foreach (Filesystem\read_directory($directory) as $entry) {
             if (Filesystem\is_directory($entry)) {
-                $scan($entry);
+                $found = Dict\merge($found, $scan($entry));
                 continue;
             }
 
@@ -74,45 +107,82 @@ function detect_packages_command(array $arguments): never
             $content = File\read($entry);
             foreach ($nsToDir as $ns => $dir) {
                 if (Regex\matches($content, '/Psl\\\\' . $ns . '[\\\\\\s;,)]/')) {
-                    $used[$dir] = true;
+                    $found[$dir] = true;
                 }
             }
         }
+
+        return $found;
     };
 
-    $scan($path);
-
-    if ($used !== []) {
-        $used['foundation'] = true;
+    /** @var array<string, true> $requireDeps */
+    $requireDeps = [];
+    foreach ($srcPaths as $path) {
+        $requireDeps = Dict\merge($requireDeps, $scan($path));
     }
 
-    $slugs = Vec\sort(Vec\keys($used));
+    /** @var array<string, true> $devDeps */
+    $devDeps = [];
+    foreach ($devPaths as $path) {
+        $devDeps = Dict\merge($devDeps, $scan($path));
+    }
+
+    $requireDevDeps = Dict\diff_by_key($devDeps, $requireDeps);
+
+    if ($requireDeps !== [] || $requireDevDeps !== []) {
+        $requireDeps['foundation'] = true;
+    }
+
+    $requireSlugs = Vec\sort(Vec\keys($requireDeps));
+    $devSlugs = Vec\sort(Vec\keys($requireDevDeps));
 
     if ($composer) {
         $constraint = resolve_version_constraint();
 
         /** @var array<string, string> $require */
         $require = [];
-        foreach ($slugs as $slug) {
+        foreach ($requireSlugs as $slug) {
             $require['php-standard-library/' . $slug] = $constraint;
         }
 
-        IO\write_line(Json\encode($require, pretty: true));
+        /** @var array<string, string> $requireDev */
+        $requireDev = [];
+        foreach ($devSlugs as $slug) {
+            $requireDev['php-standard-library/' . $slug] = $constraint;
+        }
+
+        /** @var array<string, array<string, string>> $output */
+        $output = ['require' => $require];
+        if ($devSlugs !== []) {
+            $output['require-dev'] = $requireDev;
+        }
+
+        IO\write_line(Json\encode($output, pretty: true));
         exit(0);
     }
 
-    if ($slugs === []) {
-        IO\write_line('No PSL packages detected in %s.', $path);
+    if ($requireSlugs === [] && $devSlugs === []) {
+        IO\write_line('No PSL packages detected.');
         exit(0);
     }
 
-    IO\write_line('Detected PSL packages used in %s:', $path);
+    IO\write_line('Detected PSL packages:');
     IO\write_line('');
-    foreach ($slugs as $slug) {
-        IO\write_line('  php-standard-library/%s', $slug);
+    IO\write_line('  require:');
+    foreach ($requireSlugs as $slug) {
+        IO\write_line('    php-standard-library/%s', $slug);
     }
+
+    if ($devSlugs !== []) {
+        IO\write_line('');
+        IO\write_line('  require-dev:');
+        foreach ($devSlugs as $slug) {
+            IO\write_line('    php-standard-library/%s', $slug);
+        }
+    }
+
     IO\write_line('');
-    IO\write_line('Run with --composer to get a JSON snippet for composer.json require.');
+    IO\write_line('Run with --composer to get a JSON snippet for composer.json.');
 
     exit(0);
 }
@@ -150,8 +220,13 @@ function help_command(): never
     IO\write_error_line('Usage: psl <command> [options]');
     IO\write_error_line('');
     IO\write_error_line('Commands:');
-    IO\write_error_line('  detect-packages <path> [--composer]  Detect PSL packages used in a directory');
-    IO\write_error_line('  help                                 Show this help');
+    IO\write_error_line('  detect-packages <path>... [--dev <path>...] [--composer]');
+    IO\write_error_line('    Detect PSL packages used in directories');
+    IO\write_error_line('    --src   Mark following paths as require dependencies (default)');
+    IO\write_error_line('    --dev   Mark following paths as require-dev dependencies');
+    IO\write_error_line('');
+    IO\write_error_line('  help');
+    IO\write_error_line('    Show this help');
     IO\write_error_line('');
 
     exit(1);

--- a/bin/psl
+++ b/bin/psl
@@ -1,0 +1,167 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Psl\File;
+use Psl\Filesystem;
+use Psl\IO;
+use Psl\Json;
+use Psl\Regex;
+use Psl\Str;
+use Psl\Type;
+use Psl\Vec;
+
+use function Psl\Internal\package_namespace_map;
+
+require (static function (): string {
+    if (isset($GLOBALS['_composer_autoload_path'])) {
+        return $GLOBALS['_composer_autoload_path'];
+    }
+
+    $path = __DIR__ . '/../vendor/autoload.php';
+    if (file_exists($path)) {
+        return $path;
+    }
+
+    fwrite(STDERR, "Could not find Composer autoloader.\n");
+    exit(1);
+})();
+
+/**
+ * @param list<string> $arguments
+ */
+function detect_packages_command(array $arguments): never
+{
+    $composer = false;
+    $path = null;
+
+    foreach ($arguments as $arg) {
+        if ($arg === '--composer') {
+            $composer = true;
+        } elseif (!Str\starts_with($arg, '-')) {
+            $path = $arg;
+        }
+    }
+
+    if ($path === null) {
+        IO\write_error_line('Usage: psl detect-packages <path> [--composer]');
+        exit(1);
+    }
+
+    if (!Filesystem\is_directory($path)) {
+        IO\write_error_line('Error: "%s" is not a directory.', $path);
+        exit(1);
+    }
+
+    $nsToDir = package_namespace_map();
+
+    /** @var array<string, true> $used */
+    $used = [];
+
+    $scan = static function (string $directory) use ($nsToDir, &$used, &$scan): void {
+        foreach (Filesystem\read_directory($directory) as $entry) {
+            if (Filesystem\is_directory($entry)) {
+                $scan($entry);
+                continue;
+            }
+
+            if (Filesystem\get_extension($entry) !== 'php') {
+                continue;
+            }
+
+            $content = File\read($entry);
+            foreach ($nsToDir as $ns => $dir) {
+                if (Regex\matches($content, '/Psl\\\\' . $ns . '[\\\\\\s;,)]/')) {
+                    $used[$dir] = true;
+                }
+            }
+        }
+    };
+
+    $scan($path);
+
+    if ($used !== []) {
+        $used['foundation'] = true;
+    }
+
+    $slugs = Vec\sort(Vec\keys($used));
+
+    if ($composer) {
+        $constraint = resolve_version_constraint();
+
+        /** @var array<string, string> $require */
+        $require = [];
+        foreach ($slugs as $slug) {
+            $require['php-standard-library/' . $slug] = $constraint;
+        }
+
+        IO\write_line(Json\encode($require, pretty: true));
+        exit(0);
+    }
+
+    if ($slugs === []) {
+        IO\write_line('No PSL packages detected in %s.', $path);
+        exit(0);
+    }
+
+    IO\write_line('Detected PSL packages used in %s:', $path);
+    IO\write_line('');
+    foreach ($slugs as $slug) {
+        IO\write_line('  php-standard-library/%s', $slug);
+    }
+    IO\write_line('');
+    IO\write_line('Run with --composer to get a JSON snippet for composer.json require.');
+
+    exit(0);
+}
+
+/**
+ * Resolve a version constraint from the installed PSL package version.
+ *
+ * Reads the monorepo's composer.json branch-alias to derive the major version.
+ */
+function resolve_version_constraint(): string
+{
+    $path = __DIR__ . '/../composer.json';
+    $composer = Json\typed(
+        File\read($path),
+        Type\shape([
+            'extra' => Type\nullish(Type\shape([
+                'branch-alias' => Type\nullish(Type\dict(Type\string(), Type\string())),
+            ])),
+        ]),
+    );
+
+    foreach ($composer['extra']['branch-alias'] ?? [] as $alias) {
+        $match = Regex\first_match($alias, '/^(\d+\.\d+)/');
+        if ($match !== null) {
+            return '^' . $match[1];
+        }
+    }
+
+    return '*';
+}
+
+function help_command(): never
+{
+    IO\write_error_line('');
+    IO\write_error_line('Usage: psl <command> [options]');
+    IO\write_error_line('');
+    IO\write_error_line('Commands:');
+    IO\write_error_line('  detect-packages <path> [--composer]  Detect PSL packages used in a directory');
+    IO\write_error_line('  help                                 Show this help');
+    IO\write_error_line('');
+
+    exit(1);
+}
+
+(static function (): never {
+    $arguments = Vec\slice($GLOBALS['argv'], 1);
+    $command = $arguments[0] ?? 'help';
+
+    match ($command) {
+        'detect-packages' => detect_packages_command(Vec\slice($arguments, 1)),
+        default => help_command(),
+    };
+})();

--- a/bin/psl
+++ b/bin/psl
@@ -3,6 +3,7 @@
 
 declare(strict_types=1);
 
+use Psl\Env;
 use Psl\File;
 use Psl\Filesystem;
 use Psl\IO;
@@ -157,7 +158,7 @@ function help_command(): never
 }
 
 (static function (): never {
-    $arguments = Vec\slice($GLOBALS['argv'], 1);
+    $arguments = Vec\slice(Env\args(), 1);
     $command = $arguments[0] ?? 'help';
 
     match ($command) {

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
             "email": "azjezz@protonmail.com"
         }
     ],
+    "bin": [
+        "bin/psl"
+    ],
     "require": {
         "php": "~8.4.0 || ~8.5.0",
         "ext-bcmath": "*",

--- a/docs/content/tools/detect-packages.md
+++ b/docs/content/tools/detect-packages.md
@@ -1,0 +1,97 @@
+# Detect Packages
+
+The `detect-packages` command scans PHP source directories for PSL namespace usage and reports which `php-standard-library/*` standalone packages are needed. This helps migrate from the monorepo to individual packages.
+
+This tool is only available when using the monorepo (`php-standard-library/php-standard-library`).
+
+## Usage
+
+```bash
+vendor/bin/psl detect-packages <path>... [--dev <path>...] [--composer]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--src` | Mark following paths as `require` dependencies (default) |
+| `--dev` | Mark following paths as `require-dev` dependencies |
+| `--composer` | Output a JSON snippet for `composer.json` |
+
+## Examples
+
+### Basic scan
+
+Scan a single source directory:
+
+```bash
+vendor/bin/psl detect-packages src/
+```
+
+```
+Detected PSL packages:
+
+  require:
+    php-standard-library/dict
+    php-standard-library/foundation
+    php-standard-library/str
+    php-standard-library/vec
+```
+
+### Separating require and require-dev
+
+Scan source and test directories separately. Packages found in both are placed in `require` only:
+
+```bash
+vendor/bin/psl detect-packages src/ --dev tests/
+```
+
+```
+Detected PSL packages:
+
+  require:
+    php-standard-library/dict
+    php-standard-library/foundation
+    php-standard-library/str
+    php-standard-library/vec
+
+  require-dev:
+    php-standard-library/filesystem
+    php-standard-library/os
+```
+
+### JSON output for composer.json
+
+Use `--composer` to get output you can paste directly into your `composer.json`:
+
+```bash
+vendor/bin/psl detect-packages src/ --dev tests/ --composer
+```
+
+```json
+{
+    "require": {
+        "php-standard-library/dict": "^6.1",
+        "php-standard-library/str": "^6.1",
+        "php-standard-library/vec": "^6.1"
+    },
+    "require-dev": {
+        "php-standard-library/filesystem": "^6.1",
+        "php-standard-library/os": "^6.1"
+    }
+}
+```
+
+### Multiple source paths
+
+You can pass multiple directories. Bare paths default to `require`:
+
+```bash
+vendor/bin/psl detect-packages src/ lib/ --dev tests/
+```
+
+## How it works
+
+The tool scans all `.php` files in the given directories and matches `Psl\<Namespace>` references using regex. Each namespace is mapped to its corresponding standalone package. The `foundation` package is always included when any PSL usage is detected, since all PSL packages depend on it.
+
+Transitive dependencies are not resolved — only direct usage in your code is reported. Composer handles transitive dependencies automatically when you install the standalone packages.

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -127,6 +127,7 @@ const CATEGORY_DISPLAY_NAMES = [
     'security' => 'Security',
     'system' => 'System',
     'other' => 'Other',
+    'tools' => 'Tools',
 ];
 
 /**

--- a/packages/foundation/src/Psl/Internal/package_namespace_map.php
+++ b/packages/foundation/src/Psl/Internal/package_namespace_map.php
@@ -10,6 +10,8 @@ namespace Psl\Internal;
  * Used by the splitter's verify command and by `bin/psl detect-packages`.
  *
  * @return array<non-empty-string, non-empty-string>
+ *
+ * @mago-expect lint:no-literal-password - Not really a password.
  */
 function package_namespace_map(): array
 {

--- a/packages/foundation/src/Psl/Internal/package_namespace_map.php
+++ b/packages/foundation/src/Psl/Internal/package_namespace_map.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Internal;
+
+/**
+ * Returns the canonical mapping of PSL namespace names to package directory slugs.
+ *
+ * Used by the splitter's verify command and by `bin/psl detect-packages`.
+ *
+ * @return array<non-empty-string, non-empty-string>
+ */
+function package_namespace_map(): array
+{
+    return [
+        'Ansi' => 'ansi',
+        'Async' => 'async',
+        'Binary' => 'binary',
+        'Cache' => 'cache',
+        'Channel' => 'channel',
+        'CIDR' => 'cidr',
+        'Class' => 'class',
+        'Collection' => 'collection',
+        'Comparison' => 'comparison',
+        'Compression' => 'compression',
+        'Crypto' => 'crypto',
+        'DataStructure' => 'data-structure',
+        'DNS' => 'dns',
+        'DNSSEC' => 'dnssec',
+        'DateTime' => 'date-time',
+        'Default' => 'default',
+        'Dict' => 'dict',
+        'Either' => 'either',
+        'Encoding' => 'encoding',
+        'Env' => 'env',
+        'File' => 'file',
+        'Filesystem' => 'filesystem',
+        'Fun' => 'fun',
+        'Graph' => 'graph',
+        'H2' => 'h2',
+        'Hash' => 'hash',
+        'HPACK' => 'hpack',
+        'HTTP\\Client' => 'http-client',
+        'HTTP\\Message' => 'http-message',
+        'Html' => 'html',
+        'Interface' => 'interface',
+        'Interoperability' => 'interoperability',
+        'IO' => 'io',
+        'IP' => 'ip',
+        'IRI' => 'iri',
+        'Iter' => 'iter',
+        'Json' => 'json',
+        'Locale' => 'locale',
+        'MIME' => 'mime',
+        'Message' => 'message',
+        'Math' => 'math',
+        'Network' => 'network',
+        'Observer' => 'observer',
+        'Option' => 'option',
+        'OS' => 'os',
+        'Password' => 'password',
+        'Process' => 'process',
+        'Promise' => 'promise',
+        'PseudoRandom' => 'pseudo-random',
+        'Punycode' => 'punycode',
+        'RandomSequence' => 'random-sequence',
+        'Range' => 'range',
+        'Regex' => 'regex',
+        'Result' => 'result',
+        'Runtime' => 'runtime',
+        'SecureRandom' => 'secure-random',
+        'SMTP' => 'smtp',
+        'Shell' => 'shell',
+        'Socks' => 'socks',
+        'Str' => 'str',
+        'TCP' => 'tcp',
+        'Terminal' => 'terminal',
+        'TLS' => 'tls',
+        'Trait' => 'trait',
+        'Tree' => 'tree',
+        'Type' => 'type',
+        'UDP' => 'udp',
+        'Unix' => 'unix',
+        'URI' => 'uri',
+        'URL' => 'url',
+        'Vec' => 'vec',
+        'Exception' => 'foundation',
+        'Ref' => 'foundation',
+    ];
+}

--- a/packages/foundation/src/Psl/bootstrap.php
+++ b/packages/foundation/src/Psl/bootstrap.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 (static function (): void {
     $functions = [
+        'Psl\Internal\package_namespace_map' => __DIR__ . '/Internal/package_namespace_map.php',
         'Psl\invariant' => __DIR__ . '/invariant.php',
         'Psl\invariant_violation' => __DIR__ . '/invariant_violation.php',
     ];

--- a/splitter/src/Psl/Splitter/verify.php
+++ b/splitter/src/Psl/Splitter/verify.php
@@ -24,7 +24,6 @@ use function Psl\Internal\package_namespace_map;
  *
  * @param list<Package> $packages
  *
- * @mago-expect lint:no-literal-password - Not really a password.
  * @mago-expect lint:excessive-nesting - :(
  */
 function verify(array $packages): bool

--- a/splitter/src/Psl/Splitter/verify.php
+++ b/splitter/src/Psl/Splitter/verify.php
@@ -14,6 +14,8 @@ use Psl\Str;
 use Psl\Type;
 use Psl\Vec;
 
+use function Psl\Internal\package_namespace_map;
+
 /**
  * Verify that every package's composer.json `require` section matches actual source imports,
  * and that no source dependency is incorrectly placed in `require-dev`.
@@ -27,81 +29,7 @@ use Psl\Vec;
  */
 function verify(array $packages): bool
 {
-    $nsToDir = [
-        'Ansi' => 'ansi',
-        'Async' => 'async',
-        'Binary' => 'binary',
-        'Cache' => 'cache',
-        'Channel' => 'channel',
-        'CIDR' => 'cidr',
-        'Class' => 'class',
-        'Collection' => 'collection',
-        'Comparison' => 'comparison',
-        'Compression' => 'compression',
-        'Crypto' => 'crypto',
-        'DataStructure' => 'data-structure',
-        'DNS' => 'dns',
-        'DNSSEC' => 'dnssec',
-        'DateTime' => 'date-time',
-        'Default' => 'default',
-        'Dict' => 'dict',
-        'Either' => 'either',
-        'Encoding' => 'encoding',
-        'Env' => 'env',
-        'File' => 'file',
-        'Filesystem' => 'filesystem',
-        'Fun' => 'fun',
-        'Graph' => 'graph',
-        'H2' => 'h2',
-        'Hash' => 'hash',
-        'HPACK' => 'hpack',
-        'HTTP\\Client' => 'http-client',
-        'HTTP\\Message' => 'http-message',
-        'Html' => 'html',
-        'Interface' => 'interface',
-        'Interoperability' => 'interoperability',
-        'IO' => 'io',
-        'IP' => 'ip',
-        'IRI' => 'iri',
-        'Iter' => 'iter',
-        'Json' => 'json',
-        'Locale' => 'locale',
-        'MIME' => 'mime',
-        'Message' => 'message',
-        'Math' => 'math',
-        'Network' => 'network',
-        'Observer' => 'observer',
-        'Option' => 'option',
-        'OS' => 'os',
-        'Password' => 'password',
-        'Process' => 'process',
-        'Promise' => 'promise',
-        'PseudoRandom' => 'pseudo-random',
-        'Punycode' => 'punycode',
-        'RandomSequence' => 'random-sequence',
-        'Range' => 'range',
-        'Regex' => 'regex',
-        'Result' => 'result',
-        'Runtime' => 'runtime',
-        'SecureRandom' => 'secure-random',
-        'SMTP' => 'smtp',
-        'Shell' => 'shell',
-        'Socks' => 'socks',
-        'Str' => 'str',
-        'TCP' => 'tcp',
-        'Terminal' => 'terminal',
-        'TLS' => 'tls',
-        'Trait' => 'trait',
-        'Tree' => 'tree',
-        'Type' => 'type',
-        'UDP' => 'udp',
-        'Unix' => 'unix',
-        'URI' => 'uri',
-        'URL' => 'url',
-        'Vec' => 'vec',
-        'Exception' => 'foundation',
-        'Ref' => 'foundation',
-    ];
+    $nsToDir = package_namespace_map();
 
     $ok = true;
 


### PR DESCRIPTION
## Summary

- Adds a `bin/psl` CLI tool shipped with the monorepo, with a `detect-packages` command that scans PHP source directories and reports which `php-standard-library/*` standalone packages are used.
- Supports `--dev` flag to separate `require` from `require-dev` dependencies — packages found in both are placed in `require` only.
- Supports `--composer` flag to output a JSON snippet ready to paste into `composer.json`, with version constraints derived from the installed package's branch alias.
- Centralizes the namespace-to-package map (previously inlined in the splitter's `verify.php`) into `Psl\Internal\package_namespace_map()` so both the splitter and the new binary share a single source of truth.

### Why this lives in the monorepo

This tool exists to help users **migrate away from the monorepo** (`php-standard-library/php-standard-library`) to individual standalone packages. It needs access to the full namespace-to-package map and uses several PSL packages internally (`File`, `Filesystem`, `Regex`, `Json`, `IO`, `Str`, `Vec`, `Type`). Placing it in `foundation` would force foundation to depend on all of those packages, bloating a package that currently only requires PHP itself. Since the tool's purpose is to facilitate the mono → packages transition, it naturally belongs in the monorepo — once users have migrated, they no longer need it.

### Usage

```bash
# Scan source directories
vendor/bin/psl detect-packages src/

# Separate require and require-dev
vendor/bin/psl detect-packages src/ --dev tests/

# Output JSON for composer.json
vendor/bin/psl detect-packages src/ --dev tests/ --composer
```

**Human-readable output:**

```
Detected PSL packages:

  require:
    php-standard-library/dict
    php-standard-library/file
    php-standard-library/foundation
    php-standard-library/fun
    php-standard-library/iter
    php-standard-library/math
    php-standard-library/regex
    php-standard-library/result
    php-standard-library/str
    php-standard-library/type
    php-standard-library/vec

  require-dev:
    php-standard-library/collection
    php-standard-library/filesystem
    php-standard-library/os

Run with --composer to get a JSON snippet for composer.json.
```

**JSON output (`--composer`):**

```json
{
    "require": {
        "php-standard-library/dict": "^6.1",
        "php-standard-library/file": "^6.1",
        "php-standard-library/foundation": "^6.1",
        "php-standard-library/fun": "^6.1",
        "php-standard-library/iter": "^6.1",
        "php-standard-library/math": "^6.1",
        "php-standard-library/regex": "^6.1",
        "php-standard-library/result": "^6.1",
        "php-standard-library/str": "^6.1",
        "php-standard-library/type": "^6.1",
        "php-standard-library/vec": "^6.1"
    },
    "require-dev": {
        "php-standard-library/collection": "^6.1",
        "php-standard-library/filesystem": "^6.1",
        "php-standard-library/os": "^6.1"
    }
}
```