### PR TITLE
fix(http-client): address multiple bugs

### DIFF
--- a/packages/http-client/src/Psl/HTTP/Client/Client.php
+++ b/packages/http-client/src/Psl/HTTP/Client/Client.php
@@ -102,6 +102,11 @@ final class Client implements ClientInterface
         SendConfiguration $configuration = new SendConfiguration(),
         CancellationTokenInterface $cancellation = new NullCancellationToken(),
     ): Transaction {
+        if ($request->body !== null && ($request->method === 'HEAD' || $request->method === 'TRACE')) {
+            throw Exception\RequestException::forInvalidRequest($request->method
+            . ' requests must not include a body.');
+        }
+
         $configuration = $this->configuration->withOverrides($configuration);
 
         $url = $this->resolveUrl($request, $configuration);

--- a/packages/http-client/src/Psl/HTTP/Client/Connection/PooledConnector.php
+++ b/packages/http-client/src/Psl/HTTP/Client/Connection/PooledConnector.php
@@ -29,6 +29,7 @@ use Psl\Unix;
 use Throwable;
 
 use function array_key_exists;
+use function array_key_first;
 use function array_pop;
 use function array_shift;
 use function count;
@@ -96,18 +97,33 @@ use function Psl\HTTP\Client\Internal\should_tunnel;
  * @link https://datatracker.ietf.org/doc/html/rfc7301 TLS ALPN Extension
  *
  * @api
+ *
+ * @mago-expect lint:kan-defect
+ * @mago-expect lint:cyclomatic-complexity
  */
 final class PooledConnector implements ConnectorInterface
 {
     private TCP\ConnectorInterface $tcpConnector;
 
     /**
-     * Maximum number of idle HTTP/1.x connections retained per origin.
-     *
-     * When the idle pool for an origin reaches this limit, the oldest idle
-     * connections are evicted (closed) to make room for newly released ones.
+     * Default maximum total idle HTTP/1.x connections across all origins.
      */
-    private const int MAX_IDLE_CONNECTIONS = 32;
+    private const int DEFAULT_MAX_IDLE_CONNECTIONS = 256;
+
+    /**
+     * Default maximum idle HTTP/1.x connections retained per origin.
+     */
+    private const int DEFAULT_MAX_IDLE_CONNECTIONS_PER_HOST = 32;
+
+    /**
+     * Maximum total idle HTTP/1.x connections across all origins.
+     */
+    private int $maxIdleConnections;
+
+    /**
+     * Maximum idle HTTP/1.x connections per origin.
+     */
+    private int $maxIdleConnectionsPerHost;
 
     /**
      * Idle HTTP/1.x streams available for reuse, keyed by origin string.
@@ -140,9 +156,39 @@ final class PooledConnector implements ConnectorInterface
      */
     private array $pendingConnections = [];
 
-    public function __construct(null|TCP\ConnectorInterface $tcpConnector = null)
-    {
+    /**
+     * @param null|TCP\ConnectorInterface $tcpConnector TCP connector; a default is created if null.
+     * @param int $maxIdleConnections Maximum total idle H1 connections across all origins.
+     * @param int $maxIdleConnectionsPerHost Maximum idle H1 connections per origin.
+     */
+    public function __construct(
+        null|TCP\ConnectorInterface $tcpConnector = null,
+        int $maxIdleConnections = self::DEFAULT_MAX_IDLE_CONNECTIONS,
+        int $maxIdleConnectionsPerHost = self::DEFAULT_MAX_IDLE_CONNECTIONS_PER_HOST,
+    ) {
         $this->tcpConnector = $tcpConnector ?? new TCP\Connector(new TCP\ConnectConfiguration(noDelay: true));
+        $this->maxIdleConnections = $maxIdleConnections;
+        $this->maxIdleConnectionsPerHost = $maxIdleConnectionsPerHost;
+    }
+
+    /**
+     * Close all idle connections and shut down H2 sessions.
+     */
+    public function __destruct()
+    {
+        foreach ($this->h1Idle as $streams) {
+            foreach ($streams as $stream) {
+                $stream->close();
+            }
+        }
+
+        $this->h1Idle = [];
+
+        foreach ($this->h2Sessions as [$session]) {
+            $session->markClosed();
+        }
+
+        $this->h2Sessions = [];
     }
 
     /**
@@ -198,6 +244,8 @@ final class PooledConnector implements ConnectorInterface
 
         $origin = Origin::fromUrl($url);
         $key = $origin->toString();
+
+        $this->pruneClosedH2Sessions();
 
         if (array_key_exists($key, $this->h2Sessions)) {
             [$session, $local, $peer, $tls] = $this->h2Sessions[$key];
@@ -424,9 +472,35 @@ final class PooledConnector implements ConnectorInterface
         $peer = $stream->getPeerAddress();
         $tls = $stream instanceof TLS\StreamInterface ? $stream->getState() : null;
 
+        $this->pruneClosedH2Sessions();
+        while (count($this->h2Sessions) >= $this->maxIdleConnections) {
+            $oldestKey = array_key_first($this->h2Sessions);
+            if ($oldestKey === null) {
+                break;
+            }
+
+            [$oldSession] = $this->h2Sessions[$oldestKey];
+            $oldSession->markClosed();
+            unset($this->h2Sessions[$oldestKey]);
+        }
+
         $this->h2Sessions[$key] = [$session, $local, $peer, $tls];
 
         return new H2Connection($session, $local, $peer, $tls, $this->h2Reconnect(...));
+    }
+
+    /**
+     * Remove all closed H2 sessions from the pool.
+     */
+    private function pruneClosedH2Sessions(): void
+    {
+        foreach ($this->h2Sessions as $key => [$session]) {
+            if (!$session->isClosed()) {
+                continue;
+            }
+
+            unset($this->h2Sessions[$key]);
+        }
     }
 
     /**
@@ -460,15 +534,52 @@ final class PooledConnector implements ConnectorInterface
                 return;
             }
 
-            // Evict oldest idle connections when over the cap.
             $this->h1Idle[$key] ??= [];
-            while (count($this->h1Idle[$key]) >= self::MAX_IDLE_CONNECTIONS) {
+            while (count($this->h1Idle[$key]) >= $this->maxIdleConnectionsPerHost) {
                 $evicted = array_shift($this->h1Idle[$key]);
                 $evicted?->close();
             }
 
             $this->h1Idle[$key][] = $stream;
+
+            $this->evictExcessIdleConnections();
         };
+    }
+
+    /**
+     * Evict the oldest idle H1 connections globally until the total is within
+     * {@see $maxIdleConnections}. Iterates origins in insertion order and
+     * removes the oldest (first) connection from each until under the limit.
+     */
+    private function evictExcessIdleConnections(): void
+    {
+        $total = 0;
+        foreach ($this->h1Idle as $streams) {
+            $total += count($streams);
+        }
+
+        while ($total > $this->maxIdleConnections) {
+            foreach ($this->h1Idle as $originKey => $streams) {
+                if ($streams === []) {
+                    unset($this->h1Idle[$originKey]);
+                    continue;
+                }
+
+                $evicted = array_shift($this->h1Idle[$originKey]);
+                $evicted?->close();
+
+                if ($this->h1Idle[$originKey] === []) {
+                    unset($this->h1Idle[$originKey]);
+                }
+
+                $total--;
+                break;
+            }
+
+            if ($this->h1Idle === []) {
+                break;
+            }
+        }
     }
 
     /**
@@ -487,9 +598,17 @@ final class PooledConnector implements ConnectorInterface
                 unset($this->h1Idle[$key]);
             }
 
-            if (!$stream->isClosed()) {
-                return $stream;
+            if ($stream->isClosed()) {
+                continue;
             }
+
+            $probe = $stream->tryRead(1);
+            if ($probe !== '' || $stream->reachedEndOfDataSource()) {
+                $stream->close();
+                continue;
+            }
+
+            return $stream;
         }
 
         return null;

--- a/packages/http-client/src/Psl/HTTP/Client/Internal/H2/H2Multiplexer.php
+++ b/packages/http-client/src/Psl/HTTP/Client/Internal/H2/H2Multiplexer.php
@@ -67,6 +67,7 @@ final class H2Multiplexer
         unset($this->streams[$streamId]);
 
         if ($this->streams === [] && $this->fiberRunning) {
+            $this->fiberRunning = false;
             $this->fiberCancellation->cancel();
             $this->fiberCancellation = new SignalCancellationToken();
         }

--- a/packages/http-client/src/Psl/HTTP/Client/Internal/H2/ResponseBodyHandle.php
+++ b/packages/http-client/src/Psl/HTTP/Client/Internal/H2/ResponseBodyHandle.php
@@ -23,7 +23,7 @@ use function strlen;
  *
  * @internal
  */
-final class ResponseBodyHandle implements IO\ReadHandleInterface
+final class ResponseBodyHandle implements IO\ReadHandleInterface, IO\CloseHandleInterface
 {
     use IO\ReadHandleConvenienceMethodsTrait;
 
@@ -34,7 +34,7 @@ final class ResponseBodyHandle implements IO\ReadHandleInterface
     /** @var non-negative-int */
     private int $bytesReceived = 0;
 
-    private bool $unregistered = false;
+    private bool $closed = false;
 
     /**
      * @param positive-int $streamId
@@ -48,10 +48,7 @@ final class ResponseBodyHandle implements IO\ReadHandleInterface
 
     public function __destruct()
     {
-        if (!$this->unregistered) {
-            $this->unregistered = true;
-            $this->multiplexer->unregister($this->streamId);
-        }
+        $this->close();
     }
 
     public function getTrailers(): null|FieldMap
@@ -97,7 +94,7 @@ final class ResponseBodyHandle implements IO\ReadHandleInterface
         }
 
         if ($this->stream->isBodyComplete()) {
-            $this->markDone();
+            $this->close();
         }
 
         return $data;
@@ -110,10 +107,15 @@ final class ResponseBodyHandle implements IO\ReadHandleInterface
         return $this->stream->isBodyComplete();
     }
 
-    private function markDone(): void
+    public function isClosed(): bool
     {
-        if (!$this->unregistered) {
-            $this->unregistered = true;
+        return $this->closed;
+    }
+
+    public function close(): void
+    {
+        if (!$this->closed) {
+            $this->closed = true;
             $this->multiplexer->unregister($this->streamId);
         }
     }
@@ -125,7 +127,7 @@ final class ResponseBodyHandle implements IO\ReadHandleInterface
             'H2 stream error: ' . $cause->getMessage(),
             previous: $cause,
         );
-        $this->markDone();
+        $this->close();
     }
 
     /**

--- a/packages/http-client/src/Psl/HTTP/Client/Internal/LimitedReadHandle.php
+++ b/packages/http-client/src/Psl/HTTP/Client/Internal/LimitedReadHandle.php
@@ -33,7 +33,7 @@ use function strlen;
  * @see ResponseReader::buildBody() Wraps body handles when a max size is configured.
  * @see ResponseBodyHandle Uses its own size enforcement for H2.
  */
-final class LimitedReadHandle implements IO\ReadHandleInterface
+final class LimitedReadHandle implements IO\ReadHandleInterface, IO\CloseHandleInterface
 {
     use IO\ReadHandleConvenienceMethodsTrait;
 
@@ -41,6 +41,8 @@ final class LimitedReadHandle implements IO\ReadHandleInterface
     private int $bytesRead = 0;
 
     private bool $limitReached = false;
+
+    private bool $closed = false;
 
     /**
      * @param IO\ReadHandleInterface $inner The inner body handle to read from.
@@ -50,6 +52,11 @@ final class LimitedReadHandle implements IO\ReadHandleInterface
         private readonly IO\ReadHandleInterface $inner,
         private readonly int $limit,
     ) {}
+
+    public function __destruct()
+    {
+        $this->close();
+    }
 
     /**
      * @throws Exception\RuntimeException If an error occurred during the operation.
@@ -105,6 +112,22 @@ final class LimitedReadHandle implements IO\ReadHandleInterface
         }
 
         return $this->inner->reachedEndOfDataSource();
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->closed;
+    }
+
+    public function close(): void
+    {
+        if (!$this->closed) {
+            $this->closed = true;
+
+            if ($this->inner instanceof IO\CloseHandleInterface) {
+                $this->inner->close();
+            }
+        }
     }
 
     /**

--- a/packages/http-client/src/Psl/HTTP/Client/Internal/PoolReleasingBodyHandle.php
+++ b/packages/http-client/src/Psl/HTTP/Client/Internal/PoolReleasingBodyHandle.php
@@ -11,32 +11,37 @@ use Psl\IO;
 
 /**
  * Decorating body handle that releases an HTTP/1.x connection back to the pool
- * when the response body is fully consumed.
+ * when the response body is fully consumed or the handle is closed.
  *
  * This prevents premature connection reuse: the underlying TCP/TLS stream stays
  * checked out of the pool until the consumer has read the entire response body.
  * The release callback is invoked exactly once, either when {@see read()},
  * {@see tryRead()}, or {@see reachedEndOfDataSource()} detects that the inner
- * handle has reached EOF.
+ * handle has reached EOF, or when {@see close()} is called explicitly (or via GC).
  *
  * @internal
  *
  * @see H1\H1Connection Creates this wrapper when keep-alive and pool release are both active.
  */
-final class PoolReleasingBodyHandle implements IO\ReadHandleInterface
+final class PoolReleasingBodyHandle implements IO\ReadHandleInterface, IO\CloseHandleInterface
 {
     use IO\ReadHandleConvenienceMethodsTrait;
 
-    private bool $released = false;
+    private bool $closed = false;
 
     /**
      * @param IO\ReadHandleInterface $inner The inner body handle to read from.
-     * @param Closure(): void $onComplete Called exactly once when the body is fully consumed.
+     * @param Closure(): void $onComplete Called exactly once when the body is fully consumed or the handle is closed.
      */
     public function __construct(
         private readonly IO\ReadHandleInterface $inner,
         private readonly Closure $onComplete,
     ) {}
+
+    public function __destruct()
+    {
+        $this->close();
+    }
 
     /**
      * Return available data from the inner handle without blocking.
@@ -47,8 +52,12 @@ final class PoolReleasingBodyHandle implements IO\ReadHandleInterface
      */
     public function tryRead(null|int $maxBytes = null): string
     {
+        if ($this->closed) {
+            return '';
+        }
+
         $data = $this->inner->tryRead($maxBytes);
-        $this->releaseIfDone();
+        $this->closeIfDone();
 
         return $data;
     }
@@ -62,8 +71,12 @@ final class PoolReleasingBodyHandle implements IO\ReadHandleInterface
         null|int $maxBytes = null,
         CancellationTokenInterface $cancellation = new NullCancellationToken(),
     ): string {
+        if ($this->closed) {
+            return '';
+        }
+
         $data = $this->inner->read($maxBytes, $cancellation);
-        $this->releaseIfDone();
+        $this->closeIfDone();
 
         return $data;
     }
@@ -75,32 +88,43 @@ final class PoolReleasingBodyHandle implements IO\ReadHandleInterface
      */
     public function reachedEndOfDataSource(): bool
     {
+        if ($this->closed) {
+            return true;
+        }
+
         $eof = $this->inner->reachedEndOfDataSource();
         if ($eof) {
-            $this->release();
+            $this->close();
         }
 
         return $eof;
     }
 
-    /**
-     * Check if the inner handle has reached EOF and release if so.
-     */
-    private function releaseIfDone(): void
+    public function isClosed(): bool
     {
-        if ($this->inner->reachedEndOfDataSource()) {
-            $this->release();
+        return $this->closed;
+    }
+
+    public function close(): void
+    {
+        if (!$this->closed) {
+            $this->closed = true;
+
+            if ($this->inner instanceof IO\CloseHandleInterface) {
+                $this->inner->close();
+            }
+
+            ($this->onComplete)();
         }
     }
 
     /**
-     * Invoke the release callback exactly once.
+     * Check if the inner handle has reached EOF and close if so.
      */
-    private function release(): void
+    private function closeIfDone(): void
     {
-        if (!$this->released) {
-            $this->released = true;
-            ($this->onComplete)();
+        if ($this->inner->reachedEndOfDataSource()) {
+            $this->close();
         }
     }
 }

--- a/packages/http-client/src/Psl/HTTP/Client/Internal/resolve_url.php
+++ b/packages/http-client/src/Psl/HTTP/Client/Internal/resolve_url.php
@@ -14,8 +14,9 @@ use function substr;
 /**
  * Resolve a URI reference against a base URL per RFC 3986 Section 5.2.2.
  *
- * Handles three forms of URI reference:
+ * Handles four forms of URI reference:
  * - Absolute URI (contains "://"): parsed independently, base URL ignored.
+ * - Protocol-relative (starts with "//"): inherits scheme from base URL, new authority and path.
  * - Absolute path (starts with "/"): path is resolved with dot-segment removal.
  * - Relative path (e.g., "path", "../path"): merged with the base path then
  *   dot-segments are removed.
@@ -41,6 +42,11 @@ function resolve_url(string $reference, URL\URL $baseUrl): URL\URL
 {
     if (str_contains($reference, '://')) {
         return URL\parse($reference);
+    }
+
+    // Protocol-relative reference (//authority/path): inherit scheme from base URL.
+    if (str_starts_with($reference, '//')) {
+        return URL\parse($baseUrl->scheme . ':' . $reference);
     }
 
     $fragment = null;

--- a/packages/http-client/src/Psl/HTTP/Client/RetryClient.php
+++ b/packages/http-client/src/Psl/HTTP/Client/RetryClient.php
@@ -57,6 +57,20 @@ use Psl\Network;
  * 1 initial request + 2 retries. If all attempts fail, the exception from the last
  * attempt is propagated.
  *
+ * ## Request body handling
+ *
+ * When a request has a body, retry behavior depends on whether the body is seekable:
+ *
+ * - **Seekable body** ({@see IO\SeekHandleInterface}): the body position is recorded
+ *   before the first attempt via {@see IO\SeekHandleInterface::tell()}, and rewound
+ *   via {@see IO\SeekHandleInterface::seek()} before each retry. This covers
+ *   {@see IO\MemoryHandle}, file handles, and any other seekable stream.
+ * - **Non-seekable body**: the request is NOT retried, even for idempotent methods.
+ *   The body may have been partially or fully consumed by the first attempt, so
+ *   retrying would send an incomplete or empty body. The exception from the first
+ *   attempt propagates immediately.
+ * - **No body** ({@see null}): retries proceed normally (nothing to rewind).
+ *
  * @link https://datatracker.ietf.org/doc/html/rfc9110#section-9.2.2 Idempotent Methods
  *
  * @api
@@ -111,6 +125,10 @@ final readonly class RetryClient implements ClientInterface
         CancellationTokenInterface $cancellation = new NullCancellationToken(),
     ): Transaction {
         $attempt = 0;
+        $body = $request->body;
+        $hasBody = $body !== null;
+        $seekable = $body instanceof IO\SeekHandleInterface;
+        $bodyOffset = $seekable ? $body->tell() : 0;
 
         while (true) {
             $attempt++;
@@ -124,6 +142,15 @@ final readonly class RetryClient implements ClientInterface
 
                 if (!(self::IDEMPOTENT_METHODS[$request->method] ?? false)) {
                     throw $e;
+                }
+
+                if ($hasBody && !$seekable) {
+                    throw $e;
+                }
+
+                if ($seekable) {
+                    /** @var IO\SeekHandleInterface $body */
+                    $body->seek($bodyOffset);
                 }
 
                 $delayMs = (int) (

--- a/packages/http-client/tests/unit/ClientTest.php
+++ b/packages/http-client/tests/unit/ClientTest.php
@@ -20,6 +20,7 @@ use Psl\HTTP\Message\ProtocolVersion;
 use Psl\HTTP\Message\Request;
 use Psl\HTTP\Message\Response;
 use Psl\HTTP\Message\Transaction;
+use Psl\IO;
 use Psl\Network;
 use Psl\Network\Exception\RuntimeException;
 use Psl\TLS\ConnectionState;
@@ -275,6 +276,51 @@ final class ClientTest extends TestCase
         static::assertArrayHasKey('request', (array) $capture);
         $request = $capture['request'];
         static::assertSame(['my-custom-agent'], $request->headers->getAll('user-agent'));
+    }
+
+    public function testHeadRequestWithBodyThrows(): void
+    {
+        $client = new Client(
+            connector: $this->createStub(ConnectorInterface::class),
+            configuration: new ClientConfiguration(),
+        );
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('HEAD requests must not include a body.');
+
+        $client->send(new Request(
+            method: 'HEAD',
+            url: parse('http://example.com/'),
+            body: new IO\MemoryHandle('data'),
+        ));
+    }
+
+    public function testTraceRequestWithBodyThrows(): void
+    {
+        $client = new Client(
+            connector: $this->createStub(ConnectorInterface::class),
+            configuration: new ClientConfiguration(),
+        );
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('TRACE requests must not include a body.');
+
+        $client->send(new Request(
+            method: 'TRACE',
+            url: parse('http://example.com/'),
+            body: new IO\MemoryHandle('data'),
+        ));
+    }
+
+    public function testHeadRequestWithoutBodySucceeds(): void
+    {
+        $capture = new ArrayObject();
+        $connector = $this->createCapturingConnector($capture);
+
+        $client = new Client(connector: $connector, configuration: new ClientConfiguration());
+        $tx = $client->send(new Request(method: 'HEAD', url: parse('http://example.com/')));
+
+        static::assertSame(200, $tx->response->status);
     }
 
     private function createCapturingConnector(ArrayObject $capture): ConnectorInterface

--- a/packages/http-client/tests/unit/Connection/PooledConnectorH1Test.php
+++ b/packages/http-client/tests/unit/Connection/PooledConnectorH1Test.php
@@ -11,9 +11,11 @@ use Psl\DateTime\Duration;
 use Psl\HTTP\Client\Client;
 use Psl\HTTP\Client\ClientConfiguration;
 use Psl\HTTP\Client\Connection\PooledConnector;
+use Psl\HTTP\Client\Exception\ProtocolException;
 use Psl\HTTP\Message\ProtocolVersion;
 use Psl\HTTP\Message\Request;
 use Psl\IO;
+use Psl\IO\Exception\RuntimeException;
 use Psl\Network;
 use Psl\TCP;
 
@@ -262,12 +264,12 @@ final class PooledConnectorH1Test extends TestCase
         $threw = false;
         try {
             $client->send(new Request(method: 'GET', url: $url));
-        } catch (Network\Exception\RuntimeException) {
+        } catch (Network\Exception\RuntimeException|ProtocolException) {
             $threw = true;
-        } catch (\Psl\HTTP\Client\Exception\ProtocolException) {
+        } catch (RuntimeException) {
             $threw = true;
         }
 
-        static::assertTrue($threw, 'Expected either ProtocolException or Network\\RuntimeException');
+        static::assertTrue($threw, 'Expected a connection or protocol error');
     }
 }

--- a/packages/http-client/tests/unit/Internal/H2/TransportTest.php
+++ b/packages/http-client/tests/unit/Internal/H2/TransportTest.php
@@ -1239,4 +1239,212 @@ final class TransportTest extends TestCase
             }
         }
     }
