### PR TITLE
perf(async,h2,hpack,io,tcp,network): inline hot paths, eliminate allocations, remove channel overhead in listeners

### DIFF
--- a/packages/async/src/Psl/Async/Awaitable.php
+++ b/packages/async/src/Psl/Async/Awaitable.php
@@ -256,6 +256,15 @@ final readonly class Awaitable implements PromiseInterface
      */
     public function await(CancellationTokenInterface $cancellation = new NullCancellationToken()): mixed
     {
+        if ($this->state->isComplete()) {
+            if ($cancellation->cancellable) {
+                $cancellation->throwIfCancelled();
+            }
+
+            /** @var T */
+            return $this->state->getResult();
+        }
+
         $suspension = EventLoop::getSuspension();
 
         if ($cancellation->cancellable) {

--- a/packages/async/src/Psl/Async/Internal/State.php
+++ b/packages/async/src/Psl/Async/Internal/State.php
@@ -150,6 +150,29 @@ final class State
         return $this->complete;
     }
 
+    /**
+     * Return the result directly if the operation is complete.
+     *
+     * This allows callers to bypass the subscribe/EventLoop::queue/suspend
+     * cycle when the state is already resolved.
+     *
+     * @throws Throwable If the operation completed with an error.
+     *
+     * @return T
+     */
+    public function getResult(): mixed
+    {
+        Psl\invariant($this->complete, 'Cannot get result of an incomplete operation.');
+
+        $this->handled = true;
+
+        if ($this->throwable !== null) {
+            throw $this->throwable;
+        }
+
+        return $this->result;
+    }
+
     private function invokeCallbacks(): void
     {
         $this->complete = true;

--- a/packages/async/src/Psl/Async/Sequence.php
+++ b/packages/async/src/Psl/Async/Sequence.php
@@ -94,17 +94,22 @@ final class Sequence
         try {
             return ($this->operation)($input);
         } finally {
-            $suspension = array_shift($this->pending);
-            if (null !== $suspension) {
-                $suspension->resume();
-            } else {
-                foreach ($this->waits as $suspension) {
-                    $suspension->resume();
-                }
-
-                $this->waits = [];
-
+            // Fast path: no pending waiters — just clear the flag.
+            if ($this->pending === [] && $this->waits === []) {
                 $this->ongoing = false;
+            } else {
+                $suspension = array_shift($this->pending);
+                if (null !== $suspension) {
+                    $suspension->resume();
+                } else {
+                    foreach ($this->waits as $suspension) {
+                        $suspension->resume();
+                    }
+
+                    $this->waits = [];
+
+                    $this->ongoing = false;
+                }
             }
         }
     }

--- a/packages/h2/src/Psl/H2/Internal/ConnectionTrait.php
+++ b/packages/h2/src/Psl/H2/Internal/ConnectionTrait.php
@@ -44,6 +44,7 @@ use const Psl\H2\FRAME_HEADER_SIZE;
  * @require-implements ConnectionInterface
  *
  * @mago-expect lint:kan-defect
+ * @mago-expect lint:too-many-properties
  */
 trait ConnectionTrait
 {
@@ -54,6 +55,8 @@ trait ConnectionTrait
     private string $readBuffer = '';
 
     private int $readBufferLength = 0;
+
+    private int $readBufferOffset = 0;
 
     private string $writeBuffer = '';
 
@@ -168,10 +171,10 @@ trait ConnectionTrait
         if ($responseFrames !== []) {
             $data = '';
             foreach ($responseFrames as $frame) {
-                $data .= Frame\encode($frame);
+                $data .= $frame instanceof Frame\RawFrame ? Frame\encode($frame) : $frame;
             }
 
-            $this->write($data);
+            $this->write($data, $cancellation);
         }
 
         if ($this->windowWaiters !== []) {
@@ -445,7 +448,9 @@ trait ConnectionTrait
      */
     private function readFrame(CancellationTokenInterface $cancellation = new NullCancellationToken()): RawFrame
     {
-        while ($this->readBufferLength < FRAME_HEADER_SIZE) {
+        $available = $this->readBufferLength - $this->readBufferOffset;
+
+        while ($available < FRAME_HEADER_SIZE) {
             $chunk = $this->reader->read(cancellation: $cancellation);
             if ($chunk === '' && $this->reader->reachedEndOfDataSource()) {
                 throw ConnectionException::forConnectionClosed();
@@ -453,12 +458,15 @@ trait ConnectionTrait
 
             $this->readBuffer .= $chunk;
             $this->readBufferLength += strlen($chunk);
+            $available = $this->readBufferLength - $this->readBufferOffset;
         }
 
-        $length = (ord($this->readBuffer[0]) << 16) | (ord($this->readBuffer[1]) << 8) | ord($this->readBuffer[2]);
+        $o = $this->readBufferOffset;
+        $length =
+            (ord($this->readBuffer[$o]) << 16) | (ord($this->readBuffer[$o + 1]) << 8) | ord($this->readBuffer[$o + 2]);
         $totalNeeded = FRAME_HEADER_SIZE + $length;
 
-        while ($this->readBufferLength < $totalNeeded) {
+        while ($available < $totalNeeded) {
             $chunk = $this->reader->read(cancellation: $cancellation);
             if ($chunk === '' && $this->reader->reachedEndOfDataSource()) {
                 throw ConnectionException::forConnectionClosed();
@@ -466,15 +474,22 @@ trait ConnectionTrait
 
             $this->readBuffer .= $chunk;
             $this->readBufferLength += strlen($chunk);
+            $available = $this->readBufferLength - $this->readBufferOffset;
         }
 
-        $type = ord($this->readBuffer[3]);
-        $flags = ord($this->readBuffer[4]);
+        $type = ord($this->readBuffer[$o + 3]);
+        $flags = ord($this->readBuffer[$o + 4]);
         /** @var int<0, max> $streamId */
-        $streamId = unpack('N', $this->readBuffer, 5)[1] & 0x7FFF_FFFF;
-        $payload = $length > 0 ? substr($this->readBuffer, FRAME_HEADER_SIZE, $length) : '';
-        $this->readBuffer = substr($this->readBuffer, $totalNeeded);
-        $this->readBufferLength -= $totalNeeded;
+        $streamId = unpack('N', $this->readBuffer, $o + 5)[1] & 0x7FFF_FFFF;
+        $payload = $length > 0 ? substr($this->readBuffer, $o + FRAME_HEADER_SIZE, $length) : '';
+        $this->readBufferOffset += $totalNeeded;
+
+        // Compact the buffer when the consumed portion exceeds 64KB to bound memory usage.
+        if ($this->readBufferOffset > 65_536) {
+            $this->readBuffer = substr($this->readBuffer, $this->readBufferOffset);
+            $this->readBufferLength -= $this->readBufferOffset;
+            $this->readBufferOffset = 0;
+        }
 
         return new RawFrame($type, $flags, $streamId, $payload);
     }

--- a/packages/h2/src/Psl/H2/Internal/StateMachine.php
+++ b/packages/h2/src/Psl/H2/Internal/StateMachine.php
@@ -24,7 +24,6 @@ use Psl\H2\Exception\ProtocolException;
 use Psl\H2\Exception\StreamException;
 use Psl\H2\Frame\AltSvcFrame;
 use Psl\H2\Frame\ContinuationFrame;
-use Psl\H2\Frame\DataFrame;
 use Psl\H2\Frame\FrameType;
 use Psl\H2\Frame\GoAwayFrame;
 use Psl\H2\Frame\HeadersFrame;
@@ -48,6 +47,7 @@ use Psl\HPACK\Header;
 
 use function hrtime;
 use function max;
+use function ord;
 use function pack;
 use function str_repeat;
 use function strlen;
@@ -222,7 +222,7 @@ final class StateMachine
      * @throws FrameDecodingException For malformed frame data.
      * @throws FlowControlException For flow control violations.
      *
-     * @return array{list<RawFrame>, list<EventInterface>} A tuple of [response frames to send, events to dispatch].
+     * @return array{list<RawFrame|string>, list<EventInterface>} A tuple of [response frames to send, events to dispatch].
      */
     public function receive(RawFrame $rawFrame): array
     {
@@ -237,29 +237,30 @@ final class StateMachine
         $streamId = $rawFrame->streamId;
 
         if ($streamId !== 0) {
+            /** @var int $payloadLength */
             $payloadLength = strlen($rawFrame->payload);
             if ($payloadLength > $this->localMaxFrameSize) {
                 throw ProtocolException::forFrameSizeError($this->localMaxFrameSize, $payloadLength);
             }
-        }
 
-        if ($type === 4 || $type === 6 || $type === 7 || $type === 0xc || $type === 0x10) {
-            if ($streamId !== 0) {
+            // @mago-expect analysis:redundant-comparison,redundant-logical-operation - false positives!
+            if ($type === 2 && $payloadLength !== 5) {
+                throw FrameDecodingException::forInvalidPayload('PRIORITY', 'payload must be exactly 5 bytes');
+            }
+
+            if ($type === 4 || $type === 6 || $type === 7 || $type === 0xc || $type === 0x10) {
                 throw ProtocolException::forConnectionError(
                     'Frame type ' . $type . ' must be on stream 0, received on stream ' . $streamId,
                 );
             }
-        }
 
-        if ($type === 2) {
-            if ($streamId === 0) {
-                throw ProtocolException::forConnectionError('PRIORITY frame must not be on stream 0');
+            if (($type === 3 || $type === 8) && !$this->isStreamKnown($streamId)) {
+                throw ProtocolException::forConnectionError(
+                    'Received frame type ' . $type . ' on idle stream ' . $streamId,
+                );
             }
-
-            $payloadLength = strlen($rawFrame->payload);
-            if ($payloadLength !== 5) {
-                throw FrameDecodingException::forInvalidPayload('PRIORITY', 'payload must be exactly 5 bytes');
-            }
+        } else if ($type === 2) {
+            throw ProtocolException::forConnectionError('PRIORITY frame must not be on stream 0');
         }
 
         if ($type === 9 && !$this->assembling) {
@@ -268,16 +269,8 @@ final class StateMachine
             );
         }
 
-        if ($type === 3 || $type === 8) {
-            if ($streamId !== 0 && !$this->isStreamKnown($streamId)) {
-                throw ProtocolException::forConnectionError(
-                    'Received frame type ' . $type . ' on idle stream ' . $streamId,
-                );
-            }
-        }
-
         return match ($type) {
-            0 => $this->receiveData(DataFrame::fromRaw($rawFrame)),
+            0 => $this->receiveDataRaw($rawFrame),
             1 => $this->receiveHeaders(HeadersFrame::fromRaw($rawFrame)),
             8 => $this->receiveWindowUpdateRaw($rawFrame),
             9 => $this->receiveContinuation(ContinuationFrame::fromRaw($rawFrame)),
@@ -347,7 +340,7 @@ final class StateMachine
         bool $endStream = false,
     ): string {
         try {
-            $encoded = $this->hpackEncoder->encodeWithStatus($status, self::lowercaseHeadersIterable($headers));
+            $encoded = $this->hpackEncoder->encodeWithStatus($status, self::lowercaseHeaders($headers));
         } catch (HPACKException $e) {
             throw ProtocolException::forConnectionError($e->getMessage(), $e);
         }
@@ -1173,38 +1166,65 @@ final class StateMachine
      * @throws FlowControlException If the receive window is exhausted.
      * @throws ProtocolException If the empty DATA frame rate limit is exceeded.
      *
-     * @return array{list<RawFrame>, list<EventInterface>}
+     * @return array{list<RawFrame|string>, list<EventInterface>}
      */
-    private function receiveData(DataFrame $frame): array
+    private function receiveDataRaw(RawFrame $rawFrame): array
     {
-        $stream = $this->streams->get($frame->streamId);
+        $streamId = $rawFrame->streamId;
+        if ($streamId === 0) {
+            throw FrameDecodingException::forStreamIdRequired($rawFrame->type);
+        }
+
+        $stream = $this->streams->get($streamId);
         if (
             $stream === null
             || $stream->state !== StreamState::Open && $stream->state !== StreamState::HalfClosedLocal
         ) {
             throw StreamException::forInvalidState(
-                $frame->streamId,
+                $streamId,
                 'open or half-closed (local)',
                 $stream?->state->name ?? 'idle',
             );
         }
 
-        $dataLength = strlen($frame->data);
+        $payload = $rawFrame->payload;
+        $endStream = ($rawFrame->flags & 0x01) !== 0;
+
+        if (($rawFrame->flags & 0x08) !== 0) {
+            $payloadLength = strlen($payload);
+            if ($payloadLength < 1) {
+                throw FrameDecodingException::forInvalidPayload('DATA', 'missing pad length');
+            }
+
+            $padLength = ord($payload[0]);
+            if ($padLength >= $payloadLength) {
+                throw FrameDecodingException::forInvalidPaddingLength($padLength, $payloadLength);
+            }
+
+            $payload = substr($payload, 1, $payloadLength - 1 - $padLength);
+        }
+
+        $dataLength = strlen($payload);
         if ($dataLength > 0) {
             $this->flowController->consumeReceiveWindow($stream, $dataLength);
-        } elseif (!$frame->endStream) {
+        } elseif (!$endStream) {
             $this->rateLimiter?->record(RateLimiter::EMPTY_DATA_FRAME);
         }
 
-        $events = [new DataReceived($frame->streamId, $frame->data, $frame->endStream)];
+        $events = [new DataReceived($streamId, $payload, $endStream)];
         $responseFrames = [];
 
         if ($dataLength > 0) {
             if ($this->bdpEstimator !== null) {
-                $updates = $this->bdpEstimator->recordDataReceived($frame->streamId, $dataLength);
+                $updates = $this->bdpEstimator->recordDataReceived($streamId, $dataLength);
                 foreach ($updates as [$updateStreamId, $increment]) {
-                    $payload = pack('N', $increment & 0x7FFF_FFFF);
-                    $responseFrames[] = new RawFrame(FrameType::WindowUpdate->value, 0, $updateStreamId, $payload);
+                    $responseFrames[] = pack(
+                        'NCNN',
+                        (4 << 8) | FrameType::WindowUpdate->value,
+                        0,
+                        $updateStreamId & 0x7FFF_FFFF,
+                        $increment & 0x7FFF_FFFF,
+                    );
                     if ($updateStreamId === 0) {
                         $this->flowController->applyConnectionReceiveWindowUpdate($increment);
                     } else {
@@ -1215,26 +1235,22 @@ final class StateMachine
                     }
                 }
             } else {
-                $windowUpdatePayload = pack('N', $dataLength & 0x7FFF_FFFF);
-                $responseFrames[] = new RawFrame(FrameType::WindowUpdate->value, 0, 0, $windowUpdatePayload);
-                $responseFrames[] = new RawFrame(
-                    FrameType::WindowUpdate->value,
-                    0,
-                    $frame->streamId,
-                    $windowUpdatePayload,
-                );
+                $increment = $dataLength & 0x7FFF_FFFF;
+                $responseFrames[] =
+                    pack('NCNN', (4 << 8) | FrameType::WindowUpdate->value, 0, 0, $increment)
+                    . pack('NCNN', (4 << 8) | FrameType::WindowUpdate->value, 0, $streamId & 0x7FFF_FFFF, $increment);
                 $this->flowController->applyConnectionReceiveWindowUpdate($dataLength);
                 $stream->receiveWindow += $dataLength;
             }
         }
 
-        if ($frame->endStream) {
+        if ($endStream) {
             if ($stream->state === StreamState::Open) {
-                $this->streams->markHalfClosed($frame->streamId, StreamState::HalfClosedRemote);
+                $this->streams->markHalfClosed($streamId, StreamState::HalfClosedRemote);
             } else {
-                $this->streams->close($frame->streamId);
-                $this->bdpEstimator?->removeStream($frame->streamId);
-                $events[] = new StreamClosed($frame->streamId);
+                $this->streams->close($streamId);
+                $this->bdpEstimator?->removeStream($streamId);
+                $events[] = new StreamClosed($streamId);
             }
         }
 
@@ -1337,7 +1353,7 @@ final class StateMachine
      * @throws ProtocolException If rate limit exceeded.
      * @throws FlowControlException If the BDP window update causes overflow.
      *
-     * @return array{list<RawFrame>, list<EventInterface>}
+     * @return array{list<RawFrame|string>, list<EventInterface>}
      */
     private function receivePingRateLimited(PingFrame $frame): array
     {
@@ -1361,7 +1377,7 @@ final class StateMachine
     /**
      * @throws FlowControlException If the BDP window update causes overflow.
      *
-     * @return array{list<RawFrame>, list<EventInterface>}
+     * @return array{list<RawFrame|string>, list<EventInterface>}
      */
     private function receivePing(PingFrame $frame): array
     {
@@ -1370,8 +1386,13 @@ final class StateMachine
             if ($this->bdpEstimator !== null) {
                 $windowGrowth = $this->bdpEstimator->onPingAck((int) hrtime(true) / 1e9);
                 if ($windowGrowth !== null && $windowGrowth > 0) {
-                    $payload = pack('N', $windowGrowth & 0x7FFF_FFFF);
-                    $responseFrames[] = new RawFrame(FrameType::WindowUpdate->value, 0, 0, $payload);
+                    $responseFrames[] = pack(
+                        'NCNN',
+                        (4 << 8) | FrameType::WindowUpdate->value,
+                        0,
+                        0,
+                        $windowGrowth & 0x7FFF_FFFF,
+                    );
                     $this->flowController->applyConnectionReceiveWindowUpdate($windowGrowth);
                 }
             }
@@ -1379,7 +1400,8 @@ final class StateMachine
             return [$responseFrames, [new PingReceived($frame->opaqueData, true)]];
         }
 
-        $ack = new RawFrame(FrameType::Ping->value, 0x01, 0, $frame->opaqueData);
+        // PING ACK: 8-byte opaque data, type=6, flags=0x01 (ACK), stream=0
+        $ack = pack('NCN', (8 << 8) | FrameType::Ping->value, 0x01, 0) . $frame->opaqueData;
 
         return [[$ack], [new PingReceived($frame->opaqueData, false)]];
     }
@@ -1457,29 +1479,18 @@ final class StateMachine
     }
 
     /**
-     * @param list<Header> $headers
+     * @param iterable<Header> $headers
      *
      * @return list<Header>
      */
-    private static function lowercaseHeaders(array $headers): array
+    private static function lowercaseHeaders(iterable $headers): array
     {
         $result = [];
         foreach ($headers as $header) {
-            $result[] = new Header(strtolower($header->name), $header->value, $header->sensitive);
+            $lower = strtolower($header->name);
+            $result[] = $lower === $header->name ? $header : new Header($lower, $header->value, $header->sensitive);
         }
 
         return $result;
-    }
-
-    /**
-     * @param iterable<Header> $headers
-     *
-     * @return iterable<Header>
-     */
-    private static function lowercaseHeadersIterable(iterable $headers): iterable
-    {
-        foreach ($headers as $header) {
-            yield new Header(strtolower($header->name), $header->value, $header->sensitive);
-        }
     }
 }

--- a/packages/h2/tests/unit/StateMachine/BDPEstimatorIntegrationTest.php
+++ b/packages/h2/tests/unit/StateMachine/BDPEstimatorIntegrationTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Psl\H2\Event\DataReceived;
 use Psl\H2\Event\PingReceived;
 use Psl\H2\Frame\DataFrame;
-use Psl\H2\Frame\FrameType;
 use Psl\H2\Frame\HeadersFrame;
 use Psl\H2\Frame\PingFrame;
 use Psl\H2\Internal\BDPEstimator;
@@ -18,9 +17,6 @@ use Psl\HPACK\Header;
 
 use function str_repeat;
 
-/**
- * @mago-expect lint:prefer-early-continue
- */
 final class BDPEstimatorIntegrationTest extends TestCase
 {
     public function testReceiveDataWithBdpEstimator(): void
@@ -46,14 +42,7 @@ final class BDPEstimatorIntegrationTest extends TestCase
         static::assertCount(1, $events);
         static::assertInstanceOf(DataReceived::class, $events[0]);
 
-        $hasWindowUpdate = false;
-        foreach ($responseFrames as $frame) {
-            if ($frame->type === FrameType::WindowUpdate->value) {
-                $hasWindowUpdate = true;
-            }
-        }
-
-        static::assertTrue($hasWindowUpdate);
+        static::assertNotEmpty($responseFrames);
     }
 
     public function testPingAckWithBdpEstimator(): void

--- a/packages/h2/tests/unit/StateMachine/DataTest.php
+++ b/packages/h2/tests/unit/StateMachine/DataTest.php
@@ -15,6 +15,8 @@ use Psl\H2\Internal\StateMachine;
 use Psl\HPACK\Encoder;
 use Psl\HPACK\Header;
 
+use function strlen;
+
 final class DataTest extends TestCase
 {
     /**
@@ -50,16 +52,10 @@ final class DataTest extends TestCase
         static::assertSame('hello', $events[0]->data);
         static::assertFalse($events[0]->endStream);
 
-        $windowUpdateCount = 0;
-        foreach ($responseFrames as $frame) {
-            if ($frame->type !== FrameType::WindowUpdate->value) {
-                continue;
-            }
-
-            $windowUpdateCount++;
-        }
-
-        static::assertSame(2, $windowUpdateCount);
+        static::assertCount(1, $responseFrames);
+        $encoded = $responseFrames[0];
+        static::assertIsString($encoded);
+        static::assertSame(26, strlen($encoded));
     }
 
     public function testReceiveDataEndStream(): void

--- a/packages/h2/tests/unit/StateMachine/FlowControlTest.php
+++ b/packages/h2/tests/unit/StateMachine/FlowControlTest.php
@@ -17,6 +17,7 @@ use Psl\HPACK\Encoder;
 use Psl\HPACK\Header;
 
 use function str_repeat;
+use function strlen;
 
 final class FlowControlTest extends TestCase
 {
@@ -144,17 +145,16 @@ final class FlowControlTest extends TestCase
         $dataRaw = new DataFrame(1, str_repeat('x', 100), false)->toRaw();
         [$responseFrames, $events] = $sm->receive($dataRaw);
 
-        $windowUpdates = [];
-        foreach ($responseFrames as $frame) {
-            $parsed = WindowUpdateFrame::fromRaw($frame);
-            if ($parsed instanceof WindowUpdateFrame) {
-                $windowUpdates[] = $parsed;
-            }
-        }
+        static::assertCount(1, $responseFrames);
+        $encoded = $responseFrames[0];
+        static::assertIsString($encoded);
+        static::assertSame(26, strlen($encoded));
 
-        static::assertCount(2, $windowUpdates);
-        $connectionUpdate = $windowUpdates[0] ?? null;
-        $streamUpdate = $windowUpdates[1] ?? null;
+        [$connRaw] = Frame\decode($encoded, 0);
+        [$streamRaw] = Frame\decode($encoded, 13);
+
+        $connectionUpdate = WindowUpdateFrame::fromRaw($connRaw);
+        $streamUpdate = WindowUpdateFrame::fromRaw($streamRaw);
         static::assertInstanceOf(WindowUpdateFrame::class, $connectionUpdate);
         static::assertInstanceOf(WindowUpdateFrame::class, $streamUpdate);
         static::assertSame(0, $connectionUpdate->streamId);

--- a/packages/h2/tests/unit/StateMachine/PingTest.php
+++ b/packages/h2/tests/unit/StateMachine/PingTest.php
@@ -6,6 +6,7 @@ namespace Psl\H2\Tests\Unit\StateMachine;
 
 use PHPUnit\Framework\TestCase;
 use Psl\H2\Event\PingReceived;
+use Psl\H2\Frame;
 use Psl\H2\Frame\FrameType;
 use Psl\H2\Frame\PingFrame;
 use Psl\H2\Internal\StateMachine;
@@ -53,8 +54,12 @@ final class PingTest extends TestCase
         [$responseFrames, $events] = $sm->receive($pingRaw);
 
         static::assertCount(1, $responseFrames);
-        static::assertSame(FrameType::Ping->value, $responseFrames[0]->type);
-        static::assertSame(0x01, $responseFrames[0]->flags & 0x01);
+        $encoded = $responseFrames[0];
+        static::assertIsString($encoded);
+        static::assertSame(17, strlen($encoded));
+        [$ackFrame] = Frame\decode($encoded);
+        static::assertSame(FrameType::Ping->value, $ackFrame->type);
+        static::assertSame(0x01, $ackFrame->flags & 0x01);
 
         static::assertCount(1, $events);
         static::assertInstanceOf(PingReceived::class, $events[0]);

--- a/packages/hpack/src/Psl/HPACK/Decoder.php
+++ b/packages/hpack/src/Psl/HPACK/Decoder.php
@@ -108,7 +108,7 @@ final class Decoder
                     throw DecodingException::forTooManyTableSizeUpdates();
                 }
 
-                [$newSize, $offset] = IntegerCodec::decode($encoded, $offset, 5);
+                [$newSize, $offset] = IntegerCodec::decode($encoded, $offset, 5, $length);
 
                 if ($newSize > $this->maxTableSize) {
                     throw DecodingException::forTableSizeExceedsLimit();
@@ -122,41 +122,66 @@ final class Decoder
             $sensitive = false;
 
             if (($byte & 0b1000_0000) !== 0) {
-                [$index, $offset] = IntegerCodec::decode($encoded, $offset, 7);
+                // Indexed header field (Section 6.1), 7-bit prefix.
+                $index = $byte & 0x7F;
+                if ($index < 0x7F) {
+                    $offset++;
+                } else {
+                    [$index, $offset] = IntegerCodec::decode($encoded, $offset, 7, $length);
+                }
+
                 [$name, $value] = $this->lookupIndex($index);
             } elseif (($byte & 0b0100_0000) !== 0) {
-                [$index, $offset] = IntegerCodec::decode($encoded, $offset, 6);
+                // Literal with incremental indexing (Section 6.2.1), 6-bit prefix.
+                $index = $byte & 0x3F;
+                if ($index < 0x3F) {
+                    $offset++;
+                } else {
+                    [$index, $offset] = IntegerCodec::decode($encoded, $offset, 6, $length);
+                }
 
                 if ($index > 0) {
                     [$name, $_] = $this->lookupIndex($index);
                 } else {
                     /** @var non-empty-lowercase-string $name */
-                    [$name, $offset] = $this->decodeString($encoded, $offset);
+                    [$name, $offset] = $this->decodeString($encoded, $offset, $length);
                 }
 
-                [$value, $offset] = $this->decodeString($encoded, $offset);
-                $this->dynamicTable->insert($name, $value);
+                [$value, $offset] = $this->decodeString($encoded, $offset, $length);
+                $this->dynamicTable->insert($name, strlen($name), $value, strlen($value));
             } elseif (($byte & 0b1111_0000) === 0b0001_0000) {
-                [$index, $offset] = IntegerCodec::decode($encoded, $offset, 4);
+                // Literal never indexed (Section 6.2.3), 4-bit prefix.
+                $index = $byte & 0x0F;
+                if ($index < 0x0F) {
+                    $offset++;
+                } else {
+                    [$index, $offset] = IntegerCodec::decode($encoded, $offset, 4, $length);
+                }
 
                 if ($index > 0) {
                     [$name, $_] = $this->lookupIndex($index);
                 } else {
-                    [$name, $offset] = $this->decodeString($encoded, $offset);
+                    [$name, $offset] = $this->decodeString($encoded, $offset, $length);
                 }
 
-                [$value, $offset] = $this->decodeString($encoded, $offset);
+                [$value, $offset] = $this->decodeString($encoded, $offset, $length);
                 $sensitive = true;
             } else {
-                [$index, $offset] = IntegerCodec::decode($encoded, $offset, 4);
+                // Literal without indexing (Section 6.2.2), 4-bit prefix.
+                $index = $byte & 0x0F;
+                if ($index < 0x0F) {
+                    $offset++;
+                } else {
+                    [$index, $offset] = IntegerCodec::decode($encoded, $offset, 4, $length);
+                }
 
                 if ($index > 0) {
                     [$name, $_] = $this->lookupIndex($index);
                 } else {
-                    [$name, $offset] = $this->decodeString($encoded, $offset);
+                    [$name, $offset] = $this->decodeString($encoded, $offset, $length);
                 }
 
-                [$value, $offset] = $this->decodeString($encoded, $offset);
+                [$value, $offset] = $this->decodeString($encoded, $offset, $length);
             }
 
             $totalSize += strlen($name) + strlen($value) + 32;
@@ -232,16 +257,16 @@ final class Decoder
      * @throws DecodingException
      * @throws IntegerOverflowException
      */
-    private function decodeString(string $data, int $offset): array
+    private function decodeString(string $data, int $offset, int $dataLength): array
     {
-        if ($offset >= strlen($data)) {
+        if ($offset >= $dataLength) {
             throw DecodingException::forUnexpectedEndOfData();
         }
 
         $huffman = (ord($data[$offset]) & 0b1000_0000) !== 0;
-        [$stringLength, $offset] = IntegerCodec::decode($data, $offset, 7);
+        [$stringLength, $offset] = IntegerCodec::decode($data, $offset, 7, $dataLength);
 
-        if (($offset + $stringLength) > strlen($data)) {
+        if (($offset + $stringLength) > $dataLength) {
             throw DecodingException::forInvalidStringLength();
         }
 

--- a/packages/hpack/src/Psl/HPACK/Encoder.php
+++ b/packages/hpack/src/Psl/HPACK/Encoder.php
@@ -131,12 +131,14 @@ final class Encoder
 
         $totalSize = 0;
         foreach ($headers as $header) {
-            $totalSize += strlen($header->name) + strlen($header->value) + 32;
+            $nameLen = strlen($header->name);
+            $valueLen = strlen($header->value);
+            $totalSize += $nameLen + $valueLen + 32;
             if ($totalSize > $this->maxHeaderListSize) {
                 throw HeaderListSizeException::forExceededLimit($totalSize, $this->maxHeaderListSize);
             }
 
-            $result .= $this->encodeHeaderEntry($header->name, $header->value, $header->sensitive);
+            $result .= $this->encodeHeaderEntry($header->name, $nameLen, $header->value, $valueLen, $header->sensitive);
         }
 
         return $result;
@@ -161,20 +163,23 @@ final class Encoder
     {
         $result = $this->encodePendingTableSize();
 
-        $totalSize = 7 + strlen($status) + 32;
+        $statusLen = strlen($status);
+        $totalSize = 7 + $statusLen + 32;
         if ($totalSize > $this->maxHeaderListSize) {
             throw HeaderListSizeException::forExceededLimit($totalSize, $this->maxHeaderListSize);
         }
 
-        $result .= $this->encodeHeaderEntry(':status', $status, false);
+        $result .= $this->encodeHeaderEntry(':status', 7, $status, $statusLen, false);
 
         foreach ($headers as $header) {
-            $totalSize += strlen($header->name) + strlen($header->value) + 32;
+            $nameLen = strlen($header->name);
+            $valueLen = strlen($header->value);
+            $totalSize += $nameLen + $valueLen + 32;
             if ($totalSize > $this->maxHeaderListSize) {
                 throw HeaderListSizeException::forExceededLimit($totalSize, $this->maxHeaderListSize);
             }
 
-            $result .= $this->encodeHeaderEntry($header->name, $header->value, $header->sensitive);
+            $result .= $this->encodeHeaderEntry($header->name, $nameLen, $header->value, $valueLen, $header->sensitive);
         }
 
         return $result;
@@ -205,10 +210,15 @@ final class Encoder
      *
      * @return non-empty-string
      */
-    private function encodeHeaderEntry(string $name, string $value, bool $sensitive): string
-    {
+    private function encodeHeaderEntry(
+        string $name,
+        int $nameLen,
+        string $value,
+        int $valueLen,
+        bool $sensitive,
+    ): string {
         if ($sensitive) {
-            return $this->encodeLiteralNeverIndexed($name, $value);
+            return $this->encodeLiteralNeverIndexed($name, $nameLen, $value, $valueLen);
         }
 
         $staticResult = StaticTable::search($name, $value);
@@ -236,15 +246,12 @@ final class Encoder
             $nameMatchIndex ??= $combinedIndex;
         }
 
+        $this->dynamicTable->insert($name, $nameLen, $value, $valueLen);
         if ($nameMatchIndex !== null) {
-            $this->dynamicTable->insert($name, $value);
-
-            return IntegerCodec::encode($nameMatchIndex, 6, 0b0100_0000) . $this->encodeString($value);
+            return IntegerCodec::encode($nameMatchIndex, 6, 0b0100_0000) . $this->encodeString($value, $valueLen);
         }
 
-        $this->dynamicTable->insert($name, $value);
-
-        return "\x40" . $this->encodeString($name) . $this->encodeString($value);
+        return "\x40" . $this->encodeString($name, $nameLen) . $this->encodeString($value, $valueLen);
     }
 
     /**
@@ -253,7 +260,7 @@ final class Encoder
      *
      * @return non-empty-string
      */
-    private function encodeLiteralNeverIndexed(string $name, string $value): string
+    private function encodeLiteralNeverIndexed(string $name, int $nameLen, string $value, int $valueLen): string
     {
         $staticResult = StaticTable::search($name, $value);
         $nameIndex = 0;
@@ -268,19 +275,18 @@ final class Encoder
         }
 
         if ($nameIndex > 0) {
-            return IntegerCodec::encode($nameIndex, 4, 0b0001_0000) . $this->encodeString($value);
+            return IntegerCodec::encode($nameIndex, 4, 0b0001_0000) . $this->encodeString($value, $valueLen);
         }
 
-        return "\x10" . $this->encodeString($name) . $this->encodeString($value);
+        return "\x10" . $this->encodeString($name, $nameLen) . $this->encodeString($value, $valueLen);
     }
 
     /**
      * @return non-empty-string
      */
-    private function encodeString(string $value): string
+    private function encodeString(string $value, int $rawLen): string
     {
-        $rawLen = strlen($value);
-        $estimatedBits = Huffman::estimateEncodedBits($value);
+        $estimatedBits = Huffman::estimateEncodedBits($value, $rawLen);
         $estimatedBytes = ($estimatedBits + 7) >> 3;
 
         if ($estimatedBytes >= $rawLen) {

--- a/packages/hpack/src/Psl/HPACK/Internal/DynamicTable.php
+++ b/packages/hpack/src/Psl/HPACK/Internal/DynamicTable.php
@@ -67,9 +67,9 @@ final class DynamicTable
      * @param non-empty-lowercase-string $name The header field name.
      * @param string $value The header field value.
      */
-    public function insert(string $name, string $value): void
+    public function insert(string $name, int $nameLen, string $value, int $valueLen): void
     {
-        $entrySize = strlen($name) + strlen($value) + self::ENTRY_OVERHEAD;
+        $entrySize = $nameLen + $valueLen + self::ENTRY_OVERHEAD;
 
         if ($entrySize > $this->maxSize) {
             $this->entries = [];

--- a/packages/hpack/src/Psl/HPACK/Internal/Huffman.php
+++ b/packages/hpack/src/Psl/HPACK/Internal/Huffman.php
@@ -572,10 +572,9 @@ final class Huffman
      *
      * @return int The estimated number of bits.
      */
-    public static function estimateEncodedBits(string $data): int
+    public static function estimateEncodedBits(string $data, int $length): int
     {
         $bits = 0;
-        $length = strlen($data);
         for ($i = 0; $i < $length; $i++) {
             $bits += self::BIT_LENGTHS[ord($data[$i])];
         }

--- a/packages/hpack/src/Psl/HPACK/Internal/IntegerCodec.php
+++ b/packages/hpack/src/Psl/HPACK/Internal/IntegerCodec.php
@@ -61,9 +61,9 @@ final class IntegerCodec
      *
      * @return array{int<0, max>, int<0, max>} [decoded value, new offset]
      */
-    public static function decode(string $data, int $offset, int $prefixBits): array
+    public static function decode(string $data, int $offset, int $prefixBits, null|int $length = null): array
     {
-        $length = strlen($data);
+        $length ??= strlen($data);
         if ($offset >= $length) {
             throw DecodingException::forUnexpectedEndOfData();
         }

--- a/packages/hpack/tests/unit/Internal/DynamicTableTest.php
+++ b/packages/hpack/tests/unit/Internal/DynamicTableTest.php
@@ -15,7 +15,7 @@ final class DynamicTableTest extends TestCase
     public function testInsertAndRetrieve(): void
     {
         $table = new DynamicTable();
-        $table->insert('custom-key', 'custom-value');
+        $table->insert('custom-key', 10, 'custom-value', 12);
 
         $entry = $table->get(0);
 
@@ -26,8 +26,8 @@ final class DynamicTableTest extends TestCase
     public function testNewestEntryAtIndex0(): void
     {
         $table = new DynamicTable();
-        $table->insert('first', 'one');
-        $table->insert('second', 'two');
+        $table->insert('first', 5, 'one', 3);
+        $table->insert('second', 6, 'two', 3);
 
         static::assertSame(['second', 'two'], $table->get(0));
         static::assertSame(['first', 'one'], $table->get(1));
@@ -36,7 +36,7 @@ final class DynamicTableTest extends TestCase
     public function testEntrySize(): void
     {
         $table = new DynamicTable();
-        $table->insert('name', 'value');
+        $table->insert('name', 4, 'value', 5);
 
         static::assertSame(4 + 5 + 32, $table->size());
     }
@@ -45,9 +45,9 @@ final class DynamicTableTest extends TestCase
     {
         $table = new DynamicTable(80);
 
-        $table->insert('key1', 'val1');
-        $table->insert('key2', 'val2');
-        $table->insert('key3', 'val3');
+        $table->insert('key1', 4, 'val1', 4);
+        $table->insert('key2', 4, 'val2', 4);
+        $table->insert('key3', 4, 'val3', 4);
 
         static::assertSame(['key3', 'val3'], $table->get(0));
         static::assertSame(['key2', 'val2'], $table->get(1));
@@ -58,11 +58,11 @@ final class DynamicTableTest extends TestCase
     public function testOversizedEntryEmptiesTable(): void
     {
         $table = new DynamicTable(64);
-        $table->insert('a', 'b');
+        $table->insert('a', 1, 'b', 1);
 
         static::assertSame(1, $table->count());
 
-        $table->insert(str_repeat('x', 100), 'y');
+        $table->insert(str_repeat('x', 100), 100, 'y', 1);
 
         static::assertSame(0, $table->count());
         static::assertSame(0, $table->size());
@@ -71,7 +71,7 @@ final class DynamicTableTest extends TestCase
     public function testSetMaxSizeZeroClearsTable(): void
     {
         $table = new DynamicTable();
-        $table->insert('key', 'value');
+        $table->insert('key', 3, 'value', 5);
 
         static::assertSame(1, $table->count());
 
@@ -84,9 +84,9 @@ final class DynamicTableTest extends TestCase
     public function testSetMaxSizeEvictsOldest(): void
     {
         $table = new DynamicTable(4096);
-        $table->insert('first', 'one');
-        $table->insert('second', 'two');
-        $table->insert('third', 'three');
+        $table->insert('first', 5, 'one', 3);
+        $table->insert('second', 6, 'two', 3);
+        $table->insert('third', 5, 'three', 5);
 
         $table->setMaxSize(strlen('third') + strlen('three') + 32 + strlen('second') + strlen('two') + 32);
 
@@ -98,7 +98,7 @@ final class DynamicTableTest extends TestCase
     public function testSearchFullMatch(): void
     {
         $table = new DynamicTable();
-        $table->insert('custom-key', 'custom-value');
+        $table->insert('custom-key', 10, 'custom-value', 12);
 
         $result = $table->search('custom-key', 'custom-value');
 
@@ -108,7 +108,7 @@ final class DynamicTableTest extends TestCase
     public function testSearchNameOnly(): void
     {
         $table = new DynamicTable();
-        $table->insert('custom-key', 'custom-value');
+        $table->insert('custom-key', 10, 'custom-value', 12);
 
         $result = $table->search('custom-key', 'other-value');
 
@@ -118,7 +118,7 @@ final class DynamicTableTest extends TestCase
     public function testSearchNoMatch(): void
     {
         $table = new DynamicTable();
-        $table->insert('custom-key', 'custom-value');
+        $table->insert('custom-key', 10, 'custom-value', 12);
 
         $result = $table->search('unknown', 'value');
 
@@ -145,7 +145,9 @@ final class DynamicTableTest extends TestCase
         $table = new DynamicTable();
 
         for ($i = 0; $i < 10; $i++) {
-            $table->insert('key' . $i, 'val' . $i);
+            $name = 'key' . $i;
+            $value = 'val' . $i;
+            $table->insert($name, strlen($name), $value, strlen($value));
         }
 
         static::assertSame(10, $table->count());
@@ -159,7 +161,7 @@ final class DynamicTableTest extends TestCase
         $table = new DynamicTable($entrySize);
 
         for ($i = 0; $i < 300; $i++) {
-            $table->insert('k', 'v');
+            $table->insert('k', 1, 'v', 1);
         }
 
         static::assertSame(1, $table->count());

--- a/packages/http-message/src/Psl/HTTP/Message/FieldMap.php
+++ b/packages/http-message/src/Psl/HTTP/Message/FieldMap.php
@@ -9,6 +9,7 @@ use IteratorAggregate;
 use Psl\Default\DefaultInterface;
 use Traversable;
 
+use function array_flip;
 use function count;
 use function strtolower;
 
@@ -202,11 +203,25 @@ final class FieldMap implements Countable, IteratorAggregate, DefaultInterface
      */
     public function with(string $name, string $value): self
     {
+        $lower = strtolower($name);
+        $indices = $this->buildIndex()[$lower] ?? null;
+
+        if ($indices === null) {
+            $fields = $this->fields;
+            $fields[] = [$name, $value];
+
+            return new self($fields);
+        }
+
+        if (count($indices) === 1 && $this->fields[$indices[0]][1] === $value) {
+            return $this;
+        }
+
+        $replaceSet = array_flip($indices);
         $result = [];
         $replaced = false;
-        $lower = strtolower($name);
-        foreach ($this->fields as $pair) {
-            if (strtolower($pair[0]) === $lower) {
+        foreach ($this->fields as $k => $pair) {
+            if (isset($replaceSet[$k])) {
                 if (!$replaced) {
                     $result[] = [$name, $value];
                     $replaced = true;
@@ -214,10 +229,6 @@ final class FieldMap implements Countable, IteratorAggregate, DefaultInterface
             } else {
                 $result[] = $pair;
             }
-        }
-
-        if (!$replaced) {
-            $result[] = [$name, $value];
         }
 
         return new self($result);
@@ -242,7 +253,15 @@ final class FieldMap implements Countable, IteratorAggregate, DefaultInterface
         $fields = $this->fields;
         $fields[] = [$name, $value];
 
-        return new self($fields);
+        $new = new self($fields);
+
+        if ($this->index !== null) {
+            $index = $this->index;
+            $index[strtolower($name)][] = count($this->fields);
+            $new->index = $index;
+        }
+
+        return $new;
     }
 
     /**
@@ -260,9 +279,16 @@ final class FieldMap implements Countable, IteratorAggregate, DefaultInterface
     public function without(string $name): self
     {
         $lower = strtolower($name);
+        $indices = $this->buildIndex()[$lower] ?? null;
+
+        if ($indices === null) {
+            return $this;
+        }
+
+        $removeSet = array_flip($indices);
         $result = [];
-        foreach ($this->fields as $pair) {
-            if (strtolower($pair[0]) === $lower) {
+        foreach ($this->fields as $k => $pair) {
+            if (isset($removeSet[$k])) {
                 continue;
             }
 

--- a/packages/io/src/Psl/IO/Internal/ResourceHandle.php
+++ b/packages/io/src/Psl/IO/Internal/ResourceHandle.php
@@ -290,7 +290,9 @@ class ResourceHandle implements
         string $bytes,
         Async\CancellationTokenInterface $cancellation = new Async\NullCancellationToken(),
     ): int {
-        Psl\invariant(null !== $this->writeSequence, 'The resource handle is not writable.');
+        if (null === $this->writeSequence) {
+            Psl\invariant_violation('The resource handle is not writable.');
+        }
 
         return $this->writeSequence->waitFor([$bytes, $cancellation]);
     }
@@ -420,7 +422,9 @@ class ResourceHandle implements
         null|int $maxBytes = null,
         Async\CancellationTokenInterface $cancellation = new Async\NullCancellationToken(),
     ): string {
-        Psl\invariant(null !== $this->readSequence, 'The resource handle is not readable.');
+        if (null === $this->readSequence) {
+            Psl\invariant_violation('The resource handle is not readable.');
+        }
 
         return $this->readSequence->waitFor([$maxBytes, $cancellation]);
     }

--- a/packages/network/composer.json
+++ b/packages/network/composer.json
@@ -22,7 +22,6 @@
     "require": {
         "php": "~8.4.0 || ~8.5.0",
         "php-standard-library/async": "^6.0",
-        "php-standard-library/channel": "^6.0",
         "php-standard-library/foundation": "^6.0",
         "php-standard-library/io": "^6.0",
         "revolt/event-loop": "^1.0.8"

--- a/packages/network/src/Psl/Network/CompositeListener.php
+++ b/packages/network/src/Psl/Network/CompositeListener.php
@@ -7,28 +7,25 @@ namespace Psl\Network;
 use Override;
 use Psl\Async;
 use Psl\Async\CancellationTokenInterface;
-use Psl\Async\Exception\CancelledException;
 use Psl\Async\NullCancellationToken;
-use Psl\Channel;
-use Revolt\EventLoop;
+use Revolt\EventLoop\Suspension;
 use Throwable;
+use WeakMap;
 
 use function array_map;
+use function array_shift;
 
 /**
  * A listener that accepts connections from multiple inner listeners concurrently.
  *
- * Each inner listener runs its own accept loop in a separate fiber. Accepted
- * connections are funneled through a shared channel, so a single call to
- * {@see accept()} returns the next connection from any of the inner listeners.
+ * When {@see accept()} is called and no backlog is available, each inner listener
+ * that doesn't already have a pending accept gets one in-flight accept fiber.
+ * The first to return is delivered; others fill the backlog (bounded by N where
+ * N = number of listeners) for subsequent calls.
  *
- * This is useful for servers that need to listen on multiple addresses, protocols,
- * or socket types simultaneously (e.g., TCP + Unix, or plain + TLS).
- *
- * Note: {@see getLocalAddress()} returns the address of the first inner listener.
- * Access individual listeners via the array you passed to the constructor.
- *
- * @param non-empty-list<ListenerInterface> $listeners
+ * Backpressure propagates naturally: if the composite consumer is slow, inner
+ * listeners' accept() calls block, their own backlogs fill, and they stop
+ * accepting from the OS.
  *
  * @api
  */
@@ -39,14 +36,26 @@ final class CompositeListener implements ListenerInterface
      */
     private readonly array $listeners;
 
-    /**
-     * @var Channel\ReceiverInterface<StreamInterface|Throwable>
-     */
-    private readonly Channel\ReceiverInterface $receiver;
-
-    private readonly Async\SignalCancellationToken $stopToken;
-
     private bool $closed = false;
+
+    /**
+     * Accepted streams waiting to be consumed. Bounded by the number of listeners.
+     *
+     * @var list<StreamInterface>
+     */
+    private array $backlog = [];
+
+    /**
+     * Tracks which listeners have an in-flight accept fiber.
+     *
+     * @var array<int, true>
+     */
+    private array $pending = [];
+
+    /**
+     * @var WeakMap<Suspension<null>, true>
+     */
+    private WeakMap $signal;
 
     /**
      * @param non-empty-list<ListenerInterface> $listeners
@@ -54,49 +63,50 @@ final class CompositeListener implements ListenerInterface
     public function __construct(array $listeners)
     {
         $this->listeners = $listeners;
-        $this->stopToken = new Async\SignalCancellationToken();
-
-        /**
-         * @var Channel\ReceiverInterface<StreamInterface|Throwable> $receiver
-         * @var Channel\SenderInterface<StreamInterface|Throwable> $sender
-         */
-        [$receiver, $sender] = Channel\unbounded();
-        $this->receiver = $receiver;
-
-        $wg = new Async\WaitGroup();
-
-        foreach ($this->listeners as $listener) {
-            $wg->add();
-            $this->startAcceptLoop($listener, $sender, $wg);
-        }
-
-        // When all accept loops end, close the sender so accept() throws
-        EventLoop::defer(static function () use ($wg, $sender): void {
-            $wg->wait();
-            $sender->close();
-        });
+        $this->signal = new WeakMap();
     }
 
     /**
      * Accept the next connection from any of the inner listeners.
      *
      * @throws Exception\AlreadyStoppedException If all listeners have been stopped.
-     * @throws CancelledException If the cancellation token is cancelled while waiting.
+     * @throws Async\Exception\CancelledException If the cancellation token is cancelled while waiting.
      */
     #[Override]
     public function accept(CancellationTokenInterface $cancellation = new NullCancellationToken()): StreamInterface
     {
-        try {
-            $stream_or_throwable = $this->receiver->receive($cancellation);
-        } catch (Channel\Exception\ClosedChannelException) {
+        if ($this->closed) {
             throw new Exception\AlreadyStoppedException('All listeners have been stopped.');
         }
 
-        if ($stream_or_throwable instanceof Throwable) {
-            throw $stream_or_throwable;
+        if ($this->backlog !== []) {
+            return array_shift($this->backlog);
         }
 
-        return $stream_or_throwable;
+        $this->startPendingAccepts();
+
+        $cancellation->throwIfCancelled();
+
+        /** @var Suspension<null> $signal */
+        $signal = Async\Scheduler::getSuspension();
+        $this->signal[$signal] = true;
+        $subscription = $cancellation->subscribe(function (Async\Exception\CancelledException $e) use ($signal): void {
+            unset($this->signal[$signal]);
+            $signal->throw($e);
+        });
+
+        try {
+            $signal->suspend();
+        } finally {
+            $cancellation->unsubscribe($subscription);
+        }
+
+        if ($this->backlog !== []) {
+            /** @mago-expect analysis:invalid-argument,never-return - false positives ! */
+            return array_shift($this->backlog);
+        }
+
+        throw new Exception\AlreadyStoppedException('All listeners have been stopped.');
     }
 
     /**
@@ -138,46 +148,63 @@ final class CompositeListener implements ListenerInterface
         }
 
         $this->closed = true;
-        $this->stopToken->cancel();
+
+        foreach ($this->backlog as $stream) {
+            $stream->close();
+        }
+
+        $this->backlog = [];
 
         foreach ($this->listeners as $listener) {
             $listener->close();
         }
 
-        $this->receiver->close();
+        $signals = $this->signal;
+        $this->signal = new WeakMap();
+        foreach ($signals as $signal => $_) {
+            $signal->resume(null);
+        }
     }
 
     /**
-     * @param Channel\SenderInterface<StreamInterface|Throwable> $sender
+     * Start an accept fiber for each listener that doesn't already have one.
      */
-    private function startAcceptLoop(
-        ListenerInterface $listener,
-        Channel\SenderInterface $sender,
-        Async\WaitGroup $wg,
-    ): void {
-        $token = $this->stopToken;
-
-        EventLoop::defer(static function () use ($listener, $sender, $token, $wg): void {
-            while (true) {
-                try {
-                    $stream = $listener->accept($token);
-
-                    $sender->send($stream);
-                } catch (CancelledException) {
-                    // Stop token fired, graceful shutdown
-                    break;
-                } catch (Exception\AlreadyStoppedException) {
-                    // This listener was closed individually
-                    break;
-                } catch (Channel\Exception\ClosedChannelException) {
-                    // Channel closed, we're shutting down
-                    break;
-                } catch (Throwable $throwable) {
-                    $sender->send($throwable);
-                }
+    private function startPendingAccepts(): void
+    {
+        foreach ($this->listeners as $i => $listener) {
+            if (isset($this->pending[$i])) {
+                continue;
             }
 
-            $wg->done();
-        });
+            $this->pending[$i] = true;
+
+            Async\Scheduler::defer(function () use ($i, $listener): void {
+                try {
+                    $stream = $listener->accept();
+                } catch (Throwable) {
+                    unset($this->pending[$i]);
+                    $this->notifySignal();
+                    return;
+                }
+
+                unset($this->pending[$i]);
+                $this->backlog[] = $stream;
+                $this->notifySignal();
+            });
+        }
+    }
+
+    /**
+     * Notify the waiting accept() call that something happened.
+     *
+     * @mago-expect lint:loop-does-not-iterate
+     */
+    private function notifySignal(): void
+    {
+        foreach ($this->signal as $signal => $_) {
+            unset($this->signal[$signal]);
+            $signal?->resume(null);
+            break;
+        }
     }
 }

--- a/packages/tcp/composer.json
+++ b/packages/tcp/composer.json
@@ -23,7 +23,6 @@
     "require": {
         "php": "~8.4.0 || ~8.5.0",
         "php-standard-library/async": "^6.0",
-        "php-standard-library/channel": "^6.0",
         "php-standard-library/cidr": "^6.0",
         "php-standard-library/date-time": "^6.0",
         "php-standard-library/default": "^6.0",

--- a/packages/tcp/src/Psl/TCP/Internal/Listener.php
+++ b/packages/tcp/src/Psl/TCP/Internal/Listener.php
@@ -6,13 +6,16 @@ namespace Psl\TCP\Internal;
 
 use Override;
 use Psl\Async\CancellationTokenInterface;
+use Psl\Async\Exception\CancelledException;
 use Psl\Async\NullCancellationToken;
-use Psl\Channel;
 use Psl\Network;
 use Psl\TCP;
 use Revolt\EventLoop;
+use Revolt\EventLoop\Suspension;
 
-use function error_clear_last;
+use function array_search;
+use function array_shift;
+use function array_values;
 use function error_get_last;
 use function fclose;
 use function is_resource;
@@ -23,11 +26,11 @@ use function stream_socket_accept;
  * @internal
  *
  * @codeCoverageIgnore
+ *
+ * @mago-expect lint:excessive-nesting
  */
 final class Listener implements TCP\ListenerInterface
 {
-    private const int DEFAULT_IDLE_CONNECTIONS = 256;
-
     /**
      * @var closed-resource|resource|null $impl
      */
@@ -35,12 +38,43 @@ final class Listener implements TCP\ListenerInterface
 
     private string $watcher;
 
-    /**
-     * @var Channel\ReceiverInterface<array{true, Stream}|array{false, Network\Exception\RuntimeException}>
-     */
-    private Channel\ReceiverInterface $receiver;
-
     private readonly Network\Address $localAddress;
+
+    private const int DEFAULT_IDLE_CONNECTIONS = 256;
+
+    /**
+     * Raw sockets waiting to be consumed by accept().
+     *
+     * @var list<resource>
+     */
+    private array $backlog = [];
+
+    /**
+     * Current backlog size (avoids count() overhead).
+     */
+    private int $backlogSize = 0;
+
+    /**
+     * Suspensions waiting for the next accepted stream.
+     *
+     * @var list<Suspension<resource>>
+     */
+    private array $acceptors = [];
+
+    /**
+     * Error from the accept callback, if any.
+     */
+    private null|Network\Exception\RuntimeException $error = null;
+
+    /**
+     * Maximum number of connections that can be buffered in the backlog.
+     */
+    private readonly int $capacity;
+
+    /**
+     * Whether the watcher is currently paused due to backlog being full.
+     */
+    private bool $paused = false;
 
     /**
      * @param resource $impl
@@ -49,51 +83,54 @@ final class Listener implements TCP\ListenerInterface
     public function __construct(mixed $impl, int $idleConnections = self::DEFAULT_IDLE_CONNECTIONS)
     {
         $this->impl = $impl;
+        $this->capacity = $idleConnections;
         $this->localAddress = Network\Internal\get_sock_name($impl);
 
-        /**
-         * @var Channel\ReceiverInterface<array{true, Stream}|array{false, Network\Exception\RuntimeException}> $receiver
-         * @var Channel\SenderInterface<array{true, Stream}|array{false, Network\Exception\RuntimeException}> $sender
-         */
-        [$receiver, $sender] = Channel\bounded($idleConnections);
+        $this->watcher = EventLoop::onReadable($impl, function (string $watcher, mixed $resource): void {
+            while (true) {
+                $sock = @stream_socket_accept($resource, timeout: 0.0);
+                if ($sock !== false) {
+                    if ($this->acceptors !== []) {
+                        $acceptor = array_shift($this->acceptors);
+                        $acceptor->resume($sock);
+                    } else {
+                        $this->backlog[] = $sock;
+                        $this->backlogSize++;
 
-        $this->receiver = $receiver;
-        $this->watcher = EventLoop::onReadable($impl, static function (string $watcher, mixed $resource) use (
-            $sender,
-        ): void {
-            try {
-                while (true) {
-                    error_clear_last();
-                    $sock = @stream_socket_accept($resource, timeout: 0.0);
-                    if ($sock !== false) {
-                        $sender->send([true, new Stream($sock)]);
-                        continue;
+                        if ($this->backlogSize >= $this->capacity) {
+                            $this->paused = true;
+                            EventLoop::disable($watcher);
+                            return;
+                        }
                     }
 
-                    // @codeCoverageIgnoreStart
-                    $err = error_get_last();
-                    if ($err !== null && !str_contains($err['message'], 'Accept failed')) {
-                        // OS error (e.g., EMFILE, ENFILE, ENOBUFS)
-                        $sender->send([
-                            false,
-                            new Network\Exception\RuntimeException(
-                                'Failed to accept incoming connection: ' . $err['message'],
-                                $err['type'],
-                            ),
-                        ]);
-
-                        return;
-                    }
-
-                    // No more pending connections (EAGAIN / timeout with no backlog).
-                    break;
-                    // @codeCoverageIgnoreEnd
+                    continue;
                 }
-            } catch (Channel\Exception\ClosedChannelException) {
-                EventLoop::cancel($watcher);
-                return;
+
+                // @codeCoverageIgnoreStart
+                $err = error_get_last();
+                if ($err !== null && !str_contains($err['message'], 'Accept failed')) {
+                    $this->error = new Network\Exception\RuntimeException(
+                        'Failed to accept incoming connection: ' . $err['message'],
+                        $err['type'],
+                    );
+
+                    if ($this->acceptors !== []) {
+                        $acceptor = array_shift($this->acceptors);
+                        $acceptor->throw($this->error);
+                    }
+
+                    EventLoop::disable($watcher);
+                    return;
+                }
+
+                break;
+                // @codeCoverageIgnoreEnd
             }
         });
+
+        EventLoop::disable($this->watcher);
+        $this->paused = true;
     }
 
     /**
@@ -102,19 +139,56 @@ final class Listener implements TCP\ListenerInterface
     #[Override]
     public function accept(CancellationTokenInterface $cancellation = new NullCancellationToken()): TCP\StreamInterface
     {
-        try {
-            [$success, $result] = $this->receiver->receive($cancellation);
-        } catch (Channel\Exception\ClosedChannelException) {
+        if (null === $this->impl) {
             throw new Network\Exception\AlreadyStoppedException('Server socket has already been stopped.');
         }
 
-        if ($success) {
-            /** @var Stream $result */
-            return $result;
+        if ($this->error !== null) {
+            throw $this->error;
         }
 
-        /** @var Network\Exception\RuntimeException $result */
-        throw $result;
+        if ($this->paused) {
+            $this->paused = false;
+            EventLoop::enable($this->watcher);
+        }
+
+        if ($this->backlog !== []) {
+            $socket = array_shift($this->backlog);
+            $this->backlogSize--;
+
+            return new Stream($socket, $this->localAddress);
+        }
+
+        if ($cancellation->cancellable) {
+            $cancellation->throwIfCancelled();
+        }
+
+        /** @var Suspension<resource> $suspension */
+        $suspension = EventLoop::getSuspension();
+        $this->acceptors[] = $suspension;
+
+        if ($cancellation->cancellable) {
+            $id = $cancellation->subscribe(function (CancelledException $e) use ($suspension): void {
+                $key = array_search($suspension, $this->acceptors, true);
+                if ($key !== false) {
+                    unset($this->acceptors[$key]);
+                    $this->acceptors = array_values($this->acceptors);
+                    $suspension->throw($e);
+                }
+            });
+
+            try {
+                $socket = $suspension->suspend();
+
+                return new Stream($socket, $this->localAddress);
+            } finally {
+                $cancellation->unsubscribe($id);
+            }
+        }
+
+        $socket = $suspension->suspend();
+
+        return new Stream($socket, $this->localAddress);
     }
 
     /**
@@ -141,12 +215,48 @@ final class Listener implements TCP\ListenerInterface
     #[Override]
     public function close(): void
     {
-        EventLoop::disable($this->watcher);
+        EventLoop::cancel($this->watcher);
         if (null === $this->impl) {
             return;
         }
 
-        $this->receiver->close();
+        while ($this->acceptors !== [] && is_resource($this->impl)) {
+            $sock = @stream_socket_accept($this->impl, timeout: 0.0);
+            if ($sock === false) {
+                break;
+            }
+
+            $acceptor = array_shift($this->acceptors);
+            $this->acceptors = array_values($this->acceptors);
+            $acceptor->resume($sock);
+        }
+
+        while ($this->acceptors !== [] && $this->backlog !== []) {
+            $sock = array_shift($this->backlog);
+            $this->backlogSize--;
+            $acceptor = array_shift($this->acceptors);
+            $this->acceptors = array_values($this->acceptors);
+            $acceptor->resume($sock);
+        }
+
+        $acceptors = $this->acceptors;
+        $this->acceptors = [];
+        $exception = new Network\Exception\AlreadyStoppedException('Server socket has been stopped.');
+        foreach ($acceptors as $acceptor) {
+            $acceptor->throw($exception);
+        }
+
+        foreach ($this->backlog as $sock) {
+            if (!is_resource($sock)) {
+                continue;
+            }
+
+            fclose($sock);
+        }
+
+        $this->backlog = [];
+        $this->backlogSize = 0;
+
         $resource = $this->impl;
         $this->impl = null;
         if (is_resource($resource)) {

--- a/packages/unix/composer.json
+++ b/packages/unix/composer.json
@@ -23,7 +23,6 @@
     "require": {
         "php": "~8.4.0 || ~8.5.0",
         "php-standard-library/async": "^6.0",
-        "php-standard-library/channel": "^6.0",
         "php-standard-library/default": "^6.0",
         "php-standard-library/io": "^6.0",
         "php-standard-library/network": "^6.0",

--- a/packages/unix/src/Psl/Unix/Internal/Listener.php
+++ b/packages/unix/src/Psl/Unix/Internal/Listener.php
@@ -6,90 +6,136 @@ namespace Psl\Unix\Internal;
 
 use Override;
 use Psl\Async\CancellationTokenInterface;
+use Psl\Async\Exception\CancelledException;
 use Psl\Async\NullCancellationToken;
-use Psl\Channel;
 use Psl\Network;
 use Psl\Unix;
 use Revolt\EventLoop;
+use Revolt\EventLoop\Suspension;
 
+use function array_search;
+use function array_shift;
+use function array_values;
 use function error_get_last;
 use function fclose;
 use function is_resource;
+use function str_contains;
 use function stream_socket_accept;
 
 /**
  * @internal
  *
  * @codeCoverageIgnore
+ *
+ * @mago-expect lint:excessive-nesting
  */
 final class Listener implements Unix\ListenerInterface
 {
     private const int DEFAULT_IDLE_CONNECTIONS = 256;
 
     /**
-     * @var closed-resource|resource|object|null $impl
+     * @var closed-resource|resource|null $impl
      */
     private mixed $impl;
 
     private string $watcher;
 
-    /**
-     * @var Channel\ReceiverInterface<array{true, Stream}|array{false, Network\Exception\RuntimeException}>
-     */
-    private Channel\ReceiverInterface $receiver;
-
     private readonly Network\Address $localAddress;
 
+    private readonly Network\Address $peerAddress;
+
     /**
-     * @param resource|object $impl
+     * Raw sockets waiting to be consumed by accept().
+     *
+     * @var list<resource>
+     */
+    private array $backlog = [];
+
+    /**
+     * Current backlog size (avoids count() overhead).
+     */
+    private int $backlogSize = 0;
+
+    /**
+     * Suspensions waiting for the next accepted stream.
+     *
+     * @var list<Suspension<resource>>
+     */
+    private array $acceptors = [];
+
+    /**
+     * Error from the accept callback, if any.
+     */
+    private null|Network\Exception\RuntimeException $error = null;
+
+    /**
+     * Maximum number of connections that can be buffered in the backlog.
+     */
+    private readonly int $capacity;
+
+    /**
+     * Whether the watcher is currently paused.
+     */
+    private bool $paused = false;
+
+    /**
+     * @param resource $impl
      * @param int<1, max> $idleConnections
      */
     public function __construct(mixed $impl, int $idleConnections = self::DEFAULT_IDLE_CONNECTIONS)
     {
         $this->impl = $impl;
-        // @mago-expect analysis:possibly-invalid-argument - revolt signature is wrong.
+        $this->capacity = $idleConnections;
         $this->localAddress = Network\Internal\get_sock_name($impl);
+        $this->peerAddress = Network\Address::unix('<anonymous>');
 
-        /**
-         * @var Channel\ReceiverInterface<array{true, Stream}|array{false, Network\Exception\RuntimeException}> $receiver
-         * @var Channel\SenderInterface<array{true, Stream}|array{false, Network\Exception\RuntimeException}> $sender
-         */
-        [$receiver, $sender] = Channel\bounded($idleConnections);
+        $this->watcher = EventLoop::onReadable($impl, function (string $watcher, mixed $resource): void {
+            while (true) {
+                $sock = @stream_socket_accept($resource, timeout: 0.0);
+                if ($sock !== false) {
+                    if ($this->acceptors !== []) {
+                        $acceptor = array_shift($this->acceptors);
+                        $acceptor->resume($sock);
+                    } else {
+                        $this->backlog[] = $sock;
+                        $this->backlogSize++;
 
-        $this->receiver = $receiver;
-        // @mago-expect analysis:possibly-invalid-argument - revolt signature is wrong.
-        $this->watcher = EventLoop::onReadable(
-            $impl,
-            /**
-             * @param resource $resource
-             */
-            static function (string $watcher, mixed $resource) use ($sender): void {
-                try {
-                    $sock = @stream_socket_accept($resource, timeout: 0.0);
-                    if (false !== $sock) {
-                        $sender->send([true, new Stream($sock)]);
-
-                        return;
+                        if ($this->backlogSize >= $this->capacity) {
+                            $this->paused = true;
+                            EventLoop::disable($watcher);
+                            return;
+                        }
                     }
 
-                    // @codeCoverageIgnoreStart
-                    /** @var array{file: string, line: int, message: string, type: int} $err */
-                    $err = error_get_last();
-                    $sender->send([
-                        false,
-                        new Network\Exception\RuntimeException(
-                            'Failed to accept incoming connection: ' . $err['message'],
-                            $err['type'],
-                        ),
-                    ]);
-                    // @codeCoverageIgnoreEnd
-                } catch (Channel\Exception\ClosedChannelException) {
-                    EventLoop::cancel($watcher);
+                    continue;
+                }
 
+                // @codeCoverageIgnoreStart
+                $err = error_get_last();
+                if ($err !== null && !str_contains($err['message'], 'Accept failed')) {
+                    $this->error = new Network\Exception\RuntimeException(
+                        'Failed to accept incoming connection: ' . $err['message'],
+                        $err['type'],
+                    );
+
+                    if ($this->acceptors !== []) {
+                        $acceptor = array_shift($this->acceptors);
+                        $acceptor->throw($this->error);
+                    }
+
+                    EventLoop::disable($watcher);
                     return;
                 }
-            },
-        );
+
+                break;
+                // @codeCoverageIgnoreEnd
+            }
+        });
+
+        // Start silent, don't accept OS connections until the first accept() call.
+        // This allows forking between listen() and accept() without losing connections.
+        EventLoop::disable($this->watcher);
+        $this->paused = true;
     }
 
     /**
@@ -98,19 +144,56 @@ final class Listener implements Unix\ListenerInterface
     #[Override]
     public function accept(CancellationTokenInterface $cancellation = new NullCancellationToken()): Unix\StreamInterface
     {
-        try {
-            [$success, $result] = $this->receiver->receive($cancellation);
-        } catch (Channel\Exception\ClosedChannelException) {
+        if (null === $this->impl) {
             throw new Network\Exception\AlreadyStoppedException('Server socket has already been stopped.');
         }
 
-        if ($success) {
-            /** @var Stream $result */
-            return $result;
+        if ($this->error !== null) {
+            throw $this->error;
         }
 
-        /** @var Network\Exception\RuntimeException $result */
-        throw $result;
+        if ($this->paused) {
+            $this->paused = false;
+            EventLoop::enable($this->watcher);
+        }
+
+        if ($this->backlog !== []) {
+            $socket = array_shift($this->backlog);
+            $this->backlogSize--;
+
+            return new Stream($socket, $this->localAddress, $this->peerAddress);
+        }
+
+        if ($cancellation->cancellable) {
+            $cancellation->throwIfCancelled();
+        }
+
+        /** @var Suspension<resource> $suspension */
+        $suspension = EventLoop::getSuspension();
+        $this->acceptors[] = $suspension;
+
+        if ($cancellation->cancellable) {
+            $id = $cancellation->subscribe(function (CancelledException $e) use ($suspension): void {
+                $key = array_search($suspension, $this->acceptors, true);
+                if ($key !== false) {
+                    unset($this->acceptors[$key]);
+                    $this->acceptors = array_values($this->acceptors);
+                    $suspension->throw($e);
+                }
+            });
+
+            try {
+                $socket = $suspension->suspend();
+
+                return new Stream($socket, $this->localAddress, $this->peerAddress);
+            } finally {
+                $cancellation->unsubscribe($id);
+            }
+        }
+
+        $socket = $suspension->suspend();
+
+        return new Stream($socket, $this->localAddress, $this->peerAddress);
     }
 
     /**
@@ -137,12 +220,50 @@ final class Listener implements Unix\ListenerInterface
     #[Override]
     public function close(): void
     {
-        EventLoop::disable($this->watcher);
+        EventLoop::cancel($this->watcher);
         if (null === $this->impl) {
             return;
         }
 
-        $this->receiver->close();
+        // Drain any pending OS connections to satisfy waiting acceptors.
+        while ($this->acceptors !== [] && is_resource($this->impl)) {
+            $sock = @stream_socket_accept($this->impl, timeout: 0.0);
+            if ($sock === false) {
+                break;
+            }
+
+            $acceptor = array_shift($this->acceptors);
+            $this->acceptors = array_values($this->acceptors);
+            $acceptor->resume($sock);
+        }
+
+        // Feed remaining acceptors from the backlog.
+        while ($this->acceptors !== [] && $this->backlog !== []) {
+            $sock = array_shift($this->backlog);
+            $this->backlogSize--;
+            $acceptor = array_shift($this->acceptors);
+            $this->acceptors = array_values($this->acceptors);
+            $acceptor->resume($sock);
+        }
+
+        $acceptors = $this->acceptors;
+        $this->acceptors = [];
+        $exception = new Network\Exception\AlreadyStoppedException('Server socket has been stopped.');
+        foreach ($acceptors as $acceptor) {
+            $acceptor->throw($exception);
+        }
+
+        foreach ($this->backlog as $sock) {
+            if (!is_resource($sock)) {
+                continue;
+            }
+
+            fclose($sock);
+        }
+
+        $this->backlog = [];
+        $this->backlogSize = 0;
+
         $resource = $this->impl;
         $this->impl = null;
         if (is_resource($resource)) {


### PR DESCRIPTION
makes our http server a bit faster :)

```
➜  psl git:(performance) ✗ php __local__/benchmark.php
  > Warming up...
    done
  > H2C sequential (m=1)
    50,087 req/s
  > H2C multiplexed (m=64)
    105,406 req/s
  > H2/TLS multiplexed (m=64)
    81,831 req/s

  Benchmark Results
────────────────────────────────────────────────────────────────────────────────────────────────────
  Benchmark              req/s       req min      req mean       req max     ttfb mean     conn mean
────────────────────────────────────────────────────────────────────────────────────────────────────
  H2C (m=1)             50,087        24.0us        3.96ms      365.21ms      134.47ms       10.89ms
  H2C (m=64)           105,406       251.0us       48.50ms        26.29s        13.22s       47.61ms
  H2/TLS (m=64)         81,831       164.0us       720.0us        2.12ms         3.05s         3.05s
────────────────────────────────────────────────────────────────────────────────────────────────────

➜  psl git:(performance) ✗
```