### PR TITLE
fix(docs): keep the CNAME on gh-pages across rebuilds

### DIFF
--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -153,6 +153,10 @@ jobs:
           if [ -f "${LATEST}/llms.txt" ]; then cp "${LATEST}/llms.txt" llms.txt; fi
           if [ -f "${LATEST}/llms-full.txt" ]; then cp "${LATEST}/llms-full.txt" llms-full.txt; fi
 
+          # Custom domain for GitHub Pages (kept in sync in case gh-pages was ever
+          # rebuilt from scratch and lost the CNAME).
+          echo "php-standard-library.dev" > CNAME
+
           # Ensure Jekyll is disabled
           touch .nojekyll
         env:

--- a/.github/workflows/documentation-rebuild-all.yml
+++ b/.github/workflows/documentation-rebuild-all.yml
@@ -154,6 +154,10 @@ jobs:
           if [ -f "${LATEST}/llms.txt" ]; then cp "${LATEST}/llms.txt" llms.txt; fi
           if [ -f "${LATEST}/llms-full.txt" ]; then cp "${LATEST}/llms-full.txt" llms-full.txt; fi
 
+          # Custom domain for GitHub Pages. This workflow rebuilds gh-pages from scratch,
+          # so the CNAME must be re-created or the custom domain is dropped.
+          echo "php-standard-library.dev" > CNAME
+
           touch .nojekyll
 
       - name: "commit and force-push gh-pages"


### PR DESCRIPTION
The `documentation rebuild all` workflow rebuilds `gh-pages` from scratch and
force-pushes, which dropped the `CNAME` file and took the custom domain
(`php-standard-library.dev`) offline. The normal deploy kept it only because it
checks out the existing branch first.

Both workflows now write `CNAME` on every run, so the custom domain survives a
full rebuild.

Note: this only covers future runs. The live `CNAME` still needs restoring once,
either by re-entering the custom domain under Settings -> Pages or by committing
the file to `gh-pages` directly.