+
+    public function testTimeoutOnHungServerDoesNotDeadlock(): void
+    {
+        $listener = TCP\listen('127.0.0.1', 0, new TCP\ListenConfiguration(noDelay: true));
+        $address = $listener->getLocalAddress();
+
+        $serverFuture = Async\run(static function () use ($listener): void {
+            try {
+                $conn = $listener->accept();
+                $server = new H2\ServerConnection($conn);
+                $server->readClientPreface();
+                $server->initialize();
+
+                while ($server->isConnected()) {
+                    try {
+                        $server->readEvent(new TimeoutCancellationToken(Duration::seconds(5)));
+                    } catch (CancelledException) {
+                        break;
+                    }
+                }
+            } catch (
+                IO\Exception\ExceptionInterface|Network\Exception\ExceptionInterface|H2\Exception\ExceptionInterface|HPACK\Exception\ExceptionInterface
+            ) {
+                // @mago-expect lint:no-empty-catch-clause
+            }
+        });
+
+        try {
+            $connector = new TCP\Connector(new TCP\ConnectConfiguration(noDelay: true));
+            /** @var int<0, 65535> $port */
+            $port = $address->port;
+            $stream = $connector->connect('127.0.0.1', $port, new TimeoutCancellationToken(Duration::seconds(5)));
+
+            $session = new H2Session($stream, new H2ClientConfiguration());
+            $connection = new H2Connection($session, $stream->getLocalAddress(), $stream->getPeerAddress(), null);
+
+            $url = URL\parse('http://127.0.0.1/');
+            $request = new Request(method: 'GET', url: $url, requestTarget: '/');
+            $config = new ClientConfiguration();
+
+            $threw = false;
+            try {
+                $connection->exchange($request, $config, new TimeoutCancellationToken(Duration::milliseconds(300)));
+            } catch (CancelledException) {
+                $threw = true;
+            }
+
+            static::assertTrue($threw, 'Expected CancelledException on timeout');
+        } finally {
+            $listener->close();
+            try {
+                $serverFuture->await();
+            } catch (Throwable) {
+                // @mago-expect lint:no-empty-catch-clause
+            }
+        }
+    }
+
+    public function testConcurrentTimeoutsOnHungServerDoNotDeadlock(): void
+    {
+        $listener = TCP\listen('127.0.0.1', 0, new TCP\ListenConfiguration(noDelay: true));
+        $address = $listener->getLocalAddress();
+
+        $serverFuture = Async\run(static function () use ($listener): void {
+            try {
+                $conn = $listener->accept();
+                $server = new H2\ServerConnection($conn);
+                $server->readClientPreface();
+                $server->initialize();
+
+                while ($server->isConnected()) {
+                    try {
+                        $server->readEvent(new TimeoutCancellationToken(Duration::seconds(5)));
+                    } catch (CancelledException) {
+                        break;
+                    }
+                }
+            } catch (
+                IO\Exception\ExceptionInterface|Network\Exception\ExceptionInterface|H2\Exception\ExceptionInterface|HPACK\Exception\ExceptionInterface
+            ) {
+                // @mago-expect lint:no-empty-catch-clause
+            }
+        });
+
+        try {
+            $connector = new TCP\Connector(new TCP\ConnectConfiguration(noDelay: true));
+            /** @var int<0, 65535> $port */
+            $port = $address->port;
+            $stream = $connector->connect('127.0.0.1', $port, new TimeoutCancellationToken(Duration::seconds(5)));
+
+            $session = new H2Session($stream, new H2ClientConfiguration());
+            $connection = new H2Connection($session, $stream->getLocalAddress(), $stream->getPeerAddress(), null);
+
+            $url = URL\parse('http://127.0.0.1/');
+            $config = new ClientConfiguration();
+
+            $tasks = [];
+            for ($i = 0; $i < 5; $i++) {
+                $delay = 100 + ($i * 50);
+                $tasks[] = static function () use ($connection, $url, $config, $delay): bool {
+                    try {
+                        $connection->exchange(
+                            new Request(method: 'GET', url: $url, requestTarget: '/'),
+                            $config,
+                            new TimeoutCancellationToken(Duration::milliseconds($delay)),
+                        );
+                        return false;
+                    } catch (CancelledException) {
+                        return true;
+                    }
+                };
+            }
+
+            $results = Async\concurrently($tasks);
+
+            foreach ($results as $i => $cancelled) {
+                static::assertTrue($cancelled, "Request {$i} should have been cancelled");
+            }
+        } finally {
+            $listener->close();
+            try {
+                $serverFuture->await();
+            } catch (Throwable) {
+                // @mago-expect lint:no-empty-catch-clause
+            }
+        }
+    }
+
+    public function testConnectionUsableAfterTimeout(): void
+    {
+        $listener = TCP\listen('127.0.0.1', 0, new TCP\ListenConfiguration(noDelay: true));
+        $address = $listener->getLocalAddress();
+
+        $serverFuture = Async\run(static function () use ($listener): void {
+            try {
+                $conn = $listener->accept();
+                $server = new H2\ServerConnection($conn);
+                $server->readClientPreface();
+                $server->initialize();
+
+                $requestCount = 0;
+                while ($server->isConnected()) {
+                    try {
+                        $events = $server->readEvent(new TimeoutCancellationToken(Duration::seconds(5)));
+                    } catch (CancelledException) {
+                        break;
+                    }
+
+                    foreach ($events as $event) {
+                        if (!$event instanceof H2\Event\HeadersReceived) {
+                            continue;
+                        }
+
+                        $requestCount++;
+                        if ($requestCount <= 1) {
+                            continue;
+                        }
+
+                        $server->sendHeaders($event->streamId, [
+                            new HPACK\Header(':status', '200'),
+                            new HPACK\Header('content-length', '2'),
+                        ]);
+                        $server->sendData($event->streamId, 'ok', endStream: true);
+                    }
+                }
+            } catch (
+                IO\Exception\ExceptionInterface|Network\Exception\ExceptionInterface|H2\Exception\ExceptionInterface|HPACK\Exception\ExceptionInterface
+            ) {
+                // @mago-expect lint:no-empty-catch-clause
+            }
+        });
+
+        try {
+            $connector = new TCP\Connector(new TCP\ConnectConfiguration(noDelay: true));
+            /** @var int<0, 65535> $port */
+            $port = $address->port;
+            $stream = $connector->connect('127.0.0.1', $port, new TimeoutCancellationToken(Duration::seconds(5)));
+
+            $session = new H2Session($stream, new H2ClientConfiguration());
+            $connection = new H2Connection($session, $stream->getLocalAddress(), $stream->getPeerAddress(), null);
+
+            $url = URL\parse('http://127.0.0.1/');
+            $config = new ClientConfiguration();
+            $request = new Request(method: 'GET', url: $url, requestTarget: '/');
+
+            $threw = false;
+            try {
+                $connection->exchange($request, $config, new TimeoutCancellationToken(Duration::milliseconds(200)));
+            } catch (CancelledException) {
+                $threw = true;
+            }
+
+            static::assertTrue($threw, 'First request should have timed out');
+
+            $tx = $connection->exchange($request, $config, new TimeoutCancellationToken(Duration::seconds(5)));
+
+            static::assertSame(200, $tx->response->status);
+            $body = $tx->response->body?->readAll() ?? '';
+            static::assertSame('ok', $body);
+        } finally {
+            $listener->close();
+            try {
+                $serverFuture->await();
+            } catch (Throwable) {
+                // @mago-expect lint:no-empty-catch-clause
+            }
+        }
+    }
 }

