### PR TITLE
fix(docs): Update header formatting in compression.md

### DIFF
--- a/docs/content/io/compression.md
+++ b/docs/content/io/compression.md
@@ -1,4 +1,4 @@
-[# Compression
+# Compression
 
 The `Compression` component provides streaming compression and decompression abstractions for IO handles. It defines compressor and decompressor interfaces, and four handle decorators that transparently compress or decompress data as it flows through.
 


### PR DESCRIPTION
👋🏻 
on https://php-standard-library.dev/6.2.1/compression/ (and on the left navbar)
the `compression` seems different in the display, perhaps related to this PR fix

cheers!