### PR TITLE
fix last_key_opt phpdoc

### DIFF
--- a/packages/iter/src/Psl/Iter/last_key_opt.php
+++ b/packages/iter/src/Psl/Iter/last_key_opt.php
@@ -7,7 +7,7 @@ namespace Psl\Iter;
 use Psl\Option\Option;
 
 /**
- * Returns the first key of an iterable wrapped in {@see Option::some},
+ * Returns the last key of an iterable wrapped in {@see Option::some},
  * if the iterable is empty, {@see Option::none} will be returned.
  *
  * @template Tk


### PR DESCRIPTION
The docblock for Psl\Iter\last_key_opt incorrectly describes the function as returning the first key of an iterable. This patch corrects it to last, matching the function's actual behavior and name.