--- a/packages/http-client/tests/unit/Internal/ResolveUrlTest.php
+++ b/packages/http-client/tests/unit/Internal/ResolveUrlTest.php
@@ -99,4 +99,51 @@ final class ResolveUrlTest extends TestCase
         static::assertSame('key=val', $result->query);
         static::assertSame('frag', $result->fragment);
     }
+
+    public function testProtocolRelativeReference(): void
+    {
+        $base = URL\parse('https://example.com/old/path');
+
+        $result = resolve_url('//other.com/new/path', $base);
+
+        static::assertSame('https', $result->scheme);
+        static::assertSame('other.com', $result->authority->host->toString());
+        static::assertSame('/new/path', $result->path);
+    }
+
+    public function testProtocolRelativeReferenceInheritsScheme(): void
+    {
+        $base = URL\parse('http://example.com/page');
+
+        $result = resolve_url('//cdn.example.com/asset.js', $base);
+
+        static::assertSame('http', $result->scheme);
+        static::assertSame('cdn.example.com', $result->authority->host->toString());
+        static::assertSame('/asset.js', $result->path);
+    }
+
+    public function testProtocolRelativeReferenceWithPort(): void
+    {
+        $base = URL\parse('https://example.com/page');
+
+        $result = resolve_url('//other.com:8080/path', $base);
+
+        static::assertSame('https', $result->scheme);
+        static::assertSame('other.com', $result->authority->host->toString());
+        static::assertSame(8080, $result->authority->port);
+        static::assertSame('/path', $result->path);
+    }
+
+    public function testProtocolRelativeReferenceWithQueryAndFragment(): void
+    {
+        $base = URL\parse('https://example.com/page');
+
+        $result = resolve_url('//other.com/path?q=1#frag', $base);
+
+        static::assertSame('https', $result->scheme);
+        static::assertSame('other.com', $result->authority->host->toString());
+        static::assertSame('/path', $result->path);
+        static::assertSame('q=1', $result->query);
+        static::assertSame('frag', $result->fragment);
+    }
 }

