### PR TITLE
feat(docs): add permalink anchors to section headings

### DIFF
--- a/docs/generate.php
+++ b/docs/generate.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\Autolink\AutolinkExtension;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\MarkdownConverter;
 use Psl\Async;
@@ -338,10 +339,17 @@ function extract_description(string $markdown): string
  */
 function make_converter(): MarkdownConverter
 {
-    $environment = new Environment(['renderer' => ['soft_break' => "\n"]]);
+    $environment = new Environment([
+        'renderer' => ['soft_break' => "\n"],
+        'heading_permalink' => [
+            'min_heading_level' => 2, // skip the h1 page title
+            'insert' => 'after',
+        ],
+    ]);
     $environment->addExtension(new CommonMarkCoreExtension());
     $environment->addExtension(new TableExtension());
     $environment->addExtension(new AutolinkExtension());
+    $environment->addExtension(new HeadingPermalinkExtension());
 
     return new MarkdownConverter($environment);
 }

--- a/docs/resources/style.css
+++ b/docs/resources/style.css
@@ -282,6 +282,30 @@ article h4 {
     margin-bottom: 0.4rem;
 }
 
+/* Section headings get a permalink anchor (CommonMark HeadingPermalink) linking to the
+   heading's URL fragment. */
+article h2,
+article h3,
+article h4 {
+    scroll-margin-top: 1rem;
+}
+
+.heading-permalink {
+    margin-left: 0.3em;
+    text-decoration: none;
+    color: var(--muted);
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+article h2:hover .heading-permalink,
+article h3:hover .heading-permalink,
+article h4:hover .heading-permalink,
+.heading-permalink:focus-visible {
+    opacity: 1;
+    color: var(--fg);
+}
+
 article p {
     font-size: 0.9rem;
     line-height: 1.7;


### PR DESCRIPTION
## Summary

Section headings on the docs site now render with a clickable permalink anchor, so individual sections can be linked directly via URL fragments.

This enables league/commonmark's `HeadingPermalink` extension (already available via `league/commonmark`), configured minimally:
- `min_heading_level => 2` — the `h1` page title is excluded.
- `insert => after` — the anchor sits after the heading text.

Everything else uses the extension defaults (the `¶` symbol, `content-` id/fragment prefix, `heading-permalink` class).

## Styling

- The anchor is muted and revealed on heading hover / keyboard focus.
- `scroll-margin-top` is added to section headings so fragment navigation doesn't clip the heading under the viewport edge.

## Notes

- Only the rendered HTML changes; the raw `index.md` / `llms*.txt` outputs are generated from the unmodified markdown and stay clean.
- The existing install-box insertion (which keys off `</h1>`) is unaffected, since the `h1` carries no anchor.