### PR TITLE
feat(type): support 'true'/'false' string literals in bool coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### features
 
+- feat(type): support `'true'`/`'false'` string literals in `Type\bool()` coercion - [#735](https://github.com/php-standard-library/php-standard-library/pull/735) by @verweto
 - feat: introduce `MIME` component - comprehensive MIME toolkit implementing RFC 2045-2049 and related standards
   - Media type parsing, validation, and content negotiation (`MediaType`, `MediaRange`, `MediaPreferences`) per RFC 2045, RFC 6838, RFC 9110
   - MIME part construction with automatic transfer encoding (`Part\Text`, `Part\Data`) per RFC 2045

--- a/packages/type/src/Psl/Type/Internal/BoolType.php
+++ b/packages/type/src/Psl/Type/Internal/BoolType.php
@@ -10,6 +10,8 @@ use Psl\Type\Exception\AssertException;
 use Psl\Type\Exception\CoercionException;
 
 use function is_bool;
+use function is_string;
+use function mb_strtolower;
 
 /**
  * @extends Type\Type<bool>
@@ -43,6 +45,17 @@ final readonly class BoolType extends Type\Type
 
         if (1 === $value || '1' === $value) {
             return true;
+        }
+
+        if (is_string($value)) {
+            $lower = mb_strtolower($value);
+            if ('true' === $lower) {
+                return true;
+            }
+
+            if ('false' === $lower) {
+                return false;
+            }
         }
 
         throw CoercionException::withValue($value, $this->toString());

--- a/packages/type/tests/unit/BoolTypeTest.php
+++ b/packages/type/tests/unit/BoolTypeTest.php
@@ -21,17 +21,21 @@ final class BoolTypeTest extends TypeTestCase
         yield [false, false];
         yield [0, false];
         yield ['0', false];
+        yield ['false', false];
+        yield ['False', false];
+        yield ['FALSE', false];
         yield [true, true];
         yield [1, true];
         yield ['1', true];
+        yield ['true', true];
+        yield ['True', true];
+        yield ['TRUE', true];
     }
 
     #[Override]
     public static function getInvalidCoercions(): iterable
     {
         yield [null];
-        yield ['true'];
-        yield ['false'];
         yield [1.2];
         yield [Type\bool()];
     }

--- a/packages/type/tests/unit/LiteralScalarBoolTypeTest.php
+++ b/packages/type/tests/unit/LiteralScalarBoolTypeTest.php
@@ -21,6 +21,9 @@ final class LiteralScalarBoolTypeTest extends TypeTestCase
         yield ['0', false];
         yield [0, false];
         yield [false, false];
+        yield ['false', false];
+        yield ['False', false];
+        yield ['FALSE', false];
     }
 
     #[Override]
@@ -29,7 +32,8 @@ final class LiteralScalarBoolTypeTest extends TypeTestCase
         yield [null];
         yield [true];
         yield ['true'];
-        yield ['false'];
+        yield ['True'];
+        yield ['TRUE'];
         yield [1.2];
         yield [Type\bool()];
     }


### PR DESCRIPTION
## Summary
- Add support for coercing `'true'` and `'false'` string literals to `bool` in `BoolType::coerce()`
- Uses `mb_strtolower` so that `'True'`, `'FALSE'`, etc. are also handled
- Updates `LiteralScalarBoolTypeTest` to reflect the new coercion behavior

## Why
JavaScript uses `'true'`/`'false'` in its URL encoding API, XSD uses these literals for boolean values. This is a very common pattern that warrants built-in coercion support.