--- a/packages/http-client/tests/unit/RetryClientTest.php
+++ b/packages/http-client/tests/unit/RetryClientTest.php
@@ -289,4 +289,92 @@ final class RetryClientTest extends TestCase
 
         static::assertLessThan(50, $elapsed);
     }
+
+    public function testSeekableBodyIsRewoundOnRetry(): void
+    {
+        $bodies = [];
+        $inner = new class($bodies) implements ClientInterface {
+            public int $attempts = 0;
+
+            /** @param list<string> $bodies */
+            public function __construct(
+                private array &$bodies,
+            ) {}
+
+            #[Override]
+            public function send(
+                Request $request,
+                SendConfiguration $configuration = new SendConfiguration(),
+                CancellationTokenInterface $cancellation = new NullCancellationToken(),
+            ): Transaction {
+                $this->attempts++;
+                $this->bodies[] = $request->body?->readAll() ?? '';
+
+                if ($this->attempts <= 1) {
+                    throw new RuntimeException('connection refused');
+                }
+
+                return new Transaction([], null, new Response(status: 200, headers: FieldMap::default()));
+            }
+        };
+
+        $body = new IO\MemoryHandle('hello world');
+        $request = new Request(method: 'PUT', url: URL\parse('http://example.com/'), body: $body);
+
+        $client = new RetryClient($inner, maxAttempts: 3, backoff: Duration::milliseconds(1));
+        $tx = $client->send($request);
+
+        static::assertSame(200, $tx->response->status);
+        static::assertSame(2, $inner->attempts);
+        static::assertSame('hello world', $bodies[0]);
+        static::assertSame('hello world', $bodies[1]);
+    }
+
+    public function testNonSeekableBodyFailsFast(): void
+    {
+        $inner = self::alwaysFailClient();
+        $client = new RetryClient($inner, maxAttempts: 3, backoff: Duration::milliseconds(1));
+
+        $body = new class() implements IO\ReadHandleInterface {
+            use IO\ReadHandleConvenienceMethodsTrait;
+
+            public function tryRead(null|int $maxBytes = null): string
+            {
+                return '';
+            }
+
+            public function read(
+                null|int $maxBytes = null,
+                CancellationTokenInterface $cancellation = new NullCancellationToken(),
+            ): string {
+                return '';
+            }
+
+            public function reachedEndOfDataSource(): bool
+            {
+                return true;
+            }
+        };
+
+        $request = new Request(method: 'PUT', url: URL\parse('http://example.com/'), body: $body);
+
+        $this->expectException(RuntimeException::class);
+
+        try {
+            $client->send($request);
+        } finally {
+            static::assertSame(1, $inner->attempts);
+        }
+    }
+
+    public function testNoBodyRetriesNormally(): void
+    {
+        $inner = self::failThenSucceedClient(2);
+        $client = new RetryClient($inner, maxAttempts: 3, backoff: Duration::milliseconds(1));
+
+        $tx = $client->send(self::request('GET'));
+
+        static::assertSame(200, $tx->response->status);
+        static::assertSame(3, $inner->attempts);
+    }
 }


### PR DESCRIPTION
- **FD/connection leak when body not consumed**: All body handles now implement `CloseHandleInterface` with `__destruct()` cleanup. `PooledConnector` has `__destruct()` for idle connections.
- **Stale idle connections returned from pool**: `checkoutH1()` probes connections with `tryRead()` + `reachedEndOfDataSource()` before returning them.
- **Fiber deadlock on H2 timeout**: `H2Multiplexer::unregister()` now sets `fiberRunning = false` synchronously before cancelling the token, so `register()` always starts a fresh read fiber.
- **No total pool size limit**: `PooledConnector` now has configurable `$maxIdleConnections` (default 256) and `$maxIdleConnectionsPerHost` (default 32). H2 sessions pruned lazily and capped.
- **Protocol-relative redirect URLs**: `resolve_url()` handles `//host/path` references by inheriting the base URL scheme.
- **Non-seekable body breaks retry**: `RetryClient` records body position via `tell()`, rewinds via `seek()` on retry. Non-seekable bodies fail fast.
- **HEAD/TRACE with body silently sent**: `Client::send()` throws `RequestException` for HEAD/TRACE requests with a body.