### PR TITLE
fix(splitter): consider all 2xx responses as a success

### DIFF
--- a/splitter/src/Psl/Splitter/create_releases.php
+++ b/splitter/src/Psl/Splitter/create_releases.php
@@ -68,7 +68,7 @@ function create_releases(Client\Client $httpClient, MonolithicRepository $monore
             ])),
         ));
 
-        if ($transaction->response->status !== Message\STATUS_OK) {
+        if ($transaction->response->status >= 300) {
             $content = $transaction->response->body?->readAll() ?? '';
             $body = Json\typed($content, $errorType);
             Log\error('%s release failed: %s', $package->name, $body['message']);
@@ -99,7 +99,7 @@ function create_releases(Client\Client $httpClient, MonolithicRepository $monore
         ])),
     ));
 
-    if ($transaction->response->status !== Message\STATUS_OK) {
+    if ($transaction->response->status >= 300) {
         $content = $transaction->response->body?->readAll() ?? '';
         $body = Json\typed($content, $errorType);
         Log\error('main repo release failed: %s', $body['message']);


### PR DESCRIPTION
GitHub returns 201 on success, the previous !== 200 caused the create release workflow to fail